### PR TITLE
Add optimized squaring (~15% speedup)

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -37,10 +37,13 @@ task test, "Run all tests":
 
   test "", "tests/test_io_fields"
   test "", "tests/test_finite_fields.nim"
+  test "", "tests/test_finite_fields_mulsquare.nim"
   test "", "tests/test_finite_fields_powinv.nim"
 
   test "", "tests/test_bigints_vs_gmp.nim"
   test "", "tests/test_finite_fields_vs_gmp.nim"
+
+  test "", "tests/test_fp2.nim"
 
   if sizeof(int) == 8: # 32-bit tests
     test "-d:Constantine32", "tests/test_primitives.nim"
@@ -51,10 +54,13 @@ task test, "Run all tests":
 
     test "-d:Constantine32", "tests/test_io_fields"
     test "-d:Constantine32", "tests/test_finite_fields.nim"
+    test "-d:Constantine32", "tests/test_finite_fields_mulsquare.nim"
     test "-d:Constantine32", "tests/test_finite_fields_powinv.nim"
 
     test "-d:Constantine32", "tests/test_bigints_vs_gmp.nim"
     test "-d:Constantine32", "tests/test_finite_fields_vs_gmp.nim"
+
+    test "", "tests/test_fp2.nim"
 
 task test_no_gmp, "Run tests that don't require GMP":
   # -d:testingCurves is configured in a *.nim.cfg for convenience
@@ -66,7 +72,10 @@ task test_no_gmp, "Run tests that don't require GMP":
 
   test "", "tests/test_io_fields"
   test "", "tests/test_finite_fields.nim"
+  test "", "tests/test_finite_fields_mulsquare.nim"
   test "", "tests/test_finite_fields_powinv.nim"
+
+  test "", "tests/test_fp2.nim"
 
   if sizeof(int) == 8: # 32-bit tests
     test "-d:Constantine32", "tests/test_primitives.nim"
@@ -77,4 +86,7 @@ task test_no_gmp, "Run tests that don't require GMP":
 
     test "-d:Constantine32", "tests/test_io_fields"
     test "-d:Constantine32", "tests/test_finite_fields.nim"
+    test "-d:Constantine32", "tests/test_finite_fields_mulsquare.nim"
     test "-d:Constantine32", "tests/test_finite_fields_powinv.nim"
+
+    test "", "tests/test_fp2.nim"

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -29,64 +29,84 @@ proc test(flags, path: string) =
 ### tasks
 task test, "Run all tests":
   # -d:testingCurves is configured in a *.nim.cfg for convenience
+
+  # Primitives
   test "", "tests/test_primitives.nim"
 
+  # Big ints
   test "", "tests/test_io_bigints.nim"
   test "", "tests/test_bigints.nim"
   test "", "tests/test_bigints_multimod.nim"
 
+  test "", "tests/test_bigints_vs_gmp.nim"
+
+  # Field
   test "", "tests/test_io_fields"
   test "", "tests/test_finite_fields.nim"
   test "", "tests/test_finite_fields_mulsquare.nim"
   test "", "tests/test_finite_fields_powinv.nim"
 
-  test "", "tests/test_bigints_vs_gmp.nim"
   test "", "tests/test_finite_fields_vs_gmp.nim"
 
+  # 𝔽p2
   test "", "tests/test_fp2.nim"
 
   if sizeof(int) == 8: # 32-bit tests
+    # Primitives
     test "-d:Constantine32", "tests/test_primitives.nim"
 
+    # Big ints
     test "-d:Constantine32", "tests/test_io_bigints.nim"
     test "-d:Constantine32", "tests/test_bigints.nim"
     test "-d:Constantine32", "tests/test_bigints_multimod.nim"
 
+    test "-d:Constantine32", "tests/test_bigints_vs_gmp.nim"
+
+    # Field
     test "-d:Constantine32", "tests/test_io_fields"
     test "-d:Constantine32", "tests/test_finite_fields.nim"
     test "-d:Constantine32", "tests/test_finite_fields_mulsquare.nim"
     test "-d:Constantine32", "tests/test_finite_fields_powinv.nim"
 
-    test "-d:Constantine32", "tests/test_bigints_vs_gmp.nim"
     test "-d:Constantine32", "tests/test_finite_fields_vs_gmp.nim"
 
+    # 𝔽p2
     test "", "tests/test_fp2.nim"
 
 task test_no_gmp, "Run tests that don't require GMP":
   # -d:testingCurves is configured in a *.nim.cfg for convenience
+
+  # Primitives
   test "", "tests/test_primitives.nim"
 
+  # Big ints
   test "", "tests/test_io_bigints.nim"
   test "", "tests/test_bigints.nim"
   test "", "tests/test_bigints_multimod.nim"
 
+  # Field
   test "", "tests/test_io_fields"
   test "", "tests/test_finite_fields.nim"
   test "", "tests/test_finite_fields_mulsquare.nim"
   test "", "tests/test_finite_fields_powinv.nim"
 
+  # 𝔽p2
   test "", "tests/test_fp2.nim"
 
   if sizeof(int) == 8: # 32-bit tests
+    # Primitives
     test "-d:Constantine32", "tests/test_primitives.nim"
 
+    # Big ints
     test "-d:Constantine32", "tests/test_io_bigints.nim"
     test "-d:Constantine32", "tests/test_bigints.nim"
     test "-d:Constantine32", "tests/test_bigints_multimod.nim"
 
+    # Field
     test "-d:Constantine32", "tests/test_io_fields"
     test "-d:Constantine32", "tests/test_finite_fields.nim"
     test "-d:Constantine32", "tests/test_finite_fields_mulsquare.nim"
     test "-d:Constantine32", "tests/test_finite_fields_powinv.nim"
 
+    # 𝔽p2
     test "", "tests/test_fp2.nim"

--- a/constantine/arithmetic/finite_fields.nim
+++ b/constantine/arithmetic/finite_fields.nim
@@ -148,7 +148,7 @@ func prod*(r: var Fp, a, b: Fp) =
 
 func square*(r: var Fp, a: Fp) =
   ## Squaring modulo p
-  r.mres.montySquare(a.mres, Fp.C.Mod.mres, Fp.C.getNegInvModWord(), Fp.C.canUseNoCarryMontyMul())
+  r.mres.montySquare(a.mres, Fp.C.Mod.mres, Fp.C.getNegInvModWord(), Fp.C.canUseNoCarryMontySquare())
 
 func neg*(r: var Fp, a: Fp) =
   ## Negate modulo p

--- a/constantine/arithmetic/precomputed.nim
+++ b/constantine/arithmetic/precomputed.nim
@@ -128,6 +128,14 @@ func useNoCarryMontyMul*(M: BigInt): bool =
   # https://github.com/nim-lang/Nim/issues/9679
   BaseType(M.limbs[^1]) < high(BaseType) shr 1
 
+func useNoCarryMontySquare*(M: BigInt): bool =
+  ## Returns if the modulus is compatible
+  ## with the no-carry Montgomery Squaring
+  ## from https://hackmd.io/@zkteam/modular_multiplication
+  # Indirection needed because static object are buggy
+  # https://github.com/nim-lang/Nim/issues/9679
+  BaseType(M.limbs[^1]) < high(BaseType) shr 2
+
 func negInvModWord*(M: BigInt): BaseType =
   ## Returns the Montgomery domain magic constant for the input modulus:
   ##

--- a/constantine/config/curves.nim
+++ b/constantine/config/curves.nim
@@ -52,6 +52,9 @@ when not defined(testingCurves):
       bitsize: 381
       modulus: "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
       # Equation: y^2 = x^3 + 4
+    curve P224: # NIST P-224
+      bitsize: 224
+      modulus: "0xffffffff_ffffffff_ffffffff_ffffffff_00000000_00000000_00000001"
     curve P256: # secp256r1 / NIST P-256
       bitsize: 256
       modulus: "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
@@ -70,6 +73,9 @@ else:
     curve Mersenne127:
       bitsize: 127
       modulus: "0x7fffffffffffffffffffffffffffffff" # 2^127 - 1
+    curve P224: # NIST P-224
+      bitsize: 224
+      modulus: "0xffffffff_ffffffff_ffffffff_ffffffff_00000000_00000000_00000001"
     curve P256: # secp256r1 / NIST P-256
       bitsize: 256
       modulus: "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
@@ -113,6 +119,17 @@ macro genMontyMagics(T: typed): untyped =
     result.add newConstStmt(
       ident($curve & "_CanUseNoCarryMontyMul"), newCall(
         bindSym"useNoCarryMontyMul",
+        nnkDotExpr.newTree(
+          bindSym($curve & "_Modulus"),
+          ident"mres"
+        )
+      )
+    )
+
+    # const MyCurve_CanUseNoCarryMontySquare = useNoCarryMontySquare(MyCurve_Modulus)
+    result.add newConstStmt(
+      ident($curve & "_CanUseNoCarryMontySquare"), newCall(
+        bindSym"useNoCarryMontySquare",
         nnkDotExpr.newTree(
           bindSym($curve & "_Modulus"),
           ident"mres"
@@ -169,6 +186,11 @@ macro canUseNoCarryMontyMul*(C: static Curve): untyped =
   ## Returns true if the Modulus is compatible with a fast
   ## Montgomery multiplication that avoids many carries
   result = bindSym($C & "_CanUseNoCarryMontyMul")
+
+macro canUseNoCarryMontySquare*(C: static Curve): untyped =
+  ## Returns true if the Modulus is compatible with a fast
+  ## Montgomery squaring that avoids many carries
+  result = bindSym($C & "_CanUseNoCarryMontySquare")
 
 macro getR2modP*(C: static Curve): untyped =
   ## Get the Montgomery "R^2 mod P" constant associated to a curve field modulus

--- a/constantine/primitives/extended_precision_64bit_uint128.nim
+++ b/constantine/primitives/extended_precision_64bit_uint128.nim
@@ -36,6 +36,24 @@ func unsafeDiv2n1n*(q, r: var Ct[uint64], n_hi, n_lo, d: Ct[uint64]) {.inline.}=
     {.emit:["*",q, " = (NU64)(", dblPrec," / ", d, ");"].}
     {.emit:["*",r, " = (NU64)(", dblPrec," % ", d, ");"].}
 
+func mul*(hi, lo: var Ct[uint64], a, b: Ct[uint64]) {.inline.} =
+  ## Extended precision multiplication
+  ## (hi, lo) <- a*b
+  ##
+  ## This is constant-time on most hardware
+  ## See: https://www.bearssl.org/ctmul.html
+  block:
+    var dblPrec {.noInit.}: uint128
+    {.emit:[dblPrec, " = (unsigned __int128)", a," * (unsigned __int128)", b,";"].}
+
+    # Don't forget to dereference the var param in C mode
+    when defined(cpp):
+      {.emit:[hi, " = (NU64)(", dblPrec," >> ", 64'u64, ");"].}
+      {.emit:[lo, " = (NU64)", dblPrec,";"].}
+    else:
+      {.emit:["*",hi, " = (NU64)(", dblPrec," >> ", 64'u64, ");"].}
+      {.emit:["*",lo, " = (NU64)", dblPrec,";"].}
+
 func muladd1*(hi, lo: var Ct[uint64], a, b, c: Ct[uint64]) {.inline.} =
   ## Extended precision multiplication + addition
   ## (hi, lo) <- a*b + c

--- a/constantine/primitives/extended_precision_x86_64_msvc.nim
+++ b/constantine/primitives/extended_precision_x86_64_msvc.nim
@@ -43,6 +43,14 @@ func unsafeDiv2n1n*(q, r: var Ct[uint64], n_hi, n_lo, d: Ct[uint64]) {.inline.}=
     #          -> use uint128? Compiler might add unwanted branches
     q = udiv128(n_hi, n_lo, d, r)
 
+func mul*(hi, lo: var Ct[uint64], a, b: Ct[uint64]) {.inline.} =
+  ## Extended precision multiplication
+  ## (hi, lo) <- a*b
+  ##
+  ## This is constant-time on most hardware
+  ## See: https://www.bearssl.org/ctmul.html
+  lo = umul128(a, b, hi)
+
 func muladd1*(hi, lo: var Ct[uint64], a, b, c: Ct[uint64]) {.inline.} =
   ## Extended precision multiplication + addition
   ## (hi, lo) <- a*b + c

--- a/tests/test_finite_fields_mulsquare.nim
+++ b/tests/test_finite_fields_mulsquare.nim
@@ -24,221 +24,49 @@ static: doAssert defined(testingCurves), "This modules requires the -d:testingCu
 
 import ../constantine/config/common
 
+proc sanity(C: static Curve) =
+  test "Squaring 0,1,2 with "& $C & " [FastSquaring = " & $Fake101.canUseNoCarryMontySquare & "]":
+        block: # 0² mod
+          var n: Fp[C]
+
+          n.fromUint(0'u32)
+          let expected = n
+
+          var r: Fp[C]
+          r.square(n)
+
+          check: bool(r == expected)
+
+        block: # 1² mod
+          var n: Fp[C]
+
+          n.fromUint(1'u32)
+          let expected = n
+
+          var r: Fp[C]
+          r.square(n)
+
+          check: bool(r == expected)
+
+        block: # 2² mod
+          var n, expected: Fp[C]
+
+          n.fromUint(2'u32)
+          expected.fromUint(4'u32)
+
+          var r: Fp[C]
+          r.square(n)
+
+          check: bool(r == expected)
+
 proc mainSanity() =
   suite "Modular squaring is consistent with multiplication on special elements":
-    test "Squaring 0,1,2 mod 101 [FastSquaring = " & $Fake101.canUseNoCarryMontySquare & "]":
-      block: # 0² mod
-        var n: Fp[Fake101]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[Fake101]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[Fake101]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[Fake101]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[Fake101]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[Fake101]
-        r.square(n)
-
-        check: bool(r == expected)
-
-    test "Squaring 0,1,2 mod 2^61-1 [FastSquaring = " & $Mersenne61.canUseNoCarryMontySquare & "]":
-      block: # 0² mod
-        var n: Fp[Mersenne61]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[Mersenne61]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[Mersenne61]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[Mersenne61]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[Mersenne61]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[Mersenne61]
-        r.square(n)
-
-        check: bool(r == expected)
-
-    test "Squaring 0,1,2 mod 2^127-1 [FastSquaring = " & $Mersenne127.canUseNoCarryMontySquare & "]":
-      block: # 0² mod
-        var n: Fp[Mersenne127]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[Mersenne127]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[Mersenne127]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[Mersenne127]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[Mersenne127]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[Mersenne127]
-        r.square(n)
-
-        check: bool(r == expected)
-
-    test "Squaring 0,1,2 mod P-224 [FastSquaring = " & $P224.canUseNoCarryMontySquare & "]":
-      # P224 can use the fast path in 32-bit mode but not in 64-bit mode
-      block: # 0² mod
-        var n: Fp[P224]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[P224]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[P224]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[P224]
-        r.square(n)
-
-        var r2: Fp[P224]
-        r2.prod(n, n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[P224]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[P224]
-        r.square(n)
-
-        check: bool(r == expected)
-
-    test "Squaring 0,1,2 mod P-256 [FastSquaring = " & $P256.canUseNoCarryMontySquare & "]":
-      block: # 0² mod
-        var n: Fp[P256]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[P256]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[P256]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[P256]
-        r.square(n)
-
-        var r2: Fp[P256]
-        r2.prod(n, n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[P256]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[P256]
-        r.square(n)
-
-        check: bool(r == expected)
-
-    test "Squaring 0,1,2 mod BLS12_381 [FastSquaring = " & $BLS12_381.canUseNoCarryMontySquare & "]":
-      block: # 0² mod
-        var n: Fp[BLS12_381]
-
-        n.fromUint(0'u32)
-        let expected = n
-
-        var r: Fp[BLS12_381]
-        r.square(n)
-
-        check: bool(r == expected)
-
-      block: # 1² mod
-        var n: Fp[BLS12_381]
-
-        n.fromUint(1'u32)
-        let expected = n
-
-        var r: Fp[BLS12_381]
-        r.square(n)
-
-        var r2: Fp[BLS12_381]
-        r2.prod(n, n)
-
-        check: bool(r == expected)
-
-      block: # 2² mod
-        var n, expected: Fp[BLS12_381]
-
-        n.fromUint(2'u32)
-        expected.fromUint(4'u32)
-
-        var r: Fp[BLS12_381]
-        r.square(n)
-
-        check: bool(r == expected)
+    sanity Fake101
+    sanity Mersenne61
+    sanity Mersenne127
+    sanity P224         # P224 uses the fast-path with 64-bit words and the slow path with 32-bit words
+    sanity P256
+    sanity BLS12_381
 
 mainSanity()
 

--- a/tests/test_finite_fields_mulsquare.nim
+++ b/tests/test_finite_fields_mulsquare.nim
@@ -1,0 +1,284 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import  std/unittest, std/times,
+        ../constantine/arithmetic/[bigints, finite_fields],
+        ../constantine/io/[io_bigints, io_fields],
+        ../constantine/config/curves,
+        # Test utilities
+        ./prng
+
+const Iters = 128
+
+var rng: RngState
+let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+rng.seed(seed)
+echo "test_finite_fields_mulsquare xoshiro512** seed: ", seed
+
+static: doAssert defined(testingCurves), "This modules requires the -d:testingCurves compile option"
+
+import ../constantine/config/common
+
+proc mainSanity() =
+  suite "Modular squaring is consistent with multiplication on special elements":
+    test "Squaring 0,1,2 mod 101 [FastSquaring = " & $Fake101.canUseNoCarryMontySquare & "]":
+      block: # 0² mod
+        var n: Fp[Fake101]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[Fake101]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[Fake101]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[Fake101]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[Fake101]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[Fake101]
+        r.square(n)
+
+        check: bool(r == expected)
+
+    test "Squaring 0,1,2 mod 2^61-1 [FastSquaring = " & $Mersenne61.canUseNoCarryMontySquare & "]":
+      block: # 0² mod
+        var n: Fp[Mersenne61]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[Mersenne61]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[Mersenne61]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[Mersenne61]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[Mersenne61]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[Mersenne61]
+        r.square(n)
+
+        check: bool(r == expected)
+
+    test "Squaring 0,1,2 mod 2^127-1 [FastSquaring = " & $Mersenne127.canUseNoCarryMontySquare & "]":
+      block: # 0² mod
+        var n: Fp[Mersenne127]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[Mersenne127]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[Mersenne127]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[Mersenne127]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[Mersenne127]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[Mersenne127]
+        r.square(n)
+
+        check: bool(r == expected)
+
+    test "Squaring 0,1,2 mod P-224 [FastSquaring = " & $P224.canUseNoCarryMontySquare & "]":
+      # P224 can use the fast path in 32-bit mode but not in 64-bit mode
+      block: # 0² mod
+        var n: Fp[P224]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[P224]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[P224]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[P224]
+        r.square(n)
+
+        var r2: Fp[P224]
+        r2.prod(n, n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[P224]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[P224]
+        r.square(n)
+
+        check: bool(r == expected)
+
+    test "Squaring 0,1,2 mod P-256 [FastSquaring = " & $P256.canUseNoCarryMontySquare & "]":
+      block: # 0² mod
+        var n: Fp[P256]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[P256]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[P256]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[P256]
+        r.square(n)
+
+        var r2: Fp[P256]
+        r2.prod(n, n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[P256]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[P256]
+        r.square(n)
+
+        check: bool(r == expected)
+
+    test "Squaring 0,1,2 mod BLS12_381 [FastSquaring = " & $BLS12_381.canUseNoCarryMontySquare & "]":
+      block: # 0² mod
+        var n: Fp[BLS12_381]
+
+        n.fromUint(0'u32)
+        let expected = n
+
+        var r: Fp[BLS12_381]
+        r.square(n)
+
+        check: bool(r == expected)
+
+      block: # 1² mod
+        var n: Fp[BLS12_381]
+
+        n.fromUint(1'u32)
+        let expected = n
+
+        var r: Fp[BLS12_381]
+        r.square(n)
+
+        var r2: Fp[BLS12_381]
+        r2.prod(n, n)
+
+        check: bool(r == expected)
+
+      block: # 2² mod
+        var n, expected: Fp[BLS12_381]
+
+        n.fromUint(2'u32)
+        expected.fromUint(4'u32)
+
+        var r: Fp[BLS12_381]
+        r.square(n)
+
+        check: bool(r == expected)
+
+mainSanity()
+
+proc mainSelectCases() =
+  suite "Modular Squaring: selected tricky cases":
+    test "P-256 [FastSquaring = " & $P256.canUseNoCarryMontySquare & "]":
+      block:
+        # Triggered an issue in the (t[N+1], t[N]) = t[N] + (A1, A0)
+        # between the squaring and reduction step, with t[N+1] and A1 being carry bits.
+        var a: Fp[P256]
+        a.fromHex"0xa0da36b4885df98997ee89a22a7ceb64fa431b2ecc87342fc083587da3d6ebc7"
+
+        var r_mul, r_sqr: Fp[P256]
+
+        r_mul.prod(a, a)
+        r_sqr.square(a)
+
+        doAssert bool(r_mul == r_sqr)
+
+mainSelectCases()
+
+proc randomCurve(C: static Curve) =
+  let a = rng.random(Fp[C])
+
+  var r_mul, r_sqr: Fp[C]
+
+  r_mul.prod(a, a)
+  r_sqr.square(a)
+
+  doAssert bool(r_mul == r_sqr)
+
+suite "Random Modular Squaring is consistent with Modular Multiplication":
+  test "Random squaring mod P-224 [FastSquaring = " & $P224.canUseNoCarryMontySquare & "]":
+    for _ in 0 ..< Iters:
+      randomCurve(P224)
+
+  test "Random squaring mod P-256 [FastSquaring = " & $P256.canUseNoCarryMontySquare & "]":
+    for _ in 0 ..< Iters:
+      randomCurve(P256)
+
+  test "Random squaring mod BLS12_381 [FastSquaring = " & $BLS12_381.canUseNoCarryMontySquare & "]":
+    for _ in 0 ..< Iters:
+      randomCurve(BLS12_381)

--- a/tests/test_finite_fields_mulsquare.nim.cfg
+++ b/tests/test_finite_fields_mulsquare.nim.cfg
@@ -1,0 +1,1 @@
+-d:testingCurves

--- a/tests/test_finite_fields_powinv.nim
+++ b/tests/test_finite_fields_powinv.nim
@@ -8,10 +8,8 @@
 
 import  unittest,
         ../constantine/arithmetic/[bigints, finite_fields],
-        ../constantine/io/io_fields,
+        ../constantine/io/[io_bigints, io_fields],
         ../constantine/config/curves
-
-import ../constantine/io/io_bigints
 
 static: doAssert defined(testingCurves), "This modules requires the -d:testingCurves compile option"
 


### PR DESCRIPTION
This implements a specialized path for squaring.

### Benchmark old
On i9-9980XE overclocked all-core turbo at 4.1GHz
Using Clang and -d:danger (GCC is significantly slower i.e. 188 cycles for field multiplication of BLS12_381 instead of 137 cycles.)

```
Warmup: 0.9125 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[Secp256k1]           2 ns         8 cycles
Substraction    Fp[Secp256k1]           2 ns         6 cycles
Negation        Fp[Secp256k1]           0 ns         0 cycles
Multiplication  Fp[Secp256k1]          22 ns        68 cycles
Squaring        Fp[Secp256k1]          23 ns        71 cycles
Inversion       Fp[Secp256k1]        9766 ns     29299 cycles


Warmup: 0.9047 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[BN254]               2 ns         8 cycles
Substraction    Fp[BN254]               2 ns         6 cycles
Negation        Fp[BN254]               0 ns         0 cycles
Multiplication  Fp[BN254]              21 ns        64 cycles
Squaring        Fp[BN254]              22 ns        67 cycles
Inversion       Fp[BN254]            9283 ns     27851 cycles


Warmup: 0.9047 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[BLS12_381]           3 ns        11 cycles
Substraction    Fp[BLS12_381]           2 ns         8 cycles
Negation        Fp[BLS12_381]           0 ns         0 cycles
Multiplication  Fp[BLS12_381]          45 ns       136 cycles
Squaring        Fp[BLS12_381]          45 ns       137 cycles
Inversion       Fp[BLS12_381]       24968 ns     74904 cycles
```

### Benchmark new

```
Warmup: 0.9144 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[Secp256k1]           3 ns         9 cycles
Substraction    Fp[Secp256k1]           2 ns         6 cycles
Negation        Fp[Secp256k1]           0 ns         0 cycles
Multiplication  Fp[Secp256k1]          22 ns        68 cycles
Squaring        Fp[Secp256k1]          21 ns        63 cycles
Inversion       Fp[Secp256k1]        9140 ns     27421 cycles


Warmup: 0.9057 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[BN254]               2 ns         8 cycles
Substraction    Fp[BN254]               2 ns         6 cycles
Negation        Fp[BN254]               0 ns         0 cycles
Multiplication  Fp[BN254]              21 ns        64 cycles
Squaring        Fp[BN254]              18 ns        54 cycles
Inversion       Fp[BN254]            8469 ns     25408 cycles


Warmup: 0.9068 s, result 224 (displayed to avoid compiler optimizing warmup away)


⚠️ Measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
==========================================================================================================

Addition        Fp[BLS12_381]           3 ns        11 cycles
Substraction    Fp[BLS12_381]           3 ns         9 cycles
Negation        Fp[BLS12_381]           0 ns         0 cycles
Multiplication  Fp[BLS12_381]          45 ns       137 cycles
Squaring        Fp[BLS12_381]          39 ns       118 cycles
Inversion       Fp[BLS12_381]       22928 ns     68786 cycles
```

### Impact:

Modular Inversion (via exponentiation + Little Fermat Theorem) sees an appreciable boost.
Pairings computations use a lot of squarings so the impact down the line might be significant.

Note that secp256k1 uses the full Montgomery Multiply and Squaring as all 256-bit are used while BN254 and BLS12-381 can use no-carry variants since there is some spare bits.

### Future improvements

As mentioned at the bottom of https://github.com/mratsim/constantine/pull/17 we can still improve performance by using MULX/ADCX/ADOX dual carry chains in multiplication.

#### Comparison with MCL

[MCL](https://github.com/herumi/mcl) uses a JIT and MULX/ADCX/ADOX on a Skylake X CPU.

MCL as of e0f7f5d0735f9214c157b4b163b3f048375e05c7 (Feb 12 2020)

Perf is the following on 6 limbs (BLS12-381) with the JIT backend:
```
i=0 curve=BLS12_381
Fp::add         16.10 clk
Fp::sub          9.01 clk
Fp::neg          8.47 clk
Fp::mul        106.31 clk
Fp::sqr         95.61 clk
Fp::inv         63.768Kclk
Fp2::add        19.63 clk
Fp2::sub        13.93 clk
Fp2::neg        13.91 clk
Fp2::mul       303.24 clk
Fp2::sqr       228.76 clk
Fp2::inv        66.340Kclk
```

Alternatively it can use [assembly](https://github.com/herumi/mcl/tree/master/src/asm) generated from LLVM wide-integers (i384 in our case)
```
i=0 curve=BLS12_381
Fp::add         33.21 clk
Fp::sub         12.84 clk
Fp::neg          8.79 clk
Fp::mul        129.20 clk
Fp::sqr        128.23 clk
Fp::inv         63.804Kclk
Fp2::add        25.19 clk
Fp2::sub        26.88 clk
Fp2::neg        19.11 clk
Fp2::mul       529.55 clk
Fp2::sqr       299.50 clk
Fp2::inv        67.006Kclk
```

#### Comparison with goff

[Goff](https://github.com/ConsenSys/goff) is Consensys Zero-Knowledge team code generator for finite field arithmetic, write-up: https://hackmd.io/@zkteam/goff and benches https://hackmd.io/@zkteam/modular_multiplication#goff-vs-others

This is on BLS12-377 which also uses 6 limbs

```
name              time/op
InverseELEMENT    4.50µs ± 3%
ExpELEMENT        4.58µs ± 0%
DoubleELEMENT     8.11ns ± 0%
AddELEMENT        4.41ns ±15%
SubELEMENT        5.13ns ±25%
NegELEMENT        3.83ns ± 1%
DivELEMENT        4.54µs ± 1%
FromMontELEMENT   31.1ns ± 0%
ToMontELEMENT     44.9ns ± 0%
SquareELEMENT     41.5ns ± 0%
SqrtELEMENT       38.4µs ±43%
MulAssignELEMENT  44.4ns ± 0%
```
Note that Inverse, Exp, Div, Sqrt are not constant-time and exposes several if not all bits of one of the operand to side-channel attacks
Add, Sub, Square, MulAssign are almost constant-time (the bigger than modulo test + modulo substraction/division)
