### PR TITLE
Improve bn curve family support

### DIFF
--- a/constantine/arithmetic/limbs_modular.nim
+++ b/constantine/arithmetic/limbs_modular.nim
@@ -276,7 +276,7 @@ func shlAddMod_estimate(a: LimbsViewMut, aLen: int,
 
     block: # q*p
       # q * p + carry (doubleword) carry from previous limb
-      muladd1(carry, qp_lo, q, M[i], Word carry)
+      muladd1(carry, qp_lo, q, M[i], carry)
 
     block: # a*2^64 - q*p
       var borrow: Borrow
@@ -293,8 +293,8 @@ func shlAddMod_estimate(a: LimbsViewMut, aLen: int,
   # if carry < q or carry == q and over_p we must do "a -= p"
   # if carry > hi (negative result) we must do "a += p"
 
-  result.neg = Word(carry) > hi
-  result.tooBig = not(result.neg) and (over_p or (Word(carry) < hi))
+  result.neg = carry > hi
+  result.tooBig = not(result.neg) and (over_p or (carry < hi))
 
 func shlAddMod(a: LimbsViewMut, aLen: int,
                c: Word, M: LimbsViewConst, mBits: int) =

--- a/constantine/arithmetic/precomputed.nim
+++ b/constantine/arithmetic/precomputed.nim
@@ -104,6 +104,22 @@ func sub(a: var BigInt, w: BaseType): bool =
 
   result = bool(borrow)
 
+func cadd(a: var BigInt, b: BigInt, ctl: bool): bool =
+  ## In-place optional addition
+  ##
+  ## It is NOT constant-time and is intended
+  ## only for compile-time precomputation
+  ## of non-secret data.
+  var carry, sum: BaseType
+  for i in 0 ..< a.limbs.len:
+    let ai = BaseType(a.limbs[i])
+    let bi = BaseType(b.limbs[i])
+    addC(carry, sum, ai, bi, carry)
+    if ctl:
+      a.limbs[i] = Word(sum)
+
+  result = bool(carry)
+
 func csub(a: var BigInt, b: BigInt, ctl: bool): bool =
   ## In-place optional substraction
   ##
@@ -361,3 +377,39 @@ func primePlus1Div4_BE*[bits: static int](
   tmp.shiftRight(1)
 
   result.exportRawUint(tmp, bigEndian)
+
+func toCanonicalIntRepr*[bits: static int](
+       a: BigInt[bits]
+     ): array[(bits+7) div 8, byte] {.noInit.} =
+  ## Export a bigint to its canonical BigEndian representation
+  ## (octet-string)
+  result.exportRawUint(a, bigEndian)
+
+func bn_6u_minus_1_BE*[bits: static int](
+       u: BigInt[bits]
+     ): array[(bits+7+3) div 8, byte] {.noInit.} =
+  ## For a BN curve
+  ## Precompute 6u-1 (for Little Fermat inversion)
+  ## and store it in canonical integer representation
+  # TODO: optimize output size
+  #       each extra 0-bit is an extra useless squaring for a public exponent
+  #       For example, for BN254-Snarks, u = 0x44E992B44A6909F1 (63-bit)
+  #       and 6u+1 is 65-bit (not 66 as inferred)
+
+  # Zero-extend "u"
+  var u_ext: BigInt[bits+3]
+
+  for i in 0 ..< u.limbs.len:
+    u_ext.limbs[i] = u.limbs[i]
+
+  # Addition chain to u -> 6u
+  discard u_ext.dbl()              # u_ext = 2u
+  let u_ext2 = u_ext               # u_ext2 = 2u
+  discard u_ext.dbl()              # u_ext = 4u
+  discard u_ext.cadd(u_ext2, true)  # u_ext = 6u
+
+  # Sustract 1
+  discard u_ext.sub(1)
+
+  # Export
+  result.exportRawUint(u_ext, bigEndian)

--- a/constantine/config/curves.nim
+++ b/constantine/config/curves.nim
@@ -187,7 +187,7 @@ func getCurveBitSize*(C: static Curve): static int =
 template matchingBigInt*(C: static Curve): untyped =
   BigInt[CurveBitSize[C]]
 
-func getCurveFamily*(C: static Curve): CurveFamily =
+func family*(C: static Curve): CurveFamily =
   result = static(CurveFamilies[C])
 
 # ############################################################
@@ -371,9 +371,9 @@ macro getPrimePlus1div4_BE*(C: static Curve): untyped =
 # -------------------------------------------------------
 macro canUseFast_BN_Inversion*(C: static Curve): untyped =
   ## A BN curve can use the fast BN inversion if the parameter "u" is positive
-  if CurveFamilies[C] == BarretoNaehrig:
+  if CurveFamilies[C] != BarretoNaehrig:
     return newLit false
-  return newCall(ident"declared", ident($C & "_BN_param_u"))
+  return bindSym($C & "_BN_can_use_fast_inversion")
 
 macro getBN_param_u_BE*(C: static Curve): untyped =
   ## Get the ``u`` parameter of a BN curve in canonical big-endian representation
@@ -382,7 +382,7 @@ macro getBN_param_u_BE*(C: static Curve): untyped =
 macro getBN_param_6u_minus_1_BE*(C: static Curve): untyped =
   ## Get the ``6u-1`` from the ``u`` parameter
   ## of a BN curve in canonical big-endian representation
-  result = bindSym($C & "bn_6u_minus_1_BE")
+  result = bindSym($C & "_BN_6u_minus_1_BE")
 
 # ############################################################
 #

--- a/constantine/config/curves_parser.nim
+++ b/constantine/config/curves_parser.nim
@@ -56,10 +56,14 @@ macro declareCurves*(curves: untyped): untyped =
   #           StrLit "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
 
   var Curves: seq[NimNode]
-  var CurveBitSize = nnKBracket.newTree()
+  var MapCurveBitWidth = nnkBracket.newTree()
+  var MapCurveFamily = nnkBracket.newTree()
   var curveModStmts = newStmtList()
+  var curveExtraStmts = newStmtList()
 
   for curveDesc in curves:
+    # Checks
+    # -----------------------------------------------
     curveDesc.expectKind(nnkCommand)
     doAssert curveDesc[0].eqIdent"curve"
     curveDesc[1].expectKind(nnkIdent)    # Curve name
@@ -67,32 +71,37 @@ macro declareCurves*(curves: untyped): untyped =
     curveDesc[2][0].expectKind(nnkCall)
     curveDesc[2][1].expectKind(nnkCall)
 
+    # Mandatory fields
+    # -----------------------------------------------
     let curve = curveDesc[1]
+    let curveParams = curveDesc[2]
 
     var offset = 0
     var testCurve = false
-    if curveDesc[2][0][0].eqident"testingCurve":
+    if curveParams[0][0].eqident"testingCurve":
       offset = 1
-      testCurve = curveDesc[2][0][1].boolVal
+      testCurve = curveParams[0][1].boolVal
 
-    let sizeSection = curveDesc[2][offset]
+    let sizeSection = curveParams[offset]
     doAssert sizeSection[0].eqIdent"bitsize"
     sizeSection[1].expectKind(nnkStmtList)
     let bitSize = sizeSection[1][0]
 
-    let modSection = curveDesc[2][offset+1]
+    let modSection = curveParams[offset+1]
     doAssert modSection[0].eqIdent"modulus"
     modSection[1].expectKind(nnkStmtList)
     let modulus = modSection[1][0]
 
+    # Construct the constants
+    # -----------------------------------------------
     if not testCurve or defined(testingCurves):
       Curves.add curve
       # "BN254: 254" for array construction
-      CurveBitSize.add nnkExprColonExpr.newTree(
+      MapCurveBitWidth.add nnkExprColonExpr.newTree(
         curve, bitSize
       )
 
-      # const BN254_Modulus = fromHex(BigInt[254], "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47")
+      # const BN254_Snarks_Modulus = fromHex(BigInt[254], "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47")
       let modulusID = ident($curve & "_Modulus")
       curveModStmts.add newConstStmt(
         modulusID,
@@ -101,6 +110,41 @@ macro declareCurves*(curves: untyped): untyped =
           nnkBracketExpr.newTree(bindSym"BigInt", bitSize),
           modulus
         )
+      )
+
+    # Family specific
+    # -----------------------------------------------
+    if offset + 2 < curveParams.len:
+      let familySection = curveParams[offset+2]
+      doAssert familySection[0].eqIdent"family"
+      familySection[1].expectKind(nnkStmtList)
+      let family = familySection[1][0]
+
+      MapCurveFamily.add nnkExprColonExpr.newTree(
+        curve, family
+      )
+
+      if offset + 5 == curveParams.len:
+        if family.eqIdent"BarretoNaehrig" and
+              curveParams[offset+3][0].eqIdent"bn_u_bitwidth" and
+              curveParams[offset+4][0].eqIdent"bn_u":
+
+          let bn_u_bitwidth = curveParams[offset+3][1][0]
+          let bn_u = curveParams[offset+4][1][0]
+
+          # const BN254_Snarks_BN_param_u = fromHex(BigInt[63], "0x44E992B44A6909F1")
+          curveExtraStmts.add newConstStmt(
+            ident($curve & "_BN_param_u"),
+            newCall(
+              bindSym"fromHex",
+              nnkBracketExpr.newTree(bindSym"BigInt", bn_u_bitwidth),
+              bn_u
+            )
+          )
+
+    else:
+      MapCurveFamily.add nnkExprColonExpr.newTree(
+        curve, ident"NoFamily"
       )
 
   # end for ---------------------------------------------------
@@ -117,11 +161,15 @@ macro declareCurves*(curves: untyped): untyped =
   )
 
   # const CurveBitSize: array[Curve, int] = ...
-  let cbs = ident("CurveBitSize")
   result.add newConstStmt(
-    cbs, CurveBitSize
+    ident("CurveBitSize"), MapCurveBitWidth
+  )
+  # const CurveFamily: array[Curve, CurveFamily] = ...
+  result.add newConstStmt(
+    ident("CurveFamilies"), MapCurveFamily
   )
 
   result.add curveModStmts
+  result.add curveExtraStmts
 
-  # echo result.toStrLit()
+  echo result.toStrLit()

--- a/constantine/config/curves_parser.nim
+++ b/constantine/config/curves_parser.nim
@@ -172,4 +172,4 @@ macro declareCurves*(curves: untyped): untyped =
   result.add curveModStmts
   result.add curveExtraStmts
 
-  echo result.toStrLit()
+  # echo result.toStrLit()

--- a/tests/test_finite_fields_sqrt.nim
+++ b/tests/test_finite_fields_sqrt.nim
@@ -6,14 +6,14 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import  std/unittest, std/times,
-        ../constantine/[arithmetic, primitives],
+import  ../constantine/[arithmetic, primitives],
         ../constantine/io/[io_fields],
         ../constantine/config/[curves, common],
         # Test utilities
         ../helpers/prng,
         # Standard library
-        std/tables
+        std/tables,
+        std/unittest, std/times
 
 const Iters = 128
 


### PR DESCRIPTION
This:
- Adds a new `CurveFamily` enum. For now only used for Barreto-Naehrig family and in the future to specialize pairing per curve family
- Adds a specialized inversion scheme that uses the low Hamming Weight and special form of BN primes if the base BN parameter is positive like for the SNARKS / Ethereum alt_bn128 curve. Unfortunately this is actually significantly slower than the current generic inversion and so is not activated. Furthermore some inputs are failing and need to be debugged. The test suite has been expanded to catch those cases.