### PR TITLE
[WIP] Skewed RNGs that trigger corner cases

### DIFF
--- a/helpers/prng_unsafe.nim
+++ b/helpers/prng_unsafe.nim
@@ -169,7 +169,7 @@ func random_highHammingWeight[T](rng: var RngState, a: var T, C: static Curve) =
   ## to have a higher probability of triggering carries
   when T is BigInt:
     var reduced, unreduced{.noInit.}: T
-    rng.random_word_highHammingWeight(unreduced)
+    rng.random_highHammingWeight(unreduced)
 
     # Note: a simple modulo will be biaised but it's simple and "fast"
     reduced.reduce(unreduced, C.Mod)

--- a/helpers/prng_unsafe.nim
+++ b/helpers/prng_unsafe.nim
@@ -356,7 +356,7 @@ func random_long01Seq*(rng: var RngState, T: typedesc): T =
   else: # Fields
     rng.random_long01Seq(result, T.C)
 
-func random_long01Seq*(rng: var RngState, T: typedesc[ECP_SWei_Proj]): T =
+func random_long01Seq_with_randZ*(rng: var RngState, T: typedesc[ECP_SWei_Proj]): T =
   ## Create a random curve element with a random Z coordinate
   ## Skewed towards long bitstrings of 0 or 1
   rng.random_long01Seq_with_randZ(result)

--- a/tests/t_finite_fields_mulsquare.nim
+++ b/tests/t_finite_fields_mulsquare.nim
@@ -115,15 +115,47 @@ proc randomCurve(C: static Curve) =
 
   doAssert bool(r_mul == r_sqr)
 
+proc randomHighHammingWeight(C: static Curve) =
+  let a = rng.random_highHammingWeight(Fp[C])
+
+  var r_mul, r_sqr: Fp[C]
+
+  r_mul.prod(a, a)
+  r_sqr.square(a)
+
+  doAssert bool(r_mul == r_sqr)
+
+proc random_long01Seq(C: static Curve) =
+  let a = rng.random_long01Seq(Fp[C])
+
+  var r_mul, r_sqr: Fp[C]
+
+  r_mul.prod(a, a)
+  r_sqr.square(a)
+
+  doAssert bool(r_mul == r_sqr)
+
 suite "Random Modular Squaring is consistent with Modular Multiplication" & " [" & $WordBitwidth & "-bit mode]":
   test "Random squaring mod P-224 [FastSquaring = " & $P224.canUseNoCarryMontySquare & "]":
     for _ in 0 ..< Iters:
       randomCurve(P224)
+    for _ in 0 ..< Iters:
+      randomHighHammingWeight(P224)
+    for _ in 0 ..< Iters:
+      random_long01Seq(P224)
 
   test "Random squaring mod P-256 [FastSquaring = " & $P256.canUseNoCarryMontySquare & "]":
     for _ in 0 ..< Iters:
       randomCurve(P256)
+    for _ in 0 ..< Iters:
+      randomHighHammingWeight(P256)
+    for _ in 0 ..< Iters:
+      random_long01Seq(P256)
 
   test "Random squaring mod BLS12_381 [FastSquaring = " & $BLS12_381.canUseNoCarryMontySquare & "]":
     for _ in 0 ..< Iters:
       randomCurve(BLS12_381)
+    for _ in 0 ..< Iters:
+      randomHighHammingWeight(BLS12_381)
+    for _ in 0 ..< Iters:
+      random_long01Seq(BLS12_381)

--- a/tests/t_finite_fields_powinv.nim
+++ b/tests/t_finite_fields_powinv.nim
@@ -170,6 +170,26 @@ proc main() =
           a2.double()
           check: bool(a == a2)
 
+        for _ in 0 ..< Iters:
+          let a = rng.randomHighHammingWeight(Fp[curve])
+          var a2 = a
+          a2.double()
+          a2.div2()
+          check: bool(a == a2)
+          a2.div2()
+          a2.double()
+          check: bool(a == a2)
+
+        for _ in 0 ..< Iters:
+          let a = rng.random_long01Seq(Fp[curve])
+          var a2 = a
+          a2.double()
+          a2.div2()
+          check: bool(a == a2)
+          a2.div2()
+          a2.double()
+          check: bool(a == a2)
+
     testRandomDiv2 P224
     testRandomDiv2 BN254_Nogami
     testRandomDiv2 BN254_Snarks
@@ -239,6 +259,22 @@ proc main() =
 
         for _ in 0 ..< Iters:
           let a = rng.random_unsafe(Fp[curve])
+          aInv.inv(a)
+          r.prod(a, aInv)
+          check: bool r.isOne()
+          r.prod(aInv, a)
+          check: bool r.isOne()
+
+        for _ in 0 ..< Iters:
+          let a = rng.randomHighHammingWeight(Fp[curve])
+          aInv.inv(a)
+          r.prod(a, aInv)
+          check: bool r.isOne()
+          r.prod(aInv, a)
+          check: bool r.isOne()
+
+        for _ in 0 ..< Iters:
+          let a = rng.random_long01Seq(Fp[curve])
           aInv.inv(a)
           r.prod(a, aInv)
           check: bool r.isOne()


### PR DESCRIPTION
This PR addresses #53.
- An uniform RNG has a hard time triggering carry paths, especially with 64-bit word, the probability is 2^-64 * 2^-64 = 2^-128.
- A significant amount of algebra bugs in established libraries like OpenSSL are due to carries. ![algebra bugs](https://user-images.githubusercontent.com/22738317/85069647-c248c500-b1b4-11ea-8bd6-5c2900e3e8cc.png)
- Most fuzzing tools like AFL or LibFuzzer are branch coverage based, but constant-time code is branchless so it's likely that they won't focus on the carry path as it's indistinguishable from the normal path from a Control Flow Graph perspective.

- [x] Add a RNG biaised towards high Hamming Weight words
- [x] Add the same RNG as libsecp256k1 that produces long sequences of 1111... and 0000...
  and found [CVE-2014-3570](https://www.openssl.org/news/secadv/20150108.txt) in OpenSSL and would likely have found similar bug in TweetNaCK: https://gist.github.com/CodesInChaos/8374632
- [x] Use them in testing, in particular check if they can trigger the same edge cases as #30, #42 and #43 that are targeted for solving in #58 