### PR TITLE
Unify GCC and Clang ASM

### DIFF
--- a/constantine/primitives/macro_assembler_x86.nim
+++ b/constantine/primitives/macro_assembler_x86.nim
@@ -286,6 +286,9 @@ func getStrOffset(a: Assembler_x86, op: Operand): string =
 
   # Beware GCC / Clang differences with array offsets
   # https://lists.llvm.org/pipermail/llvm-dev/2017-August/116202.html
+  # - 8+%rax works with GCC
+  # - 8%rax works with Clang
+  # - 8(%rax) works with both
 
   if op.desc.rm in {Mem, AnyRegOrMem, MemOffsettable, AnyMemOffImm, AnyRegMemImm}:
     # Directly accessing memory

--- a/constantine/primitives/macro_assembler_x86.nim
+++ b/constantine/primitives/macro_assembler_x86.nim
@@ -302,12 +302,11 @@ func getStrOffset(a: Assembler_x86, op: Operand): string =
        (op.desc.rm == ElemsInReg and op.kind == kFromArray):
     if op.offset == 0:
       return "(%" & $op.desc.asmId & ')'
-    if defined(gcc):
-      return $(op.offset * a.wordSize) & "+(%" & $op.desc.asmId & ')'
-    elif defined(clang):
-      return $(op.offset * a.wordSize) & "(%" & $op.desc.asmId & ')'
-    else:
-      error "Unconfigured compiler"
+    # GCC & Clang seemed to disagree on pointer indexing
+    # in the past and required different codegen
+    # if defined(gcc):
+    #   return $(op.offset * a.wordSize) & "+(%" & $op.desc.asmId & ')'
+    return $(op.offset * a.wordSize) & "(%" & $op.desc.asmId & ')'
   else:
     error "Unsupported: " & $op.desc.rm.ord
 


### PR DESCRIPTION
Not sure why I needed different codegen for GCC and CLang, it was actually unnecessary?

Or maybe the parenthesis changes everything compared to the original test code https://github.com/mratsim/finite-fields/blob/master/macro_add_carry.nim#L24-L42

```Nim
  when defined(gcc):
    for byteOffset in countup(wsize, maxByteOffset-1, wsize):
      asmStmt.add (block:
        "\n" &
        # movq 8+%[b], %[tmp]
        "      movq " & $byteOffset & "+%[b], %[tmp]\n" &
        # adcq %[tmp], 8+%[a]
        "      adcq %[tmp], " & $byteOffset & "+%[a]\n"
      )
  elif defined(clang):
    # https://lists.llvm.org/pipermail/llvm-dev/2017-August/116202.html
    for byteOffset in countup(wsize, maxByteOffset-1, wsize):
      asmStmt.add (block:
        "\n" &
        # movq 8+%[b], %[tmp]
        "      movq " & $byteOffset & "%[b], %[tmp]\n" &
        # adcq %[tmp], 8+%[a]
        "      adcq %[tmp], " & $byteOffset & "%[a]\n"
      )
```