### PR TITLE
Fix 50% perf regression (2x with GCC) on binary GCD based inversion

### DIFF
--- a/constantine/arithmetic/limbs.nim
+++ b/constantine/arithmetic/limbs.nim
@@ -246,16 +246,22 @@ func cadd*(a: var Limbs, b: Limbs, ctl: SecretBool): Carry =
   ## The carry is always computed whether ctl is true or false
   ##
   ## Time and memory accesses are the same whether a copy occurs or not
-  var t = a
-  result = t.add(b)
-  a.ccopy(t, ctl)
+  result = Carry(0)
+  var sum: SecretWord
+  for i in 0 ..< a.len:
+    addC(result, sum, a[i], b[i], result)
+    ctl.ccopy(a[i], sum)
 
-func cadd*(a: var Limbs, w: SecretWord, ctl: SecretBool): Carry =
+func cadd*(a: var Limbs, w: SecretWord, ctl: SecretBool): Borrow =
   ## Limbs conditional addition, sub a number that fits in a word
   ## Returns the borrow
-  var t = a
-  result = t.add(w)
-  a.ccopy(t, ctl)
+  result = Carry(0)
+  var diff: SecretWord
+  addC(result, diff, a[0], w, result)
+  ctl.ccopy(a[0], diff)
+  for i in 1 ..< a.len:
+    addC(result, diff, a[i], Zero, result)
+    ctl.ccopy(a[i], diff)
 
 func csub*(a: var Limbs, b: Limbs, ctl: SecretBool): Borrow =
   ## Limbs conditional substraction
@@ -266,16 +272,22 @@ func csub*(a: var Limbs, b: Limbs, ctl: SecretBool): Borrow =
   ## The borrow is always computed whether ctl is true or false
   ##
   ## Time and memory accesses are the same whether a copy occurs or not
-  var t = a
-  result = t.sub(b)
-  a.ccopy(t, ctl)
+  result = Borrow(0)
+  var diff: SecretWord
+  for i in 0 ..< a.len:
+    subB(result, diff, a[i], b[i], result)
+    ctl.ccopy(a[i], diff)
 
 func csub*(a: var Limbs, w: SecretWord, ctl: SecretBool): Borrow =
   ## Limbs conditional substraction, sub a number that fits in a word
   ## Returns the borrow
-  var t = a
-  result = t.sub(w)
-  a.ccopy(t, ctl)
+  result = Borrow(0)
+  var diff: SecretWord
+  subB(result, diff, a[0], w, result)
+  ctl.ccopy(a[0], diff)
+  for i in 1 ..< a.len:
+    subB(result, diff, a[i], Zero, result)
+    ctl.ccopy(a[i], diff)
 
 func cneg*(a: var Limbs, ctl: CTBool) =
   ## Conditional negation.

--- a/constantine/curves/zoo_inversions.nim
+++ b/constantine/curves/zoo_inversions.nim
@@ -26,8 +26,11 @@ export
 func hasInversionAddchain*(C: static Curve): static bool =
   # TODO: For now we don't activate the addition chains
   #      for Secp256k1
-  # Performance is slower than GCD
-  when C in {BN254_Nogami, BN254_Snarks, BLS12_377, BLS12_381, BW6_761}:
+  #      Performance is slower than GCD (to investigate)
+  # For BW6-761 the addition chain is over 2x slower than Euclid-based inversion
+  # due to multiplication being so costly with 12 limbs (grows quadratically)
+  # while Euclid costs grows linearly.
+  when C in {BN254_Nogami, BN254_Snarks, BLS12_377, BLS12_381}:
     true
   else:
     false


### PR DESCRIPTION
Revert part of #95, fix #134

Before GCC compiler
![image](https://user-images.githubusercontent.com/22738317/105612605-a007cd00-5dbd-11eb-9c0d-271ee3206eca.png)

Before Clang
![image](https://user-images.githubusercontent.com/22738317/105612611-a72edb00-5dbd-11eb-9492-e87172984ffc.png)

After GCC
![image](https://user-images.githubusercontent.com/22738317/105612675-bada4180-5dbd-11eb-840a-671d969f187f.png)

After Clang
![image](https://user-images.githubusercontent.com/22738317/105612716-0260cd80-5dbe-11eb-9b53-45c3cf0b1262.png)


Conclusion
Implement stuff in assembly ...