### PR TITLE
Implement Jacobian mixed addition

### DIFF
--- a/benchmarks/bench_ec_g1.nim
+++ b/benchmarks/bench_ec_g1.nim
@@ -48,6 +48,7 @@ proc main() =
     addBench(ECP_ShortW_Proj[Fp[curve], NotOnTwist], Iters)
     addBench(ECP_ShortW_Jac[Fp[curve], NotOnTwist], Iters)
     mixedAddBench(ECP_ShortW_Proj[Fp[curve], NotOnTwist], Iters)
+    mixedAddBench(ECP_ShortW_Jac[Fp[curve], NotOnTwist], Iters)
     doublingBench(ECP_ShortW_Proj[Fp[curve], NotOnTwist], Iters)
     doublingBench(ECP_ShortW_Jac[Fp[curve], NotOnTwist], Iters)
     separator()

--- a/benchmarks/bench_ec_g2.nim
+++ b/benchmarks/bench_ec_g2.nim
@@ -49,6 +49,7 @@ proc main() =
     addBench(ECP_ShortW_Proj[Fp2[curve], OnTwist], Iters)
     addBench(ECP_ShortW_Jac[Fp2[curve], OnTwist], Iters)
     mixedAddBench(ECP_ShortW_Proj[Fp2[curve], OnTwist], Iters)
+    mixedAddBench(ECP_ShortW_Jac[Fp2[curve], OnTwist], Iters)
     doublingBench(ECP_ShortW_Proj[Fp2[curve], OnTwist], Iters)
     doublingBench(ECP_ShortW_Jac[Fp2[curve], OnTwist], Iters)
     separator()

--- a/benchmarks/bench_elliptic_template.nim
+++ b/benchmarks/bench_elliptic_template.nim
@@ -17,7 +17,11 @@ import
   ../constantine/config/[curves, common],
   ../constantine/arithmetic,
   ../constantine/io/io_bigints,
-  ../constantine/elliptic/[ec_shortweierstrass_affine, ec_shortweierstrass_projective, ec_scalar_mul, ec_endomorphism_accel],
+  ../constantine/elliptic/[
+    ec_shortweierstrass_affine,
+    ec_shortweierstrass_projective,
+    ec_shortweierstrass_jacobian,
+    ec_scalar_mul, ec_endomorphism_accel],
   # Helpers
   ../helpers/[prng_unsafe, static_for],
   ./platforms,
@@ -64,7 +68,10 @@ proc mixedAddBench*(T: typedesc, iters: int) =
   let P = rng.random_unsafe(T)
   let Q = rng.random_unsafe(T)
   var Qaff: ECP_ShortW_Aff[T.F, T.Tw]
-  Qaff.affineFromProjective(Q)
+  when Q is ECP_ShortW_Proj:
+    Qaff.affineFromProjective(Q)
+  else:
+    Qaff.affineFromJacobian(Q)
   bench("EC Mixed Addition " & G1_or_G2, T, iters):
     r.madd(P, Qaff)
 

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -75,7 +75,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ("tests/t_ec_shortw_jac_g1_mul_sanity.nim", false),
   # ("tests/t_ec_shortw_jac_g1_mul_distri.nim", false),
   ("tests/t_ec_shortw_jac_g1_mul_vs_ref.nim", false),
-  # mixed_add
+  ("tests/t_ec_shortw_jac_g1_mixed_add.nim", false),
 
   # Elliptic curve arithmetic G2
   # ----------------------------------------------------------
@@ -107,25 +107,25 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ("tests/t_ec_shortw_jac_g2_mul_sanity_bn254_snarks.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_distri_bn254_snarks.nim", false),
   ("tests/t_ec_shortw_jac_g2_mul_vs_ref_bn254_snarks.nim", false),
-  # mixed_add
+  ("tests/t_ec_shortw_jac_g2_mixed_add_bn254_snarks.nim", false),
 
   # ("tests/t_ec_shortw_jac_g2_add_double_bls12_381.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_sanity_bls12_381.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_distri_bls12_381.nim", false),
   ("tests/t_ec_shortw_jac_g2_mul_vs_ref_bls12_381.nim", false),
-  # mixed_add
+  ("tests/t_ec_shortw_jac_g2_mixed_add_bls12_381.nim", false),
 
   # ("tests/t_ec_shortw_jac_g2_add_double_bls12_377.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_sanity_bls12_377.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_distri_bls12_377.nim", false),
   ("tests/t_ec_shortw_jac_g2_mul_vs_ref_bls12_377.nim", false),
-  # mixed_add
+  ("tests/t_ec_shortw_jac_g2_mixed_add_bls12_377.nim", false),
 
   # ("tests/t_ec_shortw_jac_g2_add_double_bw6_761.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_sanity_bw6_761.nim", false),
   # ("tests/t_ec_shortw_jac_g2_mul_distri_bw6_761.nim", false),
   ("tests/t_ec_shortw_jac_g2_mul_vs_ref_bw6_761.nim", false),
-  # mixed_add
+  ("tests/t_ec_shortw_jac_g2_mixed_add_bw6_761.nim", false),
 
   # Elliptic curve arithmetic vs Sagemath
   # ----------------------------------------------------------

--- a/constantine/arithmetic/limbs.nim
+++ b/constantine/arithmetic/limbs.nim
@@ -63,13 +63,14 @@ when UseASM_X86_64:
 
 func setZero*(a: var Limbs) =
   ## Set ``a`` to 0
-  zeroMem(a[0].addr, sizeof(a))
+  for i in 0 ..< a.len:
+    a[i] = Zero
 
 func setOne*(a: var Limbs) =
   ## Set ``a`` to 1
   a[0] = One
-  when a.len > 1:
-    zeroMem(a[1].addr, (a.len - 1) * sizeof(SecretWord))
+  for i in 1 ..< a.len:
+    a[i] = Zero
 
 func czero*(a: var Limbs, ctl: SecretBool) =
   ## Set ``a`` to 0 if ``ctl`` is true

--- a/constantine/elliptic/ec_shortweierstrass_affine.nim
+++ b/constantine/elliptic/ec_shortweierstrass_affine.nim
@@ -32,6 +32,16 @@ type
     ## over a field F
     x*, y*: F
 
+func isInf*(P: ECP_ShortW_Aff): SecretBool =
+  ## Returns true if P is an infinity point
+  ## and false otherwise
+  ##
+  ## Note: the jacobian coordinates equation is
+  ##       Y² = X³ + aXZ⁴ + bZ⁶
+  ## A "zero" point is any point with coordinates X and Z = 0
+  ## Y can be anything
+  result = P.x.isZero() and P.y.isZero()
+
 func curve_eq_rhs*[F](y2: var F, x: F, Tw: static Twisted) =
   ## Compute the curve equation right-hand-side from field element `x`
   ## i.e.  `y²` in `y² = x³ + a x + b`

--- a/tests/t_ec_shortw_jac_g1_mixed_add.nim
+++ b/tests/t_ec_shortw_jac_g1_mixed_add.nim
@@ -1,0 +1,42 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../constantine/config/curves,
+  ../constantine/elliptic/ec_shortweierstrass_jacobian,
+  ../constantine/arithmetic,
+  # Test utilities
+  ./t_ec_template
+
+const
+  Iters = 12
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BN254_Snarks], NotOnTwist],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BN254_Snarks
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BLS12_381], NotOnTwist],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BLS12_381
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BLS12_377], NotOnTwist],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BLS12_377
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BW6_761], NotOnTwist],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BW6_761
+  )

--- a/tests/t_ec_template.nim
+++ b/tests/t_ec_template.nim
@@ -441,7 +441,10 @@ proc run_EC_mixed_add_impl*(
           let a = rng.random_point(EC, randZ, gen)
           let b = rng.random_point(EC, randZ, gen)
           var bAff: ECP_ShortW_Aff[EC.F, EC.Tw]
-          bAff.affineFromProjective(b)
+          when b is ECP_ShortW_Proj:
+            bAff.affineFromProjective(b)
+          else:
+            bAff.affineFromJacobian(b)
 
           var r_generic, r_mixed: EC
 


### PR DESCRIPTION
This does the following

- [x] Add mixed addition on Jacobian coordinates
- [x] Fix Jacobian -> affine conversion
- [x] Allow setZero and setOne at compile-time

Jacobian coordinates are significantly more efficient on G2 than projective due to not having to deal with the Twist factors.
Surprisingly mixed addition with projective or jacobian coordinates on G1 takes the same number of cycles

Benchmark G1
![image](https://user-images.githubusercontent.com/22738317/106356438-dda9b000-62ff-11eb-8f7b-024192667992.png)
![image](https://user-images.githubusercontent.com/22738317/106356444-ec906280-62ff-11eb-92f3-38dfb0f74cb0.png)
![image](https://user-images.githubusercontent.com/22738317/106356452-f7e38e00-62ff-11eb-81b2-f8c4eb900203.png)

Benchmark G2
![image](https://user-images.githubusercontent.com/22738317/106356474-1d709780-6300-11eb-9035-ebdc515b00f6.png)
![image](https://user-images.githubusercontent.com/22738317/106356519-69234100-6300-11eb-929a-f6e7d32743f4.png)
![image](https://user-images.githubusercontent.com/22738317/106356488-38430c00-6300-11eb-81c8-5caabaffc103.png)

This should improve the perf on the benchmarks ran by @yelhousni
