### PR TITLE
Double-Precision towering

### DIFF
--- a/benchmarks/bench_blueprint.nim
+++ b/benchmarks/bench_blueprint.nim
@@ -88,7 +88,6 @@ proc notes*() =
   echo "    Bench on specific compiler with assembler: \"nimble bench_ec_g1_gcc\" or \"nimble bench_ec_g1_clang\"."
   echo "    Bench on specific compiler with assembler: \"nimble bench_ec_g1_gcc_noasm\" or \"nimble bench_ec_g1_clang_noasm\"."
   echo "  - The simplest operations might be optimized away by the compiler."
-  echo "  - Fast Squaring and Fast Multiplication are possible if there are spare bits in the prime representation (i.e. the prime uses 254 bits out of 256 bits)"
 
 template measure*(iters: int,
                startTime, stopTime: untyped,

--- a/benchmarks/bench_fp_double_precision.nim
+++ b/benchmarks/bench_fp_double_precision.nim
@@ -121,12 +121,12 @@ func random_unsafe(rng: var RngState, a: var FpDbl, Base: typedesc) =
   for i in 0 ..< aHi.mres.limbs.len:
     a.limbs2x[aLo.mres.limbs.len+i] = aHi.mres.limbs[i]
 
-proc sumUnred(T: typedesc, iters: int) =
+proc sumUnr(T: typedesc, iters: int) =
   var r: T
   let a = rng.random_unsafe(T)
   let b = rng.random_unsafe(T)
   bench("Addition unreduced", $T, iters):
-    r.sumUnred(a, b)
+    r.sumUnr(a, b)
 
 proc sum(T: typedesc, iters: int) =
   var r: T
@@ -135,12 +135,12 @@ proc sum(T: typedesc, iters: int) =
   bench("Addition", $T, iters):
     r.sum(a, b)
 
-proc diffUnred(T: typedesc, iters: int) =
+proc diffUnr(T: typedesc, iters: int) =
   var r: T
   let a = rng.random_unsafe(T)
   let b = rng.random_unsafe(T)
   bench("Substraction unreduced", $T, iters):
-    r.diffUnred(a, b)
+    r.diffUnr(a, b)
 
 proc diff(T: typedesc, iters: int) =
   var r: T
@@ -155,7 +155,7 @@ proc diff2xNoReduce(T: typedesc, iters: int) =
   rng.random_unsafe(a, T)
   rng.random_unsafe(b, T)
   bench("Substraction 2x unreduced", $doublePrec(T), iters):
-    r.diff2xUnred(a, b)
+    r.diff2xUnr(a, b)
 
 proc diff2x(T: typedesc, iters: int) =
   var r, a, b: doublePrec(T)
@@ -188,8 +188,8 @@ proc reduce2x*(T: typedesc, iters: int) =
 
 proc main() =
   separator()
-  sumUnred(Fp[BLS12_381], iters = 10_000_000)
-  diffUnred(Fp[BLS12_381], iters = 10_000_000)
+  sumUnr(Fp[BLS12_381], iters = 10_000_000)
+  diffUnr(Fp[BLS12_381], iters = 10_000_000)
   sum(Fp[BLS12_381], iters = 10_000_000)
   diff(Fp[BLS12_381], iters = 10_000_000)
   diff2x(Fp[BLS12_381], iters = 10_000_000)

--- a/benchmarks/bench_fp_double_precision.nim
+++ b/benchmarks/bench_fp_double_precision.nim
@@ -150,19 +150,19 @@ proc diff(T: typedesc, iters: int) =
     r.diff(a, b)
 
 proc diff2xNoReduce(T: typedesc, iters: int) =
-  var r, a, b: doubleWidth(T)
+  var r, a, b: doublePrec(T)
   rng.random_unsafe(r, T)
   rng.random_unsafe(a, T)
   rng.random_unsafe(b, T)
-  bench("Substraction 2x unreduced", $doubleWidth(T), iters):
+  bench("Substraction 2x unreduced", $doublePrec(T), iters):
     r.diff2xUnred(a, b)
 
 proc diff2x(T: typedesc, iters: int) =
-  var r, a, b: doubleWidth(T)
+  var r, a, b: doublePrec(T)
   rng.random_unsafe(r, T)
   rng.random_unsafe(a, T)
   rng.random_unsafe(b, T)
-  bench("Substraction 2x reduced", $doubleWidth(T), iters):
+  bench("Substraction 2x reduced", $doublePrec(T), iters):
     r.diff2xMod(a, b)
 
 proc prod2xBench*(rLen, aLen, bLen: static int, iters: int) =
@@ -180,10 +180,10 @@ proc square2xBench*(rLen, aLen: static int, iters: int) =
 
 proc reduce2x*(T: typedesc, iters: int) =
   var r: T
-  var t: doubleWidth(T)
+  var t: doublePrec(T)
   rng.random_unsafe(t, T)
 
-  bench("Redc 2x", $T & " <- " & $doubleWidth(T), iters):
+  bench("Redc 2x", $T & " <- " & $doublePrec(T), iters):
     r.redc2x(t)
 
 proc main() =

--- a/benchmarks/bench_fp_double_precision.nim
+++ b/benchmarks/bench_fp_double_precision.nim
@@ -149,7 +149,23 @@ proc diff(T: typedesc, iters: int) =
   bench("Substraction", $T, iters):
     r.diff(a, b)
 
-proc diff2xNoReduce(T: typedesc, iters: int) =
+proc sum2xUnreduce(T: typedesc, iters: int) =
+  var r, a, b: doublePrec(T)
+  rng.random_unsafe(r, T)
+  rng.random_unsafe(a, T)
+  rng.random_unsafe(b, T)
+  bench("Addition 2x unreduced", $doublePrec(T), iters):
+    r.sum2xUnr(a, b)
+
+proc sum2x(T: typedesc, iters: int) =
+  var r, a, b: doublePrec(T)
+  rng.random_unsafe(r, T)
+  rng.random_unsafe(a, T)
+  rng.random_unsafe(b, T)
+  bench("Addition 2x reduced", $doublePrec(T), iters):
+    r.sum2xMod(a, b)
+
+proc diff2xUnreduce(T: typedesc, iters: int) =
   var r, a, b: doublePrec(T)
   rng.random_unsafe(r, T)
   rng.random_unsafe(a, T)
@@ -188,12 +204,16 @@ proc reduce2x*(T: typedesc, iters: int) =
 
 proc main() =
   separator()
-  sumUnr(Fp[BLS12_381], iters = 10_000_000)
-  diffUnr(Fp[BLS12_381], iters = 10_000_000)
   sum(Fp[BLS12_381], iters = 10_000_000)
+  sumUnr(Fp[BLS12_381], iters = 10_000_000)
   diff(Fp[BLS12_381], iters = 10_000_000)
+  diffUnr(Fp[BLS12_381], iters = 10_000_000)
+  separator()
+  sum2x(Fp[BLS12_381], iters = 10_000_000)
+  sum2xUnreduce(Fp[BLS12_381], iters = 10_000_000)
   diff2x(Fp[BLS12_381], iters = 10_000_000)
-  diff2xNoReduce(Fp[BLS12_381], iters = 10_000_000)
+  diff2xUnreduce(Fp[BLS12_381], iters = 10_000_000)
+  separator()
   prod2xBench(768, 384, 384, iters = 10_000_000)
   square2xBench(768, 384, iters = 10_000_000)
   reduce2x(Fp[BLS12_381], iters = 10_000_000)

--- a/benchmarks/bench_fp_double_width.nim
+++ b/benchmarks/bench_fp_double_width.nim
@@ -121,12 +121,12 @@ func random_unsafe(rng: var RngState, a: var FpDbl, Base: typedesc) =
   for i in 0 ..< aHi.mres.limbs.len:
     a.limbs2x[aLo.mres.limbs.len+i] = aHi.mres.limbs[i]
 
-proc sumNoReduce(T: typedesc, iters: int) =
+proc sumUnred(T: typedesc, iters: int) =
   var r: T
   let a = rng.random_unsafe(T)
   let b = rng.random_unsafe(T)
-  bench("Addition no reduce", $T, iters):
-    r.sumNoReduce(a, b)
+  bench("Addition unreduced", $T, iters):
+    r.sumUnred(a, b)
 
 proc sum(T: typedesc, iters: int) =
   var r: T
@@ -135,12 +135,12 @@ proc sum(T: typedesc, iters: int) =
   bench("Addition", $T, iters):
     r.sum(a, b)
 
-proc diffNoReduce(T: typedesc, iters: int) =
+proc diffUnred(T: typedesc, iters: int) =
   var r: T
   let a = rng.random_unsafe(T)
   let b = rng.random_unsafe(T)
-  bench("Substraction no reduce", $T, iters):
-    r.diffNoReduce(a, b)
+  bench("Substraction unreduced", $T, iters):
+    r.diffUnred(a, b)
 
 proc diff(T: typedesc, iters: int) =
   var r: T
@@ -154,28 +154,28 @@ proc diff2xNoReduce(T: typedesc, iters: int) =
   rng.random_unsafe(r, T)
   rng.random_unsafe(a, T)
   rng.random_unsafe(b, T)
-  bench("Substraction 2x no reduce", $doubleWidth(T), iters):
-    r.diffNoReduce(a, b)
+  bench("Substraction 2x unreduced", $doubleWidth(T), iters):
+    r.diff2xUnred(a, b)
 
 proc diff2x(T: typedesc, iters: int) =
   var r, a, b: doubleWidth(T)
   rng.random_unsafe(r, T)
   rng.random_unsafe(a, T)
   rng.random_unsafe(b, T)
-  bench("Substraction 2x", $doubleWidth(T), iters):
-    r.diff(a, b)
+  bench("Substraction 2x reduced", $doubleWidth(T), iters):
+    r.diff2xMod(a, b)
 
-proc mul2xBench*(rLen, aLen, bLen: static int, iters: int) =
+proc prod2xBench*(rLen, aLen, bLen: static int, iters: int) =
   var r: BigInt[rLen]
   let a = rng.random_unsafe(BigInt[aLen])
   let b = rng.random_unsafe(BigInt[bLen])
-  bench("Multiplication", $rLen & " <- " & $aLen & " x " & $bLen, iters):
+  bench("Multiplication 2x", $rLen & " <- " & $aLen & " x " & $bLen, iters):
     r.prod(a, b)
 
 proc square2xBench*(rLen, aLen: static int, iters: int) =
   var r: BigInt[rLen]
   let a = rng.random_unsafe(BigInt[aLen])
-  bench("Squaring", $rLen & " <- " & $aLen & "²", iters):
+  bench("Squaring 2x", $rLen & " <- " & $aLen & "²", iters):
     r.square(a)
 
 proc reduce2x*(T: typedesc, iters: int) =
@@ -183,18 +183,18 @@ proc reduce2x*(T: typedesc, iters: int) =
   var t: doubleWidth(T)
   rng.random_unsafe(t, T)
 
-  bench("Reduce 2x-width", $T & " <- " & $doubleWidth(T), iters):
-    r.reduce(t)
+  bench("Redc 2x", $T & " <- " & $doubleWidth(T), iters):
+    r.redc2x(t)
 
 proc main() =
   separator()
-  sumNoReduce(Fp[BLS12_381], iters = 10_000_000)
-  diffNoReduce(Fp[BLS12_381], iters = 10_000_000)
+  sumUnred(Fp[BLS12_381], iters = 10_000_000)
+  diffUnred(Fp[BLS12_381], iters = 10_000_000)
   sum(Fp[BLS12_381], iters = 10_000_000)
   diff(Fp[BLS12_381], iters = 10_000_000)
   diff2x(Fp[BLS12_381], iters = 10_000_000)
   diff2xNoReduce(Fp[BLS12_381], iters = 10_000_000)
-  mul2xBench(768, 384, 384, iters = 10_000_000)
+  prod2xBench(768, 384, 384, iters = 10_000_000)
   square2xBench(768, 384, iters = 10_000_000)
   reduce2x(Fp[BLS12_381], iters = 10_000_000)
   separator()

--- a/benchmarks/bench_pairing_template.nim
+++ b/benchmarks/bench_pairing_template.nim
@@ -32,15 +32,15 @@ import
   ./bench_blueprint
 
 export notes
-proc separator*() = separator(177)
+proc separator*() = separator(132)
 
 proc report(op, curve: string, startTime, stopTime: MonoTime, startClk, stopClk: int64, iters: int) =
   let ns = inNanoseconds((stopTime-startTime) div iters)
   let throughput = 1e9 / float64(ns)
   when SupportsGetTicks:
-    echo &"{op:<60} {curve:<15} {throughput:>15.3f} ops/s     {ns:>9} ns/op     {(stopClk - startClk) div iters:>9} CPU cycles (approx)"
+    echo &"{op:<40} {curve:<15} {throughput:>15.3f} ops/s     {ns:>9} ns/op     {(stopClk - startClk) div iters:>9} CPU cycles (approx)"
   else:
-    echo &"{op:<60} {curve:<15} {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+    echo &"{op:<40} {curve:<15} {throughput:>15.3f} ops/s     {ns:>9} ns/op"
 
 template bench(op: string, C: static Curve, iters: int, body: untyped): untyped =
   measure(iters, startTime, stopTime, startClk, stopClk, body)

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -50,6 +50,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ----------------------------------------------------------
   ("tests/t_fp2.nim", false),
   ("tests/t_fp2_sqrt.nim", false),
+  ("tests/t_fp4.nim", false),
   ("tests/t_fp6_bn254_snarks.nim", false),
   ("tests/t_fp6_bls12_377.nim", false),
   ("tests/t_fp6_bls12_381.nim", false),

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -43,7 +43,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/t_finite_fields_powinv.nim", false),
   ("tests/t_finite_fields_vs_gmp.nim", true),
   ("tests/t_fp_cubic_root.nim", false),
-  # Double-width finite fields
+  # Double-precision finite fields
   # ----------------------------------------------------------
   ("tests/t_finite_fields_double_precision.nim", false),
   # Towers of extension fields

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -45,7 +45,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/t_fp_cubic_root.nim", false),
   # Double-width finite fields
   # ----------------------------------------------------------
-  ("tests/t_finite_fields_double_width.nim", false),
+  ("tests/t_finite_fields_double_precision.nim", false),
   # Towers of extension fields
   # ----------------------------------------------------------
   ("tests/t_fp2.nim", false),
@@ -260,7 +260,7 @@ proc buildAllBenches() =
   echo "\n\n------------------------------------------------------\n"
   echo "Building benchmarks to ensure they stay relevant ..."
   buildBench("bench_fp")
-  buildBench("bench_fp_double_width")
+  buildBench("bench_fp_double_precision")
   buildBench("bench_fp2")
   buildBench("bench_fp6")
   buildBench("bench_fp12")
@@ -401,19 +401,19 @@ task bench_fp_clang_noasm, "Run benchmark 𝔽p with clang - no Assembly":
   runBench("bench_fp", "clang", useAsm = false)
 
 task bench_fpdbl, "Run benchmark 𝔽pDbl with your default compiler":
-  runBench("bench_fp_double_width")
+  runBench("bench_fp_double_precision")
 
 task bench_fpdbl_gcc, "Run benchmark 𝔽p with gcc":
-  runBench("bench_fp_double_width", "gcc")
+  runBench("bench_fp_double_precision", "gcc")
 
 task bench_fpdbl_clang, "Run benchmark 𝔽p with clang":
-  runBench("bench_fp_double_width", "clang")
+  runBench("bench_fp_double_precision", "clang")
 
 task bench_fpdbl_gcc_noasm, "Run benchmark 𝔽p with gcc - no Assembly":
-  runBench("bench_fp_double_width", "gcc", useAsm = false)
+  runBench("bench_fp_double_precision", "gcc", useAsm = false)
 
 task bench_fpdbl_clang_noasm, "Run benchmark 𝔽p with clang - no Assembly":
-  runBench("bench_fp_double_width", "clang", useAsm = false)
+  runBench("bench_fp_double_precision", "clang", useAsm = false)
 
 task bench_fp2, "Run benchmark with 𝔽p2 your default compiler":
   runBench("bench_fp2")

--- a/constantine/arithmetic.nim
+++ b/constantine/arithmetic.nim
@@ -12,7 +12,7 @@ import
     finite_fields,
     finite_fields_inversion,
     finite_fields_square_root,
-    finite_fields_double_width
+    finite_fields_double_precision
   ]
 
 export
@@ -21,4 +21,4 @@ export
   finite_fields,
   finite_fields_inversion,
   finite_fields_square_root,
-  finite_fields_double_width
+  finite_fields_double_precision

--- a/constantine/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
@@ -77,7 +77,7 @@ macro addmod2x_gen[N: static int](R: var Limbs[N], A, B: Limbs[N], m: Limbs[N di
     ctx.mov u[i-H], v[i-H]
 
   # Mask: overflowed contains 0xFFFF or 0x0000
-  # TODO: unnecessary if MSB never set, i.e. "canUseNoCarryMontyMul"
+  # TODO: unnecessary if MSB never set, i.e. "Field.getSpareBits >= 1"
   let overflowed = b.reuseRegister()
   ctx.sbb overflowed, overflowed
 

--- a/constantine/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
@@ -14,17 +14,25 @@ import
   ../../primitives
 
 # ############################################################
-#
-#        Assembly implementation of FpDbl
-#
+#                                                            #
+#        Assembly implementation of FpDbl                    #
+#                                                            #
 # ############################################################
+
+# A FpDbl is a partially-reduced double-precision element of Fp
+# The allowed range is [0, 2ⁿp)
+# with n = w*WordBitSize
+# and w the number of words necessary to represent p on the machine.
+# Concretely a 381-bit p needs 6*64 bits limbs (hence 384 bits total)
+# and so FpDbl would 768 bits.
 
 static: doAssert UseASM_X86_64
 {.localPassC:"-fomit-frame-pointer".} # Needed so that the compiler finds enough registers
 
-# TODO slower than intrinsics
+# Field addition
+# ------------------------------------------------------------
 
-# Substraction
+# Field Substraction
 # ------------------------------------------------------------
 
 macro sub2x_gen[N: static int](R: var Limbs[N], A, B: Limbs[N], m: Limbs[N div 2]): untyped =

--- a/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
@@ -69,7 +69,7 @@ macro addmod_gen[N: static int](R: var Limbs[N], A, B, m: Limbs[N]): untyped =
     ctx.mov v[i], u[i]
 
   # Mask: overflowed contains 0xFFFF or 0x0000
-  # TODO: unnecessary if MSB never set, i.e. "canUseNoCarryMontyMul"
+  # TODO: unnecessary if MSB never set, i.e. "Field.getSpareBits >= 1"
   let overflowed = b.reuseRegister()
   ctx.sbb overflowed, overflowed
 

--- a/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
@@ -73,7 +73,7 @@ macro addmod_gen[N: static int](R: var Limbs[N], A, B, m: Limbs[N]): untyped =
   let overflowed = b.reuseRegister()
   ctx.sbb overflowed, overflowed
 
-  # Now substract the modulus
+  # Now substract the modulus to test a < p
   for i in 0 ..< N:
     if i == 0:
       ctx.sub v[0], M[0]

--- a/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_modular_x86.nim
@@ -81,7 +81,7 @@ macro addmod_gen[N: static int](R: var Limbs[N], A, B, m: Limbs[N]): untyped =
       ctx.sbb v[i], M[i]
 
   # If it overflows here, it means that it was
-  # smaller than the modulus and we don'u need V
+  # smaller than the modulus and we don't need V
   ctx.sbb overflowed, 0
 
   # Conditional Mov and

--- a/constantine/arithmetic/assembly/limbs_asm_montred_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_montred_x86.nim
@@ -88,7 +88,7 @@ macro montyRedc2x_gen[N: static int](
        a_MR: array[N*2, SecretWord],
        M_MR: array[N, SecretWord],
        m0ninv_MR: BaseType,
-       canUseNoCarryMontyMul: static bool
+       spareBits: static int
       ) =
   # TODO, slower than Clang, in particular due to the shadowing
 
@@ -236,7 +236,7 @@ macro montyRedc2x_gen[N: static int](
 
   let reuse = repackRegisters(t, scratch[N], scratch[N+1])
 
-  if canUseNoCarryMontyMul:
+  if spareBits >= 1:
     ctx.finalSubNoCarry(r, scratch, M, reuse)
   else:
     ctx.finalSubCanOverflow(r, scratch, M, reuse, rRAX)
@@ -249,7 +249,7 @@ func montRed_asm*[N: static int](
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType,
-       canUseNoCarryMontyMul: static bool
+       spareBits: static int
       ) =
   ## Constant-time Montgomery reduction
-  montyRedc2x_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)
+  montyRedc2x_gen(r, a, M, m0ninv, spareBits)

--- a/constantine/arithmetic/assembly/limbs_asm_montred_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_montred_x86.nim
@@ -83,7 +83,7 @@ proc finalSubCanOverflow*(
 # Montgomery reduction
 # ------------------------------------------------------------
 
-macro montyRed_gen[N: static int](
+macro montyRedc2x_gen[N: static int](
        r_MR: var array[N, SecretWord],
        a_MR: array[N*2, SecretWord],
        M_MR: array[N, SecretWord],
@@ -252,4 +252,4 @@ func montRed_asm*[N: static int](
        canUseNoCarryMontyMul: static bool
       ) =
   ## Constant-time Montgomery reduction
-  montyRed_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)
+  montyRedc2x_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)

--- a/constantine/arithmetic/assembly/limbs_asm_montred_x86_adx_bmi2.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_montred_x86_adx_bmi2.nim
@@ -40,7 +40,7 @@ macro montyRedc2xx_gen[N: static int](
        a_MR: array[N*2, SecretWord],
        M_MR: array[N, SecretWord],
        m0ninv_MR: BaseType,
-       canUseNoCarryMontyMul: static bool
+       spareBits: static int
       ) =
   # TODO, slower than Clang, in particular due to the shadowing
 
@@ -175,7 +175,7 @@ macro montyRedc2xx_gen[N: static int](
 
   let reuse = repackRegisters(t, scratch[N])
 
-  if canUseNoCarryMontyMul:
+  if spareBits >= 1:
     ctx.finalSubNoCarry(r, scratch, M, reuse)
   else:
     ctx.finalSubCanOverflow(r, scratch, M, reuse, hi)
@@ -188,7 +188,7 @@ func montRed_asm_adx_bmi2*[N: static int](
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType,
-       canUseNoCarryMontyMul: static bool
+       spareBits: static int
       ) =
   ## Constant-time Montgomery reduction
-  montyRedc2xx_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)
+  montyRedc2xx_gen(r, a, M, m0ninv, spareBits)

--- a/constantine/arithmetic/assembly/limbs_asm_montred_x86_adx_bmi2.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_montred_x86_adx_bmi2.nim
@@ -35,7 +35,7 @@ static: doAssert UseASM_X86_64
 # Montgomery reduction
 # ------------------------------------------------------------
 
-macro montyRedx_gen[N: static int](
+macro montyRedc2xx_gen[N: static int](
        r_MR: var array[N, SecretWord],
        a_MR: array[N*2, SecretWord],
        M_MR: array[N, SecretWord],
@@ -191,4 +191,4 @@ func montRed_asm_adx_bmi2*[N: static int](
        canUseNoCarryMontyMul: static bool
       ) =
   ## Constant-time Montgomery reduction
-  montyRedx_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)
+  montyRedc2xx_gen(r, a, M, m0ninv, canUseNoCarryMontyMul)

--- a/constantine/arithmetic/assembly/limbs_asm_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_x86.nim
@@ -143,7 +143,7 @@ macro add_gen[N: static int](carry: var Carry, r: var Limbs[N], a, b: Limbs[N]):
 
   for i in 1 ..< N:
     ctx.mov t1, arrA[i]   # Prepare the next iteration
-    ctx.mov arrR[i-1], t0 # Save the previous reult in an interleaved manner
+    ctx.mov arrR[i-1], t0 # Save the previous result in an interleaved manner
     ctx.adc t1, arrB[i]   # Compute
     swap(t0, t1)          # Break dependency chain
 
@@ -210,7 +210,7 @@ macro sub_gen[N: static int](borrow: var Borrow, r: var Limbs[N], a, b: Limbs[N]
 
   ctx.mov arrR[N-1], t0   # Epilogue
   ctx.setToCarryFlag(borrow)
-  
+
   # Codegen
   result.add ctx.generate
 

--- a/constantine/arithmetic/assembly/limbs_asm_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_x86.nim
@@ -138,14 +138,16 @@ macro add_gen[N: static int](carry: var Carry, r: var Limbs[N], a, b: Limbs[N]):
     var `t0sym`{.noinit.}, `t1sym`{.noinit.}: BaseType
 
   # Algorithm
-  for i in 0 ..< N:
-    ctx.mov t0, arrA[i]
-    if i == 0:
-      ctx.add t0, arrB[0]
-    else:
-      ctx.adc t0, arrB[i]
-    ctx.mov arrR[i], t0
-    swap(t0, t1)
+  ctx.mov t0, arrA[0]     # Prologue
+  ctx.add t0, arrB[0]
+
+  for i in 1 ..< N:
+    ctx.mov t1, arrA[i]   # Prepare the next iteration
+    ctx.mov arrR[i-1], t0 # Save the previous reult in an interleaved manner
+    ctx.adc t1, arrB[i]   # Compute
+    swap(t0, t1)          # Break dependency chain
+
+  ctx.mov arrR[N-1], t0   # Epilogue
   ctx.setToCarryFlag(carry)
 
   # Codegen
@@ -197,16 +199,18 @@ macro sub_gen[N: static int](borrow: var Borrow, r: var Limbs[N], a, b: Limbs[N]
     var `t0sym`{.noinit.}, `t1sym`{.noinit.}: BaseType
 
   # Algorithm
-  for i in 0 ..< N:
-    ctx.mov t0, arrA[i]
-    if i == 0:
-      ctx.sub t0, arrB[0]
-    else:
-      ctx.sbb t0, arrB[i]
-    ctx.mov arrR[i], t0
-    swap(t0, t1)
-  ctx.setToCarryFlag(borrow)
+  ctx.mov t0, arrA[0]     # Prologue
+  ctx.sub t0, arrB[0]
 
+  for i in 1 ..< N:
+    ctx.mov t1, arrA[i]   # Prepare the next iteration
+    ctx.mov arrR[i-1], t0 # Save the previous reult in an interleaved manner
+    ctx.sbb t1, arrB[i]   # Compute
+    swap(t0, t1)          # Break dependency chain
+
+  ctx.mov arrR[N-1], t0   # Epilogue
+  ctx.setToCarryFlag(borrow)
+  
   # Codegen
   result.add ctx.generate
 

--- a/constantine/arithmetic/finite_fields.nim
+++ b/constantine/arithmetic/finite_fields.nim
@@ -169,7 +169,7 @@ func sum*(r: var FF, a, b: FF) {.meter.} =
     overflowed = overflowed or not(r.mres < FF.fieldMod())
     discard csub(r.mres, FF.fieldMod(), overflowed)
 
-func sumUnred*(r: var FF, a, b: FF) {.meter.} =
+func sumUnr*(r: var FF, a, b: FF) {.meter.} =
   ## Sum ``a`` and ``b`` into ``r`` without reduction
   discard r.mres.sum(a.mres, b.mres)
 
@@ -183,7 +183,7 @@ func diff*(r: var FF, a, b: FF) {.meter.} =
     var underflowed = r.mres.diff(a.mres, b.mres)
     discard cadd(r.mres, FF.fieldMod(), underflowed)
 
-func diffUnred*(r: var FF, a, b: FF) {.meter.} =
+func diffUnr*(r: var FF, a, b: FF) {.meter.} =
   ## Substract `b` from `a` and store the result into `r`
   ## without reduction
   discard r.mres.diff(a.mres, b.mres)

--- a/constantine/arithmetic/finite_fields.nim
+++ b/constantine/arithmetic/finite_fields.nim
@@ -169,7 +169,7 @@ func sum*(r: var FF, a, b: FF) {.meter.} =
     overflowed = overflowed or not(r.mres < FF.fieldMod())
     discard csub(r.mres, FF.fieldMod(), overflowed)
 
-func sumNoReduce*(r: var FF, a, b: FF) {.meter.} =
+func sumUnred*(r: var FF, a, b: FF) {.meter.} =
   ## Sum ``a`` and ``b`` into ``r`` without reduction
   discard r.mres.sum(a.mres, b.mres)
 
@@ -183,7 +183,7 @@ func diff*(r: var FF, a, b: FF) {.meter.} =
     var underflowed = r.mres.diff(a.mres, b.mres)
     discard cadd(r.mres, FF.fieldMod(), underflowed)
 
-func diffNoReduce*(r: var FF, a, b: FF) {.meter.} =
+func diffUnred*(r: var FF, a, b: FF) {.meter.} =
   ## Substract `b` from `a` and store the result into `r`
   ## without reduction
   discard r.mres.diff(a.mres, b.mres)

--- a/constantine/arithmetic/finite_fields.nim
+++ b/constantine/arithmetic/finite_fields.nim
@@ -389,59 +389,57 @@ func `*=`*(a: var FF, b: static int) =
   elif b == 2:
     a.double()
   elif b == 3:
-    let t1 = a
-    a.double()
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    a += t
   elif b == 4:
     a.double()
     a.double()
   elif b == 5:
-    let t1 = a
-    a.double()
-    a.double()
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    a += t
   elif b == 6:
-    a.double()
-    let t2 = a
-    a.double() # 4
-    a += t2
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a # 3
+    a.double(t)
   elif b == 7:
-    let t1 = a
-    a.double()
-    let t2 = a
-    a.double() # 4
-    a += t2
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    t.double()
+    a.diff(t, a)
   elif b == 8:
     a.double()
     a.double()
     a.double()
   elif b == 9:
-    let t1 = a
-    a.double()
-    a.double()
-    a.double() # 8
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    t.double()
+    a.sum(t, a)
   elif b == 10:
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    a += t     # 5
     a.double()
-    let t2 = a
-    a.double()
-    a.double() # 8
-    a += t2
   elif b == 11:
-    let t1 = a
-    a.double()
-    let t2 = a
-    a.double()
-    a.double() # 8
-    a += t2
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a       # 3
+    t.double()   # 6
+    t.double()   # 12
+    a.diff(t, a) # 11
   elif b == 12:
-    a.double()
-    a.double() # 4
-    let t4 = a
-    a.double() # 8
-    a += t4
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a       # 3
+    t.double()   # 6
+    a.double(t)   # 12
   else:
     {.error: "Multiplication by this small int not implemented".}
 

--- a/constantine/arithmetic/finite_fields.nim
+++ b/constantine/arithmetic/finite_fields.nim
@@ -56,7 +56,7 @@ func fromBig*(dst: var FF, src: BigInt) =
   when nimvm:
     dst.mres.montyResidue_precompute(src, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord())
   else:
-    dst.mres.montyResidue(src, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+    dst.mres.montyResidue(src, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func fromBig*[C: static Curve](T: type FF[C], src: BigInt): FF[C] {.noInit.} =
   ## Convert a BigInt to its Montgomery form
@@ -65,7 +65,7 @@ func fromBig*[C: static Curve](T: type FF[C], src: BigInt): FF[C] {.noInit.} =
 func toBig*(src: FF): auto {.noInit, inline.} =
   ## Convert a finite-field element to a BigInt in natural representation
   var r {.noInit.}: typeof(src.mres)
-  r.redc(src.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+  r.redc(src.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.getSpareBits())
   return r
 
 # Copy
@@ -201,11 +201,11 @@ func double*(r: var FF, a: FF) {.meter.} =
 func prod*(r: var FF, a, b: FF) {.meter.} =
   ## Store the product of ``a`` by ``b`` modulo p into ``r``
   ## ``r`` is initialized / overwritten
-  r.mres.montyMul(a.mres, b.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+  r.mres.montyMul(a.mres, b.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func square*(r: var FF, a: FF) {.meter.} =
   ## Squaring modulo p
-  r.mres.montySquare(a.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.canUseNoCarryMontySquare())
+  r.mres.montySquare(a.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func neg*(r: var FF, a: FF) {.meter.} =
   ## Negate modulo p
@@ -279,8 +279,7 @@ func pow*(a: var FF, exponent: BigInt) =
     exponent,
     FF.fieldMod(), FF.getMontyOne(),
     FF.getNegInvModWord(), windowSize,
-    FF.canUseNoCarryMontyMul(),
-    FF.canUseNoCarryMontySquare()
+    FF.getSpareBits()
   )
 
 func pow*(a: var FF, exponent: openarray[byte]) =
@@ -292,8 +291,7 @@ func pow*(a: var FF, exponent: openarray[byte]) =
     exponent,
     FF.fieldMod(), FF.getMontyOne(),
     FF.getNegInvModWord(), windowSize,
-    FF.canUseNoCarryMontyMul(),
-    FF.canUseNoCarryMontySquare()
+    FF.getSpareBits()
   )
 
 func powUnsafeExponent*(a: var FF, exponent: BigInt) =
@@ -312,8 +310,7 @@ func powUnsafeExponent*(a: var FF, exponent: BigInt) =
     exponent,
     FF.fieldMod(), FF.getMontyOne(),
     FF.getNegInvModWord(), windowSize,
-    FF.canUseNoCarryMontyMul(),
-    FF.canUseNoCarryMontySquare()
+    FF.getSpareBits()
   )
 
 func powUnsafeExponent*(a: var FF, exponent: openarray[byte]) =
@@ -332,8 +329,7 @@ func powUnsafeExponent*(a: var FF, exponent: openarray[byte]) =
     exponent,
     FF.fieldMod(), FF.getMontyOne(),
     FF.getNegInvModWord(), windowSize,
-    FF.canUseNoCarryMontyMul(),
-    FF.canUseNoCarryMontySquare()
+    FF.getSpareBits()
   )
 
 # ############################################################
@@ -350,7 +346,7 @@ func `*=`*(a: var FF, b: FF) {.meter.} =
 
 func square*(a: var FF) {.meter.} =
   ## Squaring modulo p
-  a.mres.montySquare(a.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.canUseNoCarryMontySquare())
+  a.mres.montySquare(a.mres, FF.fieldMod(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func square_repeated*(r: var FF, num: int) {.meter.} =
   ## Repeated squarings

--- a/constantine/arithmetic/finite_fields_double_precision.nim
+++ b/constantine/arithmetic/finite_fields_double_precision.nim
@@ -75,7 +75,7 @@ func redc2x*(r: var Fp, a: FpDbl) =
     a.limbs2x,
     Fp.C.Mod.limbs,
     Fp.getNegInvModWord(),
-    Fp.canUseNoCarryMontyMul()
+    Fp.getSpareBits()
   )
 
 func diff2xUnr*(r: var FpDbl, a, b: FpDbl) =

--- a/constantine/arithmetic/finite_fields_double_precision.nim
+++ b/constantine/arithmetic/finite_fields_double_precision.nim
@@ -142,8 +142,8 @@ func sum2xMod*(r: var FpDbl, a, b: FpDbl) =
 func neg2xMod*(r: var FpDbl, a: FpDbl) =
   ## Double-precision modular substraction
   ## Negate modulo 2ⁿp
-  when false: # TODO UseASM_X86_64:
-    {.error: "Implement assembly".}
+  when UseASM_X86_64:
+    negmod2x_asm(r.limbs2x, a.limbs2x, FpDbl.C.Mod.limbs)
   else:
     # If a = 0 we need r = 0 and not r = M
     # as comparison operator assume unicity

--- a/constantine/arithmetic/finite_fields_double_precision.nim
+++ b/constantine/arithmetic/finite_fields_double_precision.nim
@@ -65,7 +65,7 @@ func redc2x*(r: var Fp, a: FpDbl) =
     Fp.canUseNoCarryMontyMul()
   )
 
-func diff2xUnred*(r: var FpDbl, a, b: FpDbl) =
+func diff2xUnr*(r: var FpDbl, a, b: FpDbl) =
   ## Double-width substraction without reduction
   discard r.limbs2x.diff(a.limbs2x, b.limbs2x)
 
@@ -84,7 +84,7 @@ func diff2xMod*(r: var FpDbl, a, b: FpDbl) =
       addC(carry, sum, r.limbs2x[i+N], M.limbs[i], carry)
       underflowed.ccopy(r.limbs2x[i+N], sum)
 
-func sum2xUnred*(r: var FpDbl, a, b: FpDbl) =
+func sum2xUnr*(r: var FpDbl, a, b: FpDbl) =
   ## Double-width addition without reduction
   discard r.limbs2x.sum(a.limbs2x, b.limbs2x)
 

--- a/constantine/arithmetic/finite_fields_double_precision.nim
+++ b/constantine/arithmetic/finite_fields_double_precision.nim
@@ -16,16 +16,22 @@ import
   ./limbs_montgomery
 
 when UseASM_X86_64:
-  import assembly/limbs_asm_modular_dbl_width_x86
+  import assembly/limbs_asm_modular_dbl_prec_x86
 
 type FpDbl*[C: static Curve] = object
-  ## Double-width Fp element
-  ## This allows saving on reductions
-  # We directly work with double the number of limbs
+  ## Double-precision Fp element
+  ## A FpDbl is a partially-reduced double-precision element of Fp
+  ## The allowed range is [0, 2ⁿp)
+  ## with n = w*WordBitSize
+  ## and w the number of words necessary to represent p on the machine.
+  ## Concretely a 381-bit p needs 6*64 bits limbs (hence 384 bits total)
+  ## and so FpDbl would 768 bits.
+  # We directly work with double the number of limbs,
+  # instead of BigInt indirection.
   limbs2x*: matchingLimbs2x(C)
 
-template doubleWidth*(T: type Fp): type =
-  ## Return the double-width type matching with Fp
+template doublePrec*(T: type Fp): type =
+  ## Return the double-precision type matching with Fp
   FpDbl[T.C]
 
 # No exceptions allowed

--- a/constantine/arithmetic/finite_fields_double_precision.nim
+++ b/constantine/arithmetic/finite_fields_double_precision.nim
@@ -118,7 +118,7 @@ func sum2xMod*(r: var FpDbl, a, b: FpDbl) =
   ## Double-precision modular addition
   ## Output is conditionally reduced by 2ⁿp
   ## to stay in the [0, 2ⁿp) range
-  when false:
+  when UseASM_X86_64:
     addmod2x_asm(r.limbs2x, a.limbs2x, b.limbs2x, FpDbl.C.Mod.limbs)
   else:
     # Addition step

--- a/constantine/arithmetic/finite_fields_double_width.nim
+++ b/constantine/arithmetic/finite_fields_double_width.nim
@@ -35,18 +35,20 @@ template doubleWidth*(T: typedesc[Fp]): typedesc =
 func `==`*(a, b: FpDbl): SecretBool =
   a.limbs2x == b.limbs2x
 
-func mulNoReduce*(r: var FpDbl, a, b: Fp) =
+func prod2x*(r: var FpDbl, a, b: Fp) =
+  ## Double-precision multiplication
   ## Store the product of ``a`` by ``b`` into ``r``
   r.limbs2x.prod(a.mres.limbs, b.mres.limbs)
 
-func squareNoReduce*(r: var FpDbl, a: Fp) =
+func square2x*(r: var FpDbl, a: Fp) =
+  ## Double-precision squaring
   ## Store the square of ``a`` into ``r``
   r.limbs2x.square(a.mres.limbs)
 
-func reduce*(r: var Fp, a: FpDbl) =
-  ## Reduce a double-width field element into r
+func redc2x*(r: var Fp, a: FpDbl) =
+  ## Reduce a double-precision field element into r
   const N = r.mres.limbs.len
-  montyRed(
+  montyRedc2x(
     r.mres.limbs,
     a.limbs2x,
     Fp.C.Mod.limbs,
@@ -54,11 +56,11 @@ func reduce*(r: var Fp, a: FpDbl) =
     Fp.canUseNoCarryMontyMul()
   )
 
-func diffNoReduce*(r: var FpDbl, a, b: FpDbl) =
+func diff2xUnred*(r: var FpDbl, a, b: FpDbl) =
   ## Double-width substraction without reduction
   discard r.limbs2x.diff(a.limbs2x, b.limbs2x)
 
-func diff*(r: var FpDbl, a, b: FpDbl) =
+func diff2xMod*(r: var FpDbl, a, b: FpDbl) =
   ## Double-width modular substraction
   when UseASM_X86_64:
     sub2x_asm(r.limbs2x, a.limbs2x, b.limbs2x, FpDbl.C.Mod.limbs)
@@ -72,10 +74,6 @@ func diff*(r: var FpDbl, a, b: FpDbl) =
     for i in 0 ..< N:
       addC(carry, sum, r.limbs2x[i+N], M.limbs[i], carry)
       underflowed.ccopy(r.limbs2x[i+N], sum)
-
-func `-=`*(a: var FpDbl, b: FpDbl) =
-  ## Double-width modular substraction
-  a.diff(a, b)
 
 {.pop.} # inline
 {.pop.} # raises no exceptions

--- a/constantine/arithmetic/limbs_extmul.nim
+++ b/constantine/arithmetic/limbs_extmul.nim
@@ -72,7 +72,8 @@ func prod*[rLen, aLen, bLen: static int](r: var Limbs[rLen], a: Limbs[aLen], b: 
   ## `r` must not alias ``a`` or ``b``
 
   when UseASM_X86_64 and aLen <= 6:
-    if ({.noSideEffect.}: hasBmi2()) and ({.noSideEffect.}: hasAdx()):
+    # ADX implies BMI2
+    if ({.noSideEffect.}: hasAdx()):
       mul_asm_adx_bmi2(r, a, b)
     else:
       mul_asm(r, a, b)

--- a/constantine/arithmetic/limbs_montgomery.nim
+++ b/constantine/arithmetic/limbs_montgomery.nim
@@ -286,7 +286,7 @@ func montyRedc2x_CIOS[N: static int](
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType) =
-  ## Montgomery reduce a double-width bigint modulo M
+  ## Montgomery reduce a double-precision bigint modulo M
   # - Analyzing and Comparing Montgomery Multiplication Algorithms
   #   Cetin Kaya Koc and Tolga Acar and Burton S. Kaliski Jr.
   #   http://pdfs.semanticscholar.org/5e39/41ff482ec3ee41dc53c3298f0be085c69483.pdf
@@ -299,7 +299,7 @@ func montyRedc2x_CIOS[N: static int](
   # Algorithm
   # Inputs:
   # - N number of limbs
-  # - a[0 ..< 2N] (double-width input to reduce)
+  # - a[0 ..< 2N] (double-precision input to reduce)
   # - M[0 ..< N] The field modulus (must be odd for Montgomery reduction)
   # - m0ninv: Montgomery Reduction magic number = -1/M[0]
   # Output:
@@ -348,7 +348,7 @@ func montyRedc2x_Comba[N: static int](
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType) =
-  ## Montgomery reduce a double-width bigint modulo M
+  ## Montgomery reduce a double-precision bigint modulo M
   # We use Product Scanning / Comba multiplication
   var t, u, v = Zero
   var carry: Carry
@@ -464,7 +464,7 @@ func montyRedc2x*[N: static int](
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType, canUseNoCarryMontyMul: static bool) {.inline.} =
-  ## Montgomery reduce a double-width bigint modulo M
+  ## Montgomery reduce a double-precision bigint modulo M
   when UseASM_X86_64 and r.len <= 6:
     if ({.noSideEffect.}: hasBmi2()) and ({.noSideEffect.}: hasAdx()):
       montRed_asm_adx_bmi2(r, a, M, m0ninv, canUseNoCarryMontyMul)

--- a/constantine/arithmetic/limbs_montgomery.nim
+++ b/constantine/arithmetic/limbs_montgomery.nim
@@ -421,7 +421,8 @@ func montyMul*(
   # - keep it generic and optimize code size
   when spareBits >= 1:
     when UseASM_X86_64 and a.len in {2 .. 6}: # TODO: handle spilling
-      if ({.noSideEffect.}: hasBmi2()) and ({.noSideEffect.}: hasAdx()):
+      # ADX implies BMI2
+      if ({.noSideEffect.}: hasAdx()):
         montMul_CIOS_nocarry_asm_adx_bmi2(r, a, b, M, m0ninv)
       else:
         montMul_CIOS_nocarry_asm(r, a, b, M, m0ninv)
@@ -466,7 +467,8 @@ func montyRedc2x*[N: static int](
        m0ninv: BaseType, spareBits: static int) {.inline.} =
   ## Montgomery reduce a double-precision bigint modulo M
   when UseASM_X86_64 and r.len <= 6:
-    if ({.noSideEffect.}: hasBmi2()) and ({.noSideEffect.}: hasAdx()):
+    # ADX implies BMI2
+    if ({.noSideEffect.}: hasAdx()):
       montRed_asm_adx_bmi2(r, a, M, m0ninv, spareBits)
     else:
       montRed_asm(r, a, M, m0ninv, spareBits)

--- a/constantine/arithmetic/limbs_montgomery.nim
+++ b/constantine/arithmetic/limbs_montgomery.nim
@@ -281,7 +281,7 @@ func montySquare_CIOS(r: var Limbs, a, M: Limbs, m0ninv: BaseType) {.used.}=
 
 # Montgomery Reduction
 # ------------------------------------------------------------
-func montyRed_CIOS[N: static int](
+func montyRedc2x_CIOS[N: static int](
        r: var array[N, SecretWord],
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
@@ -343,7 +343,7 @@ func montyRed_CIOS[N: static int](
   discard res.csub(M, SecretWord(carry).isNonZero() or not(res < M))
   r = res
 
-func montyRed_Comba[N: static int](
+func montyRedc2x_Comba[N: static int](
        r: var array[N, SecretWord],
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
@@ -459,7 +459,7 @@ func montySquare*(r: var Limbs, a, M: Limbs,
   #   montyMul_FIPS(r, a, a, M, m0ninv)
 
 # TODO upstream, using Limbs[N] breaks semcheck
-func montyRed*[N: static int](
+func montyRedc2x*[N: static int](
        r: var array[N, SecretWord],
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
@@ -474,8 +474,8 @@ func montyRed*[N: static int](
     # TODO: Assembly faster than GCC but slower than Clang
     montRed_asm(r, a, M, m0ninv, canUseNoCarryMontyMul)
   else:
-    montyRed_CIOS(r, a, M, m0ninv)
-    # montyRed_Comba(r, a, M, m0ninv)
+    montyRedc2x_CIOS(r, a, M, m0ninv)
+    # montyRedc2x_Comba(r, a, M, m0ninv)
 
 func redc*(r: var Limbs, a, one, M: Limbs,
            m0ninv: static BaseType, canUseNoCarryMontyMul: static bool) =

--- a/constantine/config/curves_derived.nim
+++ b/constantine/config/curves_derived.nim
@@ -51,18 +51,10 @@ macro genDerivedConstants*(mode: static DerivedConstantMode): untyped =
     let M = if mode == kModulus: bindSym(curve & "_Modulus")
             else: bindSym(curve & "_Order")
 
-    # const MyCurve_CanUseNoCarryMontyMul = useNoCarryMontyMul(MyCurve_Modulus)
+    # const MyCurve_SpareBits = countSpareBits(MyCurve_Modulus)
     result.add newConstStmt(
-      used(curve & ff & "_CanUseNoCarryMontyMul"), newCall(
-        bindSym"useNoCarryMontyMul",
-        M
-      )
-    )
-
-    # const MyCurve_CanUseNoCarryMontySquare = useNoCarryMontySquare(MyCurve_Modulus)
-    result.add newConstStmt(
-      used(curve & ff & "_CanUseNoCarryMontySquare"), newCall(
-        bindSym"useNoCarryMontySquare",
+      used(curve & ff & "_SpareBits"), newCall(
+        bindSym"countSpareBits",
         M
       )
     )

--- a/constantine/config/curves_prop_derived.nim
+++ b/constantine/config/curves_prop_derived.nim
@@ -61,15 +61,18 @@ template fieldMod*(Field: type FF): auto =
   else:
     Field.C.getCurveOrder()
 
-macro canUseNoCarryMontyMul*(ff: type FF): untyped =
-  ## Returns true if the Modulus is compatible with a fast
-  ## Montgomery multiplication that avoids many carries
-  result = bindConstant(ff, "CanUseNoCarryMontyMul")
-
-macro canUseNoCarryMontySquare*(ff: type FF): untyped =
-  ## Returns true if the Modulus is compatible with a fast
-  ## Montgomery squaring that avoids many carries
-  result = bindConstant(ff, "CanUseNoCarryMontySquare")
+macro getSpareBits*(ff: type FF): untyped =
+  ## Returns the number of extra bits
+  ## in the modulus M representation.
+  ##
+  ## This is used for no-carry operations
+  ## or lazily reduced operations by allowing
+  ## output in range:
+  ## - [0, 2p) if 1 bit is available
+  ## - [0, 4p) if 2 bits are available
+  ## - [0, 8p) if 3 bits are available
+  ## - ...
+  result = bindConstant(ff, "SpareBits")
 
 macro getR2modP*(ff: type FF): untyped =
   ## Get the Montgomery "R^2 mod P" constant associated to a curve field modulus

--- a/constantine/config/precompute.nim
+++ b/constantine/config/precompute.nim
@@ -238,21 +238,20 @@ func checkValidModulus(M: BigInt) =
 
   doAssert msb == expectedMsb, "Internal Error: the modulus must use all declared bits and only those"
 
-func useNoCarryMontyMul*(M: BigInt): bool =
-  ## Returns if the modulus is compatible
-  ## with the no-carry Montgomery Multiplication
-  ## from https://hackmd.io/@zkteam/modular_multiplication
-  # Indirection needed because static object are buggy
-  # https://github.com/nim-lang/Nim/issues/9679
-  BaseType(M.limbs[^1]) < high(BaseType) shr 1
-
-func useNoCarryMontySquare*(M: BigInt): bool =
-  ## Returns if the modulus is compatible
-  ## with the no-carry Montgomery Squaring
-  ## from https://hackmd.io/@zkteam/modular_multiplication
-  # Indirection needed because static object are buggy
-  # https://github.com/nim-lang/Nim/issues/9679
-  BaseType(M.limbs[^1]) < high(BaseType) shr 2
+func countSpareBits*(M: BigInt): int =
+  ## Count the number of extra bits
+  ## in the modulus M representation.
+  ##
+  ## This is used for no-carry operations
+  ## or lazily reduced operations by allowing
+  ## output in range:
+  ## - [0, 2p) if 1 bit is available
+  ## - [0, 4p) if 2 bits are available
+  ## - [0, 8p) if 3 bits are available
+  ## - ...
+  checkValidModulus(M)
+  let msb = log2(BaseType(M.limbs[^1]))
+  result = WordBitWidth - 1 - msb.int
 
 func invModBitwidth[T: SomeUnsignedInt](a: T): T =
   # We use BaseType for return value because static distinct type

--- a/constantine/tower_field_extensions/README.md
+++ b/constantine/tower_field_extensions/README.md
@@ -87,6 +87,16 @@ From Ben Edgington, https://hackmd.io/@benjaminion/bls12-381
   Jean-Luc Beuchat and Jorge Enrique González Díaz and Shigeo Mitsunari and Eiji Okamoto and Francisco Rodríguez-Henríquez and Tadanori Teruya, 2010\
   https://eprint.iacr.org/2010/354
 
+- Faster Explicit Formulas for Computing Pairings over Ordinary Curves\
+  Diego F. Aranha and Koray Karabina and Patrick Longa and Catherine H. Gebotys and Julio López, 2010\
+  https://eprint.iacr.org/2010/526.pdf\
+  https://www.iacr.org/archive/eurocrypt2011/66320047/66320047.pdf
+
+- Efficient Implementation of Bilinear Pairings on ARM Processors
+  Gurleen Grewal, Reza Azarderakhsh,
+  Patrick Longa, Shi Hu, and David Jao, 2012
+  https://eprint.iacr.org/2012/408.pdf
+
 - Choosing and generating parameters for low level pairing implementation on BN curves\
   Sylvain Duquesne and Nadia El Mrabet and Safia Haloui and Franck Rondepierre, 2015\
   https://eprint.iacr.org/2015/1212

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -333,11 +333,11 @@ template doublePrec(T: type ExtensionField): type =
 
 func has1extraBit(E: type ExtensionField): bool =
   ## We construct extensions only on Fp (and not Fr)
-  canUseNoCarryMontyMul(Fp[E.C])
+  getSpareBits(Fp[E.C]) >= 1
 
 func has2extraBits(E: type ExtensionField): bool =
   ## We construct extensions only on Fp (and not Fr)
-  canUseNoCarryMontySquare(Fp[E.C])
+  getSpareBits(Fp[E.C]) >= 2
 
 template C(E: type ExtensionField2x): Curve =
   E.F.C

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -832,7 +832,7 @@ func square_generic(r: var QuadraticExt, a: QuadraticExt) =
     v1.square(a.c1)
 
     # Aliasing: a unneeded now
-    r.c1.diff(a.c0, a.c1)
+    r.c1.sum(a.c0, a.c1)
 
     # r0 = c0² + β c1²
     r.c0.prod(v1, NonResidue)
@@ -842,7 +842,7 @@ func square_generic(r: var QuadraticExt, a: QuadraticExt) =
     r.c1.square()
     r.c1 -= v0
     r.c1 -= v1
-    
+
   else:
     mixin prod
     var v0 {.noInit.}, v1 {.noInit.}: typeof(r.c0)

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -410,25 +410,25 @@ func prod_complex(r: var QuadraticExt, a, b: QuadraticExt) =
     var d {.noInit.}: doubleWidth(typeof(r.c0))
     const msbSet = r.c0.typeof.canUseNoCarryMontyMul()
 
-    a0b0.mulNoReduce(a.c0, b.c0)     # 44 cycles - cumul 44
-    a1b1.mulNoReduce(a.c1, b.c1)     # 44 cycles - cumul 88
+    a0b0.prod2x(a.c0, b.c0)      # 44 cycles - cumul 44
+    a1b1.prod2x(a.c1, b.c1)      # 44 cycles - cumul 88
     when msbSet:
       r.c0.sum(a.c0, a.c1)
       r.c1.sum(b.c0, b.c1)
     else:
-      r.c0.sumNoReduce(a.c0, a.c1)   # 5 cycles  - cumul 93
-      r.c1.sumNoReduce(b.c0, b.c1)   # 5 cycles  - cumul 98
+      r.c0.sumUnred(a.c0, a.c1) # 5 cycles  - cumul 93
+      r.c1.sumUnred(b.c0, b.c1) # 5 cycles  - cumul 98
     # aliasing: a and b unneeded now
-    d.mulNoReduce(r.c0, r.c1)        # 44 cycles - cumul 142
+    d.prod2x(r.c0, r.c1)         # 44 cycles - cumul 142
     when msbSet:
-      d -= a0b0
-      d -= a1b1
+      d.diff2xMod(d, a0b0)
+      d.diff2xMod(d, a1b1)
     else:
-      d.diffNoReduce(d, a0b0)        # 11 cycles - cumul 153
-      d.diffNoReduce(d, a1b1)        # 11 cycles - cumul 164
-    a0b0.diff(a0b0, a1b1)            # 19 cycles - cumul 183
-    r.c0.reduce(a0b0)                # 50 cycles - cumul 233
-    r.c1.reduce(d)                   # 50 cycles - cumul 288
+      d.diff2xUnred(d, a0b0)    # 11 cycles - cumul 153
+      d.diff2xUnred(d, a1b1)    # 11 cycles - cumul 164
+    a0b0.diff2xMod(a0b0, a1b1)  # 19 cycles - cumul 183
+    r.c0.redc2x(a0b0)           # 50 cycles - cumul 233
+    r.c1.redc2x(d)              # 50 cycles - cumul 288
 
   # Single-width [3 Mul, 2 Add, 3 Sub]
   #    3*88 + 2*14 + 3*14 = 334 theoretical cycles

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -319,17 +319,17 @@ type
 
   ExtensionField2x[F] = QuadraticExt2x[F] or CubicExt2x[F]
 
-template doubleWidth(T: type ExtensionField): type =
+template doublePrec(T: type ExtensionField): type =
   # For now naive unrolling, recursive template don't match
   # and I don't want to deal with types in macros
   when T is QuadraticExt:
     when T.F is QuadraticExt: # Fp4Dbl
-      QuadraticExt2x[QuadraticExt2x[doubleWidth(T.F.F)]]
+      QuadraticExt2x[QuadraticExt2x[doublePrec(T.F.F)]]
     elif T.F is Fp:           # Fp2Dbl
-      QuadraticExt2x[doubleWidth(T.F)]
+      QuadraticExt2x[doublePrec(T.F)]
   elif T is CubicExt:
     when T.F is QuadraticExt: # Fp6Dbl
-      CubicExt2x[QuadraticExt2x[doubleWidth(T.F.F)]]
+      CubicExt2x[QuadraticExt2x[doublePrec(T.F.F)]]
 
 func has1extraBit(E: type ExtensionField): bool =
   ## We construct extensions only on Fp (and not Fr)
@@ -603,7 +603,7 @@ func prod2x_disjoint[Fdbl, F](
        a: QuadraticExt[F],
        b0, b1: F) =
   ## Return a * (b0, b1) in r
-  static: doAssert Fdbl is doubleWidth(F)
+  static: doAssert Fdbl is doublePrec(F)
 
   var V0 {.noInit.}, V1 {.noInit.}: typeof(r.c0) # Double-width
   var t0 {.noInit.}, t1 {.noInit.}: typeof(a.c0) # Single-width
@@ -1011,7 +1011,7 @@ func square*(r: var QuadraticExt, a: QuadraticExt) =
     when true:
       r.square_complex(a)
     else: # slower
-      var d {.noInit.}: doubleWidth(typeof(r))
+      var d {.noInit.}: doublePrec(typeof(r))
       d.square2x_complex(a)
       r.c0.redc2x(d.c0)
       r.c1.redc2x(d.c1)
@@ -1025,7 +1025,7 @@ func square*(r: var QuadraticExt, a: QuadraticExt) =
       # TODO:
       # - On Fp4, we can have a.c0.c0 off by p
       #   a reduction is missing
-      var d {.noInit.}: doubleWidth(typeof(r))
+      var d {.noInit.}: doublePrec(typeof(r))
       d.square2x_disjoint(a.c0, a.c1)
       r.c0.redc2x(d.c0)
       r.c1.redc2x(d.c1)
@@ -1036,7 +1036,7 @@ func prod*(r: var QuadraticExt, a, b: QuadraticExt) =
     when false:
       r.prod_complex(a, b)
     else: # faster
-      var d {.noInit.}: doubleWidth(typeof(r))
+      var d {.noInit.}: doublePrec(typeof(r))
       d.prod2x_complex(a, b)
       r.c0.redc2x(d.c0)
       r.c1.redc2x(d.c1)
@@ -1044,7 +1044,7 @@ func prod*(r: var QuadraticExt, a, b: QuadraticExt) =
     when true: # typeof(r.c0) is Fp:
       r.prod_generic(a, b)
     else: # Deactivated r.c0 is correct modulo p but >= p
-      var d {.noInit.}: doubleWidth(typeof(r))
+      var d {.noInit.}: doublePrec(typeof(r))
       d.prod2x_disjoint(a, b.c0, b.c1)
       r.c0.redc2x(d.c0)
       r.c1.redc2x(d.c1)

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -373,22 +373,22 @@ func sumUnr(r: var ExtensionField, a, b: ExtensionField) =
     r.coords[i].sumUnr(a.coords[i], b.coords[i])
 
 func diff2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
-  ## Double-width substraction without reduction
+  ## Double-precision substraction without reduction
   staticFor i, 0, a.coords.len:
     r.coords[i].diff2xUnr(a.coords[i], b.coords[i])
 
 func diff2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
-  ## Double-width modular substraction
+  ## Double-precision modular substraction
   staticFor i, 0, a.coords.len:
     r.coords[i].diff2xMod(a.coords[i], b.coords[i])
 
 func sum2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
-  ## Double-width addition without reduction
+  ## Double-precision addition without reduction
   staticFor i, 0, a.coords.len:
     r.coords[i].sum2xUnr(a.coords[i], b.coords[i])
 
 func sum2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
-  ## Double-width modular addition
+  ## Double-precision modular addition
   staticFor i, 0, a.coords.len:
     r.coords[i].sum2xMod(a.coords[i], b.coords[i])
 
@@ -520,7 +520,7 @@ func prod2x[C: static Curve](
 # ----------------------------------------------------------------------
 
 func prod2x_complex(r: var QuadraticExt2x, a, b: QuadraticExt) =
-  ## Double-width unreduced complex multiplication
+  ## Double-precision unreduced complex multiplication
   # r and a or b cannot alias
 
   mixin fromComplexExtension
@@ -547,7 +547,7 @@ func prod2x_complex(r: var QuadraticExt2x, a, b: QuadraticExt) =
   r.c0.diff2xMod(r.c0, D)        # r0 = a0 b0 - a1 b1
 
 func square2x_complex(r: var QuadraticExt2x, a: QuadraticExt) =
-  ## Double-width unreduced complex squaring
+  ## Double-precision unreduced complex squaring
 
   mixin fromComplexExtension
   static: doAssert a.fromComplexExtension()
@@ -605,7 +605,7 @@ func prod2x_disjoint[Fdbl, F](
   ## Return a * (b0, b1) in r
   static: doAssert Fdbl is doublePrec(F)
 
-  var V0 {.noInit.}, V1 {.noInit.}: typeof(r.c0) # Double-width
+  var V0 {.noInit.}, V1 {.noInit.}: typeof(r.c0) # Double-precision
   var t0 {.noInit.}, t1 {.noInit.}: typeof(a.c0) # Single-width
 
   # Require 2 extra bits
@@ -630,7 +630,7 @@ func square2x_disjoint[Fdbl, F](
        r: var QuadraticExt2x[FDbl],
        a0, a1: F) =
   ## Return (a0, a1)² in r
-  var V0 {.noInit.}, V1 {.noInit.}: typeof(r.c0) # Double-width
+  var V0 {.noInit.}, V1 {.noInit.}: typeof(r.c0) # Double-precision
   var t {.noInit.}: F # Single-width
 
   # TODO: which is the best formulation? 3 squarings or 2 Mul?

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -346,10 +346,10 @@ func redc2x(r: var ExtensionField, a: ExtensionField2x) =
 # Multiplication by a small integer known at compile-time
 # -------------------------------------------------------------------
 
-func prod(r: var ExtensionField2x, a: ExtensionField2x, b: static int) =
+func prod2x(r: var ExtensionField2x, a: ExtensionField2x, b: static int) =
   ## Multiplication by a small integer known at compile-time
   for i in 0 ..< a.coords.len:
-    a *= b
+    r.coords[i].prod2x(a.coords[i], b)
 
 # NonResidue
 # ----------------------------------------------------------------------
@@ -739,7 +739,6 @@ func square_generic(r: var QuadraticExt, a: QuadraticExt) =
     r.c1 -= v1
 
   else:
-    mixin prod
     var v0 {.noInit.}, v1 {.noInit.}: typeof(r.c0)
 
     # v1 <- (c0 + β c1)
@@ -771,7 +770,6 @@ func prod_generic(r: var QuadraticExt, a, b: QuadraticExt) =
   #
   # r0 = a0 b0 + β a1 b1
   # r1 = (a0 + a1) (b0 + b1) - a0 b0 - a1 b1 (Karatsuba)
-  mixin prod
   var v0 {.noInit.}, v1 {.noInit.}, v2 {.noInit.}: typeof(r.c0)
 
   # v2 <- (a0 + a1)(b0 + b1)
@@ -806,7 +804,6 @@ func mul_sparse_generic_by_x0(r: var QuadraticExt, a, sparseB: QuadraticExt) =
   #
   # r0 = a0 b0
   # r1 = (a0 + a1) b0 - a0 b0 = a1 b0
-  mixin prod
   template b(): untyped = sparseB
 
   r.c0.prod(a.c0, b.c0)
@@ -1038,7 +1035,6 @@ func mul_sparse_by_x0*(a: var QuadraticExt, sparseB: QuadraticExt) =
 
 func square_Chung_Hasan_SQR2(r: var CubicExt, a: CubicExt) {.used.}=
   ## Returns r = a²
-  mixin prod, square, sum
   var s0{.noInit.}, m01{.noInit.}, m12{.noInit.}: typeof(r.c0)
 
   # precomputations that use a
@@ -1074,7 +1070,6 @@ func square_Chung_Hasan_SQR2(r: var CubicExt, a: CubicExt) {.used.}=
 
 func square_Chung_Hasan_SQR3(r: var CubicExt, a: CubicExt) =
   ## Returns r = a²
-  mixin prod, square, sum
   var s0{.noInit.}, t{.noInit.}, m12{.noInit.}: typeof(r.c0)
 
   # s₀ = (a₀ + a₁ + a₂)²

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -494,12 +494,20 @@ func prod2x_disjoint[Fdbl, F](
   # Require 2 extra bits
   V0.prod2x(a.c0, b0)           # v0 = a0b0
   V1.prod2x(a.c1, b1)           # v1 = a1b1
-  t0.sum(a.c0, a.c1)
-  t1.sum(b0, b1)
+  when F.has1extraBit():
+    t0.sumUnr(a.c0, a.c1)
+    t1.sumUnr(b0, b1)
+  else:
+    t0.sum(a.c0, a.c1)
+    t1.sum(b0, b1)
 
   r.c1.prod2x(t0, t1)           # r1 = (a0 + a1)(b0 + b1)
-  r.c1.diff2xMod(r.c1, V0)      # r1 = (a0 + a1)(b0 + b1) - a0b0
-  r.c1.diff2xMod(r.c1, V1)      # r1 = (a0 + a1)(b0 + b1) - a0b0 - a1b1
+  when F.has1extraBit():
+    r.c1.diff2xMod(r.c1, V0)
+    r.c1.diff2xMod(r.c1, V1)
+  else:
+    r.c1.diff2xMod(r.c1, V0)      # r1 = (a0 + a1)(b0 + b1) - a0b0
+    r.c1.diff2xMod(r.c1, V1)      # r1 = (a0 + a1)(b0 + b1) - a0b0 - a1b1
 
   r.c0.prod2x(V1, NonResidue)   # r0 = β a1 b1
   r.c0.sum2xMod(r.c0, V0)       # r0 = a0 b0 + β a1 b1

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -235,59 +235,57 @@ func `*=`*(a: var ExtensionField, b: static int) =
   elif b == 2:
     a.double()
   elif b == 3:
-    let t1 = a
-    a.double()
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    a += t
   elif b == 4:
     a.double()
     a.double()
   elif b == 5:
-    let t1 = a
-    a.double()
-    a.double()
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    a += t
   elif b == 6:
-    a.double()
-    let t2 = a
-    a.double() # 4
-    a += t2
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a # 3
+    a.double(t)
   elif b == 7:
-    let t1 = a
-    a.double()
-    let t2 = a
-    a.double() # 4
-    a += t2
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    t.double()
+    a.diff(t, a)
   elif b == 8:
     a.double()
     a.double()
     a.double()
   elif b == 9:
-    let t1 = a
-    a.double()
-    a.double()
-    a.double() # 8
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    t.double()
+    a.sum(t, a)
   elif b == 10:
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()
+    a += t     # 5
     a.double()
-    let t2 = a
-    a.double()
-    a.double() # 8
-    a += t2
   elif b == 11:
-    let t1 = a
-    a.double()
-    let t2 = a
-    a.double()
-    a.double() # 8
-    a += t2
-    a += t1
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a       # 3
+    t.double()   # 6
+    t.double()   # 12
+    a.diff(t, a) # 11
   elif b == 12:
-    a.double()
-    a.double() # 4
-    let t4 = a
-    a.double() # 8
-    a += t4
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a       # 3
+    t.double()   # 6
+    a.double(t)   # 12
   else:
     {.error: "Multiplication by this small int not implemented".}
 

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -367,25 +367,25 @@ func setZero*(a: var ExtensionField2x) =
 # Abelian group
 # -------------------------------------------------------------------
 
-func sumUnred(r: var ExtensionField, a, b: ExtensionField) =
+func sumUnr(r: var ExtensionField, a, b: ExtensionField) =
   ## Sum ``a`` and ``b`` into ``r``
   staticFor i, 0, a.coords.len:
-    r.coords[i].sumUnred(a.coords[i], b.coords[i])
+    r.coords[i].sumUnr(a.coords[i], b.coords[i])
 
-func diff2xUnred(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func diff2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-width substraction without reduction
   staticFor i, 0, a.coords.len:
-    r.coords[i].diff2xUnred(a.coords[i], b.coords[i])
+    r.coords[i].diff2xUnr(a.coords[i], b.coords[i])
 
 func diff2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-width modular substraction
   staticFor i, 0, a.coords.len:
     r.coords[i].diff2xMod(a.coords[i], b.coords[i])
 
-func sum2xUnred(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func sum2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-width addition without reduction
   staticFor i, 0, a.coords.len:
-    r.coords[i].sum2xUnred(a.coords[i], b.coords[i])
+    r.coords[i].sum2xUnr(a.coords[i], b.coords[i])
 
 func sum2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-width modular addition
@@ -532,15 +532,15 @@ func prod2x_complex(r: var QuadraticExt2x, a, b: QuadraticExt) =
   r.c0.prod2x(a.c0, b.c0)        # r0 = a0 b0
   D.prod2x(a.c1, b.c1)           # d =  a1 b1
   when QuadraticExt.has1extraBit():
-    t0.sumUnred(a.c0, a.c1)
-    t1.sumUnred(b.c0, b.c1)
+    t0.sumUnr(a.c0, a.c1)
+    t1.sumUnr(b.c0, b.c1)
   else:
     t0.sum(a.c0, a.c1)
     t1.sum(b.c0, b.c1)
   r.c1.prod2x(t0, t1)            # r1 = (b0 + b1)(a0 + a1)
   when QuadraticExt.has1extraBit():
-    r.c1.diff2xUnred(r.c1, r.c0) # r1 = (b0 + b1)(a0 + a1) - a0 b0
-    r.c1.diff2xUnred(r.c1, D)    # r1 = (b0 + b1)(a0 + a1) - a0 b0 - a1b1
+    r.c1.diff2xUnr(r.c1, r.c0) # r1 = (b0 + b1)(a0 + a1) - a0 b0
+    r.c1.diff2xUnr(r.c1, D)    # r1 = (b0 + b1)(a0 + a1) - a0 b0 - a1b1
   else:
     r.c1.diff2xMod(r.c1, r.c0)
     r.c1.diff2xMod(r.c1, D)
@@ -556,7 +556,7 @@ func square2x_complex(r: var QuadraticExt2x, a: QuadraticExt) =
 
   # Require 2 extra bits
   when QuadraticExt.has2extraBits():
-    t0.sumUnred(a.c1, a.c1)
+    t0.sumUnr(a.c1, a.c1)
     t1.sum(a.c0, a.c1)
   else:
     t0.double(a.c1)
@@ -612,8 +612,8 @@ func prod2x_disjoint[Fdbl, F](
   V0.prod2x(a.c0, b0)
   V1.prod2x(a.c1, b1)
   when F.has2extraBits():
-    t0.sumUnred(b0, b1)
-    t1.sumUnred(a.c0, a.c1)
+    t0.sumUnr(b0, b1)
+    t1.sumUnr(a.c0, a.c1)
   else:
     t0.sum(b0, b1)
     t1.sum(a.c0, a.c1)

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -26,10 +26,10 @@ The optimizations can be of algebraic, algorithmic or "implementation details" n
   - [x] x86: MULX, ADCX, ADOX instructions
   - [x] Fused Multiply + Shift-right by word (for Barrett Reduction and approximating multiplication by fractional constant)
 - Squaring
-  - [ ] Dedicated squaring functions
-  - [ ] int128
+  - [x] Dedicated squaring functions
+  - [x] int128
   - [ ] loop unrolling
-  - [ ] x86: Full Assembly implementation
+  - [x] x86: Full Assembly implementation
   - [ ] x86: MULX, ADCX, ADOX instructions
 
 ## Finite Fields & Modular Arithmetic
@@ -107,7 +107,7 @@ The optimizations can be of algebraic, algorithmic or "implementation details" n
 
 ## Extension Fields
 
-- [ ] Lazy reduction via double-precision base fields
+- [x] Lazy reduction via double-precision base fields
 - [x] Sparse multiplication
 - Fp2
   - [x] complex multiplication

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -107,13 +107,13 @@ The optimizations can be of algebraic, algorithmic or "implementation details" n
 
 ## Extension Fields
 
-- [ ] Lazy reduction via double-width base fields
+- [ ] Lazy reduction via double-precision base fields
 - [x] Sparse multiplication
 - Fp2
   - [x] complex multiplication
   - [x] complex squaring
   - [x] sqrt via the constant-time complex method (Adj et al)
-  - [ ] sqrt using addition chain
+  - [x] sqrt using addition chain
   - [x] fused complex method sqrt by rotating in complex plane
 - Cubic extension fields
   - [x] Toom-Cook polynomial multiplication (Chung-Hasan)

--- a/helpers/prng_unsafe.nim
+++ b/helpers/prng_unsafe.nim
@@ -146,7 +146,7 @@ func random_unsafe(rng: var RngState, a: var FF) =
 
   # Note: a simple modulo will be biaised but it's simple and "fast"
   reduced.reduce(unreduced, FF.fieldMod())
-  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func random_unsafe(rng: var RngState, a: var ExtensionField) =
   ## Recursively initialize an extension Field element
@@ -177,7 +177,7 @@ func random_highHammingWeight(rng: var RngState, a: var FF) =
 
   # Note: a simple modulo will be biaised but it's simple and "fast"
   reduced.reduce(unreduced, FF.fieldMod())
-  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func random_highHammingWeight(rng: var RngState, a: var ExtensionField) =
   ## Recursively initialize an extension Field element
@@ -222,7 +222,7 @@ func random_long01Seq(rng: var RngState, a: var FF) =
 
   # Note: a simple modulo will be biaised but it's simple and "fast"
   reduced.reduce(unreduced, FF.fieldMod())
-  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.canUseNoCarryMontyMul())
+  a.mres.montyResidue(reduced, FF.fieldMod(), FF.getR2modP(), FF.getNegInvModWord(), FF.getSpareBits())
 
 func random_long01Seq(rng: var RngState, a: var ExtensionField) =
   ## Recursively initialize an extension Field element

--- a/tests/t_finite_fields_double_precision.nim
+++ b/tests/t_finite_fields_double_precision.nim
@@ -56,7 +56,7 @@ sqrTest(random_unsafe)
 sqrTest(randomHighHammingWeight)
 sqrTest(random_long01Seq)
 
-suite "Field Multiplication via double-width field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
+suite "Field Multiplication via double-precision field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
   test "With P-224 field modulus":
     for _ in 0 ..< Iters:
       mul_random_unsafe(P224)
@@ -89,7 +89,7 @@ suite "Field Multiplication via double-width field elements is consistent with s
     for _ in 0 ..< Iters:
       mul_random_long01Seq(BLS12_381)
 
-suite "Field Squaring via double-width field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
+suite "Field Squaring via double-precision field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
   test "With P-224 field modulus":
     for _ in 0 ..< Iters:
       sqr_random_unsafe(P224)

--- a/tests/t_finite_fields_double_precision.nim
+++ b/tests/t_finite_fields_double_precision.nim
@@ -154,6 +154,13 @@ suite "Field Addition/Substraction/Negation via double-precision field elements"
     for _ in 0 ..< Iters:
       addsubneg_random_long01Seq(BLS12_381)
 
+  test "Negate 0 returns 0 (unique Montgomery repr)":
+    var a: FpDbl[BN254_Snarks]
+    var r {.noInit.}: FpDbl[BN254_Snarks]
+    r.neg2xMod(a)
+
+    check: bool r.isZero()
+
 suite "Field Multiplication via double-precision field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
   test "With P-224 field modulus":
     for _ in 0 ..< Iters:

--- a/tests/t_finite_fields_double_precision.nim
+++ b/tests/t_finite_fields_double_precision.nim
@@ -22,7 +22,7 @@ var rng: RngState
 let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
 rng.seed(seed)
 echo "\n------------------------------------------------------\n"
-echo "test_finite_fields_double_width xoshiro512** seed: ", seed
+echo "test_finite_fields_double_precision xoshiro512** seed: ", seed
 
 template mulTest(rng_gen: untyped): untyped =
   proc `mul _ rng_gen`(C: static Curve) =

--- a/tests/t_finite_fields_double_width.nim
+++ b/tests/t_finite_fields_double_width.nim
@@ -33,8 +33,8 @@ template mulTest(rng_gen: untyped): untyped =
     var tmpDbl{.noInit.}: FpDbl[C]
 
     r_fp.prod(a, b)
-    tmpDbl.mulNoReduce(a, b)
-    r_fpDbl.reduce(tmpDbl)
+    tmpDbl.prod2x(a, b)
+    r_fpDbl.redc2x(tmpDbl)
 
     doAssert bool(r_fp == r_fpDbl)
 
@@ -44,8 +44,8 @@ template sqrTest(rng_gen: untyped): untyped =
 
     var mulDbl{.noInit.}, sqrDbl{.noInit.}: FpDbl[C]
 
-    mulDbl.mulNoReduce(a, a)
-    sqrDbl.squareNoReduce(a)
+    mulDbl.prod2x(a, a)
+    sqrDbl.square2x(a)
 
     doAssert bool(mulDbl == sqrDbl)
 

--- a/tests/t_finite_fields_mulsquare.nim
+++ b/tests/t_finite_fields_mulsquare.nim
@@ -27,7 +27,7 @@ echo "test_finite_fields_mulsquare xoshiro512** seed: ", seed
 static: doAssert defined(testingCurves), "This modules requires the -d:testingCurves compile option"
 
 proc sanity(C: static Curve) =
-  test "Squaring 0,1,2 with "& $Curve(C) & " [FastSquaring = " & $Fp[C].canUseNoCarryMontySquare & "]":
+  test "Squaring 0,1,2 with "& $Curve(C) & " [FastSquaring = " & $(Fp[C].getSpareBits() >= 2) & "]":
         block: # 0² mod
           var n: Fp[C]
 
@@ -89,7 +89,7 @@ mainSanity()
 
 proc mainSelectCases() =
   suite "Modular Squaring: selected tricky cases" & " [" & $WordBitwidth & "-bit mode]":
-    test "P-256 [FastSquaring = " & $Fp[P256].canUseNoCarryMontySquare & "]":
+    test "P-256 [FastSquaring = " & $(Fp[P256].getSpareBits() >= 2) & "]":
       block:
         # Triggered an issue in the (t[N+1], t[N]) = t[N] + (A1, A0)
         # between the squaring and reduction step, with t[N+1] and A1 being carry bits.
@@ -136,7 +136,7 @@ proc random_long01Seq(C: static Curve) =
   doAssert bool(r_mul == r_sqr)
 
 suite "Random Modular Squaring is consistent with Modular Multiplication" & " [" & $WordBitwidth & "-bit mode]":
-  test "Random squaring mod P-224 [FastSquaring = " & $Fp[P224].canUseNoCarryMontySquare & "]":
+  test "Random squaring mod P-224 [FastSquaring = " & $(Fp[P224].getSpareBits() >= 2) & "]":
     for _ in 0 ..< Iters:
       randomCurve(P224)
     for _ in 0 ..< Iters:
@@ -144,7 +144,8 @@ suite "Random Modular Squaring is consistent with Modular Multiplication" & " ["
     for _ in 0 ..< Iters:
       random_long01Seq(P224)
 
-  test "Random squaring mod P-256 [FastSquaring = " & $Fp[P256].canUseNoCarryMontySquare & "]":
+  test "Random squaring mod P-256 [FastSquaring = " & $(Fp[P256].getSpareBits() >= 2) & "]":
+    echo "Fp[P256].getSpareBits(): ", Fp[P256].getSpareBits()
     for _ in 0 ..< Iters:
       randomCurve(P256)
     for _ in 0 ..< Iters:
@@ -152,7 +153,7 @@ suite "Random Modular Squaring is consistent with Modular Multiplication" & " ["
     for _ in 0 ..< Iters:
       random_long01Seq(P256)
 
-  test "Random squaring mod BLS12_381 [FastSquaring = " & $Fp[BLS12_381].canUseNoCarryMontySquare & "]":
+  test "Random squaring mod BLS12_381 [FastSquaring = " & $(Fp[BLS12_381].getSpareBits() >= 2) & "]":
     for _ in 0 ..< Iters:
       randomCurve(BLS12_381)
     for _ in 0 ..< Iters:

--- a/tests/t_fp4.nim
+++ b/tests/t_fp4.nim
@@ -35,7 +35,7 @@ runTowerTests(
 # Issue when using Fp4Dbl
 
 suite "𝔽p4 - Anti-regression":
-  test "Partial reduction (off by p) on double-width field":
+  test "Partial reduction (off by p) on double-precision field":
     proc partred1() =
       type F = Fp4[BN254_Snarks]
       var x: F

--- a/tests/t_fp4.nim
+++ b/tests/t_fp4.nim
@@ -1,0 +1,129 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/unittest,
+  # Internals
+  ../constantine/towers,
+  ../constantine/io/io_towers,
+  ../constantine/config/curves,
+  # Test utilities
+  ./t_fp_tower_template
+
+const TestCurves = [
+    BN254_Nogami,
+    BN254_Snarks,
+    BLS12_377,
+    BLS12_381,
+    BW6_761
+  ]
+
+runTowerTests(
+  ExtDegree = 4,
+  Iters = 12,
+  TestCurves = TestCurves,
+  moduleName = "test_fp4",
+  testSuiteDesc = "𝔽p4 = 𝔽p2[v]"
+)
+
+# Fuzzing failure
+# Issue when using Fp4Dbl
+
+suite "𝔽p4 - Anti-regression":
+  test "Partial reduction (off by p) on double-width field":
+    proc partred1() =
+      type F = Fp4[BN254_Snarks]
+      var x: F
+      x.fromHex(
+        "0x0000000000000000000fffffffffffffffffe000000fffffffffcffffff80000",
+        "0x000000000000007ffffffffff800000001fffe000000000007ffffffffffffe0",
+        "0x000000c0ff0300fcffffffff7f00000000f0ffffffffffffffff00000000e0ff",
+        "0x0e0a77c19a07df27e5eea36f7879462c0a7ceb28e5c70b3dd35d438dc58f4d9c"
+      )
+
+      # echo "x: ", x.toHex()
+      # echo "\n----------------------"
+
+      var s: F
+      s.square(x)
+
+      # echo "s: ", s.toHex()
+      # echo "\ns raw: ", s
+
+      # echo "\n----------------------"
+      var p: F
+      p.prod(x, x)
+
+      # echo "p: ", p.toHex()
+      # echo "\np raw: ", p
+
+      check: bool(p == s)
+
+    partred1()
+
+    proc partred2() =
+      type F = Fp4[BN254_Snarks]
+      var x: F
+      x.fromHex(
+        "0x0660df54c75b67a0c32fc6208f08b13d8cc86cd93084180725a04884e7f45849",
+        "0x094185b0915ce1aa3bd3c63d33fd6d9cf3f04ea30fc88efe1e6e9b59117513bb",
+        "0x26c20beee711e46406372ab4f0e6d0069c67ded0a494bc0301bbfde48f7a4073",
+        "0x23c60254946def07120e46155466cc9b883b5c3d1c17d1d6516a6268a41dcc5d"
+      )
+
+      # echo "x: ", x.toHex()
+      # echo "\n----------------------"
+
+      var s: F
+      s.square(x)
+
+      # echo "s: ", s.toHex()
+      # echo "\ns raw: ", s
+
+      # echo "\n----------------------"
+      var p: F
+      p.prod(x, x)
+
+      # echo "p: ", p.toHex()
+      # echo "\np raw: ", p
+
+      check: bool(p == s)
+
+    partred2()
+
+
+    proc partred3() =
+      type F = Fp4[BN254_Snarks]
+      var x: F
+      x.fromHex(
+        "0x233066f735efcf7a0ad6e3ffa3afe4ed39bdfeffffb3f7d8b1fd7eeabfddfb36",
+        "0x1caba0b27fdfdfd512bdecf3fffbfebdb939fffffffbff8a14e663f7fef7fc85",
+        "0x212a64f0efefff1b7abe2ebe2bffbfc1b9335fb73ffd7c8815ffffffffffff8d",
+        "0x212ba4b1ff8feff552a61efff5ffffc5b839f7ffffffff71f477dffe7ffc7e08"
+      )
+
+      # echo "x: ", x.toHex()
+      # echo "\n----------------------"
+
+      var s: F
+      s.square(x)
+
+      # echo "s:  ", s.toHex()
+      # echo "\ns raw:  ", s
+
+      # echo "\n----------------------"
+      var n, s2: F
+      n.neg(x)
+      s2.prod(n, n)
+
+      # echo "s2: ", s2.toHex()
+      # echo "\ns2 raw: ", s2
+
+      check: bool(s == s2)
+
+    partred3()

--- a/tests/t_fp_tower_template.nim
+++ b/tests/t_fp_tower_template.nim
@@ -20,6 +20,7 @@ import
   ../constantine/towers,
   ../constantine/config/[common, curves],
   ../constantine/arithmetic,
+  ../constantine/io/io_towers,
   # Test utilities
   ../helpers/[prng_unsafe, static_for]
 
@@ -28,6 +29,8 @@ echo "\n------------------------------------------------------\n"
 template ExtField(degree: static int, curve: static Curve): untyped =
   when degree == 2:
     Fp2[curve]
+  elif degree == 4:
+    Fp4[curve]
   elif degree == 6:
     Fp6[curve]
   elif degree == 12:
@@ -273,7 +276,7 @@ proc runTowerTests*[N](
           rMul.prod(a, a)
           rSqr.square(a)
 
-          check: bool(rMul == rSqr)
+          doAssert bool(rMul == rSqr), "Failure with a: " & a.toHex()
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)
@@ -292,7 +295,7 @@ proc runTowerTests*[N](
           rSqr.square(a)
           rNegSqr.square(na)
 
-          check: bool(rSqr == rNegSqr)
+          doAssert bool(rSqr == rNegSqr), "Failure with a: " & a.toHex()
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)

--- a/tests/t_fp_tower_template.nim
+++ b/tests/t_fp_tower_template.nim
@@ -276,7 +276,7 @@ proc runTowerTests*[N](
           rMul.prod(a, a)
           rSqr.square(a)
 
-          doAssert bool(rMul == rSqr), "Failure with a: " & a.toHex()
+          doAssert bool(rMul == rSqr), "Failure with a (" & $Field & "): " & a.toHex()
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)
@@ -295,7 +295,7 @@ proc runTowerTests*[N](
           rSqr.square(a)
           rNegSqr.square(na)
 
-          doAssert bool(rSqr == rNegSqr), "Failure with a: " & a.toHex()
+          doAssert bool(rSqr == rNegSqr), "Failure with a (" & $Field & "): " & a.toHex()
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)

--- a/tests/t_fr.nim
+++ b/tests/t_fr.nim
@@ -25,7 +25,7 @@ echo "\n------------------------------------------------------\n"
 echo "test_fr xoshiro512** seed: ", seed
 
 proc sanity(C: static Curve) =
-  test "Fr: Squaring 0,1,2 with "& $Fr[C] & " [FastSquaring = " & $Fr[C].canUseNoCarryMontySquare & "]":
+  test "Fr: Squaring 0,1,2 with "& $Fr[C] & " [FastSquaring = " & $(Fr[C].getSpareBits() >= 2) & "]":
         block: # 0² mod
           var n: Fr[C]
 
@@ -112,7 +112,7 @@ proc random_long01Seq(C: static Curve) =
   doAssert bool(r_mul == r_sqr)
 
 suite "Fr: Random Modular Squaring is consistent with Modular Multiplication" & " [" & $WordBitwidth & "-bit mode]":
-  test "Random squaring mod r_BN254_Snarks [FastSquaring = " & $Fr[BN254_Snarks].canUseNoCarryMontySquare & "]":
+  test "Random squaring mod r_BN254_Snarks [FastSquaring = " & $(Fr[BN254_Snarks].getSpareBits() >= 2) & "]":
     for _ in 0 ..< Iters:
       randomCurve(BN254_Snarks)
     for _ in 0 ..< Iters:
@@ -120,7 +120,7 @@ suite "Fr: Random Modular Squaring is consistent with Modular Multiplication" & 
     for _ in 0 ..< Iters:
       random_long01Seq(BN254_Snarks)
 
-  test "Random squaring mod r_BLS12_381 [FastSquaring = " & $Fr[BLS12_381].canUseNoCarryMontySquare & "]":
+  test "Random squaring mod r_BLS12_381 [FastSquaring = " & $(Fr[BLS12_381].getSpareBits() >= 2) & "]":
     for _ in 0 ..< Iters:
       randomCurve(BLS12_381)
     for _ in 0 ..< Iters:


### PR DESCRIPTION
This PR reworks the towering to introduce double-precision finite fields.

This moderately accelerate G2  operations and significantly improves Fp12 and pairings computations.

- [x] Double-precision towering: now uses lazy reduction (related to https://github.com/mratsim/constantine/issues/15 and continues https://github.com/mratsim/constantine/pull/144)
- [x] Consistent naming `diffUnr` for unrediced Fp operations instead of `diffNoReduce`
- [x] double-width -> double-precision
- [x]  Consistent naming `diff2xMod` and `diff2xUnr` for double-precision operations.
  - [x] `prod2x`, `square2x` and `redc2x` for double-precision modular arithmetic 
- [x] Removal of `canUseNoCarryMontyMul` and `canUseNoCarryMontySquare` to instead have `getSpareBits` to access the number of extra spare bits in the field element representation.
- [x] Slightly improved assembly for add/sub via interleaving copies and operations and dependency chain latency hiding.
- [x] Small addition chains for Bigint, Fp, FpDbl, extension fields and double-precision extension fields use less temporaries and copies
- [x] Alternate formulae for Fp4[BN254_Snarks] squaring which is 25%, fix #154