### PR TITLE
Drop nim-json-serialization for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,14 +199,9 @@ jobs:
           rm -rf .git
       - name: Install test dependencies
         shell: bash
-        # Workaround #113 and https://github.com/status-im/nim-serialization/issues/33
-        # and nimble flaky pinning / dependency resolution,
-        # json_serialization install would override nim-serialization pinning
         run: |
           nimble refresh
-          nimble install -y gmp stew json_serialization
-          nimble uninstall -y serialization
-          nimble install serialization@#217d78a
+          nimble install -y gmp stew jsony
       - name: Run Constantine tests (with Assembler & with GMP)
         if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.target.cpu == 'amd64'
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,12 +127,7 @@ before_script:
     - export PATH="$PWD/nim-${CHANNEL}/bin${PATH:+:$PATH}"
 script:
     - nimble refresh
-    - nimble install -y gmp stew json_serialization
-    # Workaround #113 and https://github.com/status-im/nim-serialization/issues/33
-    # and nimble flaky pinning / dependency resolution,
-    # json_serialization install would override nim-serialization pinning
-    - nimble uninstall -y serialization
-    - nimble install serialization@#217d78a
+    - nimble install -y gmp stew jsony
 
     # Installing Clang9.0 or later is a pain in Travis
     # for inline assembly "flag output constraint"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,9 +222,7 @@ steps:
   - bash: |
       echo "PATH=${PATH}"
       nimble refresh
-      nimble install -y gmp stew json_serialization
-      nimble uninstall -y serialization
-      nimble install serialization@#217d78a
+      nimble install -y gmp stew jsony
     displayName: 'Installing package and testing dependencies'
 
   - bash: |


### PR DESCRIPTION
How to lose an evening due to flaky tooling and bugs (https://github.com/nim-lang/RFCs/issues/300)

## Context

1. PR #155 is blocked by CI failing to clone BearSSL, a commit was removed from the tree (security issue?) https://github.com/mratsim/constantine/runs/1865343014#step:15:60
2. BearSSL is brought by a dependency chain that involves nim-json-serialization https://github.com/status-im/nim-json-serialization/issues/25
3. Nimble doesn't support task-level dependencies which makes it a pain to specify packages as optional https://github.com/nim-lang/nimble/issues/482, https://github.com/nim-lang/nimble/issues/506
4. I couldn't test Constantine as a result

## Incidental Fixes

1. No more workaround for https://github.com/status-im/nim-serialization/issues/33
   Which required uninstalling nim-serialization before reinstalling it because Nimble has no pinned dependency support https://github.com/nim-lang/nimble/issues/127 https://github.com/mratsim/constantine/blob/c4a2dee42d39285a60813446dbb408f34f997114/.github/workflows/ci.yml#L200-L209
  
2. No more CI being stuck due to slow resolving of dependencies: https://github.com/nim-lang/nimble/issues/890, 40s jusst to install gmp, stew and nim-json-serialization (https://github.com/mratsim/constantine/runs/1851076249#step:15:1) 
![image](https://user-images.githubusercontent.com/22738317/107428135-833ff900-6b22-11eb-8f1f-287cf10fbb6d.png)

3. No more fighting against the generic sandwich https://github.com/nim-lang/Nim/issues/11225
