### PR TITLE
CI revamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,32 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        branch: [devel] # [version-1-2, devel] - # 1.2 doesn't compile https://github.com/mratsim/constantine/pull/20#issuecomment-646327952
+        branch: [version-1-4] # [version-1-4, devel]
         target:
           - os: linux
             cpu: amd64
             TEST_LANG: c
+            BACKEND: NO_ASM
           - os: linux
             cpu: amd64
             TEST_LANG: cpp
+            BACKEND: NO_ASM
           - os: linux
             cpu: i386
             TEST_LANG: c
+            BACKEND: NO_ASM
           - os: linux
             cpu: i386
             TEST_LANG: cpp
+            BACKEND: NO_ASM
           - os: macos
             cpu: amd64
             TEST_LANG: c
+            BACKEND: NO_ASM
           - os: macos
             cpu: amd64
             TEST_LANG: cpp
+            BACKEND: NO_ASM
           # TODO:
           #   1. Modulo/reduce bug on 32-bit
           #   2. ModInverse bug on all windows
@@ -42,6 +48,31 @@ jobs:
           # - os: windows
           #   cpu: i386
           #   TEST_LANG: cpp
+          # ----------------------------
+          - os: linux
+            cpu: amd64
+            TEST_LANG: c
+            BACKEND: ASM
+          - os: linux
+            cpu: amd64
+            TEST_LANG: cpp
+            BACKEND: ASM
+          - os: linux
+            cpu: i386
+            TEST_LANG: c
+            BACKEND: ASM
+          - os: linux
+            cpu: i386
+            TEST_LANG: cpp
+            BACKEND: ASM
+          - os: macos
+            cpu: amd64
+            TEST_LANG: c
+            BACKEND: ASM
+          - os: macos
+            cpu: amd64
+            TEST_LANG: cpp
+            BACKEND: ASM
         include:
           - target:
               os: linux
@@ -203,28 +234,28 @@ jobs:
           nimble refresh
           nimble install -y gmp stew jsony
       - name: Run Constantine tests (with Assembler & with GMP)
-        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.target.cpu == 'amd64'
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.target.BACKEND == 'ASM' && matrix.target.cpu != 'i386'
         shell: bash
         run: |
           export UCPU="$cpu"
           cd constantine
           nimble test_parallel
       - name: Run Constantine tests (no Assembler & with GMP)
-        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.target.cpu == 'amd64'
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.target.BACKEND == 'NO_ASM' && matrix.target.cpu != 'i386'
         shell: bash
         run: |
           export UCPU="$cpu"
           cd constantine
           nimble test_parallel_no_assembler
       - name: Run Constantine tests (without GMP)
-        if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
+        if: runner.os == 'Linux' && matrix.target.BACKEND == 'ASM' && matrix.target.cpu == 'i386'
         shell: bash
         run: |
           export UCPU="$cpu"
           cd constantine
           nimble test_parallel_no_gmp
       - name: Run Constantine tests (without Assembler or GMP)
-        if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
+        if: runner.os == 'Linux' && matrix.target.BACKEND == 'NO_ASM' && matrix.target.cpu == 'i386'
         shell: bash
         run: |
           export UCPU="$cpu"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           # - target:
           #     os: windows
           #   builder: windows-2019
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ matrix.target.TEST_LANG }} (${{ matrix.branch }})'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ matrix.target.TEST_LANG }}-${{ matrix.target.BACKEND }} (${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Cancel Previous Runs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
       arch: arm64
       env:
         - ARCH=arm64
-        - CHANNEL=devel
+        - CHANNEL=stable
       compiler: gcc
 
     - dist: bionic
       arch: ppc64le
       env:
         - ARCH=powerpc64el
-        - CHANNEL=devel
+        - CHANNEL=stable
       compiler: gcc
 
     # "Unknown processor s390x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ matrix:
         - CHANNEL=stable
       compiler: gcc
 
-    - dist: bionic
-      arch: ppc64le
-      env:
-        - ARCH=powerpc64el
-        - CHANNEL=stable
-      compiler: gcc
+    # - dist: bionic
+    #   arch: ppc64le
+    #   env:
+    #     - ARCH=powerpc64el
+    #     - CHANNEL=stable
+    #   compiler: gcc
 
     # "Unknown processor s390x"
     # - dist: bionic

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,21 +15,25 @@ strategy:
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
+      BACKEND: NO_ASM
     Windows_cpp_devel_64bit:
       VM: 'windows-latest'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: cpp
+      BACKEND: NO_ASM
     Linux_devel_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
+      BACKEND: NO_ASM
     Linux_cpp_devel_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: cpp
+      BACKEND: NO_ASM
 
     # Deactivated for now, this is cross-compilation and tricky to get right
     # Linux_devel_32bit:
@@ -43,6 +47,42 @@ strategy:
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
+      BACKEND: NO_ASM
+
+    # -------------------------------
+
+    # No assembly for windows
+    # Windows_devel_64bit:
+    #   VM: 'windows-latest'
+    #   UCPU: amd64
+    #   CHANNEL: stable
+    #   TEST_LANG: c
+    #   BACKEND: ASM
+    # Windows_cpp_devel_64bit:
+    #   VM: 'windows-latest'
+    #   UCPU: amd64
+    #   CHANNEL: stable
+    #   TEST_LANG: cpp
+    #   BACKEND: ASM
+    Linux_devel_64bit:
+      VM: 'ubuntu-18.04'
+      UCPU: amd64
+      CHANNEL: stable
+      TEST_LANG: c
+      BACKEND: ASM
+    Linux_cpp_devel_64bit:
+      VM: 'ubuntu-18.04'
+      UCPU: amd64
+      CHANNEL: stable
+      TEST_LANG: cpp
+      BACKEND: ASM
+    MacOS_devel_64bit:
+      VM: 'macOS-10.15'
+      UCPU: amd64
+      CHANNEL: stable
+      TEST_LANG: c
+      BACKEND: ASM
+
 pool:
   vmImage: $(VM)
 
@@ -236,14 +276,14 @@ steps:
       export ucpu=${UCPU}
       nimble test_parallel
     displayName: 'Testing Constantine with Assembler and with GMP'
-    condition: ne(variables['Agent.OS'], 'Windows_NT')
+    condition: and(ne(variables['Agent.OS'], 'Windows_NT'), eq(variables['BACKEND'], 'NO_ASM'))
 
   - bash: |
       echo "PATH=${PATH}"
       export ucpu=${UCPU}
       nimble test_parallel_no_assembler
     displayName: 'Testing Constantine without Assembler and with GMP'
-    condition: ne(variables['Agent.OS'], 'Windows_NT')
+    condition: and(ne(variables['Agent.OS'], 'Windows_NT'), eq(variables['BACKEND'], 'NO_ASM'))
 
   - bash: |
       echo "PATH=${PATH}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,25 +10,25 @@ strategy:
     #   UCPU: i686
     #   CHANNEL: devel
     #   TEST_LANG: c
-    Windows_devel_64bit:
+    Windows_stable_noasm_64bit:
       VM: 'windows-latest'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
       BACKEND: NO_ASM
-    Windows_cpp_devel_64bit:
+    Windows_cpp_stable_noasm_64bit:
       VM: 'windows-latest'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: cpp
       BACKEND: NO_ASM
-    Linux_devel_64bit:
+    Linux_stable_noasm_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
       BACKEND: NO_ASM
-    Linux_cpp_devel_64bit:
+    Linux_cpp_stable_noasm_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
@@ -42,7 +42,7 @@ strategy:
     #   CHANNEL: devel
     #   TEST_LANG: c
 
-    MacOS_devel_64bit:
+    MacOS_stable_noasm_64bit:
       VM: 'macOS-10.15'
       UCPU: amd64
       CHANNEL: stable
@@ -64,19 +64,19 @@ strategy:
     #   CHANNEL: stable
     #   TEST_LANG: cpp
     #   BACKEND: ASM
-    Linux_devel_64bit:
+    Linux_stable_asm_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: c
       BACKEND: ASM
-    Linux_cpp_devel_64bit:
+    Linux_cpp_stable_asm_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
       CHANNEL: stable
       TEST_LANG: cpp
       BACKEND: ASM
-    MacOS_devel_64bit:
+    MacOS_stable_asm_64bit:
       VM: 'macOS-10.15'
       UCPU: amd64
       CHANNEL: stable

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ steps:
 
    # https://forum.nim-lang.org/t/7494
   - powershell: |
-      bitsadmin.exe /rawreturn /transfer "cURL-certicates" /priority FOREGROUND https://curl.se/ca/cacert.pem ##vso[task.prependpath]$pwd\NimBinaries\nim-$(CHANNEL)\bin\cacert.pem
+      bitsadmin.exe /rawreturn /transfer "cURL-certicates" /priority FOREGROUND https://curl.se/ca/cacert.pem $pwd\NimBinaries\nim-$(CHANNEL)\bin\cacert.pem
     displayName: 'cURL certificates (Windows)'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,7 +276,7 @@ steps:
       export ucpu=${UCPU}
       nimble test_parallel
     displayName: 'Testing Constantine with Assembler and with GMP'
-    condition: and(ne(variables['Agent.OS'], 'Windows_NT'), eq(variables['BACKEND'], 'NO_ASM'))
+    condition: and(ne(variables['Agent.OS'], 'Windows_NT'), eq(variables['BACKEND'], 'ASM'))
 
   - bash: |
       echo "PATH=${PATH}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,22 +13,22 @@ strategy:
     Windows_devel_64bit:
       VM: 'windows-latest'
       UCPU: amd64
-      CHANNEL: devel
+      CHANNEL: stable
       TEST_LANG: c
     Windows_cpp_devel_64bit:
       VM: 'windows-latest'
       UCPU: amd64
-      CHANNEL: devel
+      CHANNEL: stable
       TEST_LANG: cpp
     Linux_devel_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
-      CHANNEL: devel
+      CHANNEL: stable
       TEST_LANG: c
     Linux_cpp_devel_64bit:
       VM: 'ubuntu-18.04'
       UCPU: amd64
-      CHANNEL: devel
+      CHANNEL: stable
       TEST_LANG: cpp
 
     # Deactivated for now, this is cross-compilation and tricky to get right
@@ -41,7 +41,7 @@ strategy:
     MacOS_devel_64bit:
       VM: 'macOS-10.15'
       UCPU: amd64
-      CHANNEL: devel
+      CHANNEL: stable
       TEST_LANG: c
 pool:
   vmImage: $(VM)
@@ -187,6 +187,12 @@ steps:
       popd # exit nim-${CHANNEL}
       popd # exit NimBinaries
     displayName: 'Building Nim'
+
+   # https://forum.nim-lang.org/t/7494
+  - powershell: |
+      bitsadmin.exe /rawreturn /transfer "cURL-certicates" /priority FOREGROUND https://curl.se/ca/cacert.pem ##vso[task.prependpath]$pwd\NimBinaries\nim-$(CHANNEL)\bin\cacert.pem
+    displayName: 'cURL certificates (Windows)'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - powershell: |
       echo "##vso[task.prependpath]$pwd\NimBinaries\nim-$(CHANNEL)\bin"


### PR DESCRIPTION
Nim devel and 1.4 now requires the curl certificates, this downloads it, see https://forum.nim-lang.org/t/7494

This PR also now targets the latest stable Nim branch instead of Nim devel since all fixes required by Constantine are in 1.4.x

Lastly it splits the Assembly and No assembly tests in different jobs as an attempt use all the parallelism CIs offer at the job level.