### PR TITLE
Double-precision cubic towering + pairing

### DIFF
--- a/constantine/pairing/mul_fp12_by_lines.nim
+++ b/constantine/pairing/mul_fp12_by_lines.nim
@@ -131,30 +131,57 @@ func mul_sparse_by_line_xyz000*[C: static Curve](
   #    = a0 b0 + a2 b0 - v0 + v1
   #    = a2 b0 + v1
 
-  var b0 {.noInit.}, v0{.noInit.}, v1{.noInit.}, t{.noInit.}: Fp4[C]
+  when false:
+    var b0 {.noInit.}, v0{.noInit.}, v1{.noInit.}, t{.noInit.}: Fp4[C]
 
-  b0.c0 = l.x
-  b0.c1 = l.y
+    b0.c0 = l.x
+    b0.c1 = l.y
 
-  v0.prod(f.c0, b0)
-  v1.mul_sparse_by_y0(f.c1, l.z)
+    v0.prod(f.c0, b0)
+    v1.mul_sparse_by_x0(f.c1, l.z)
 
-  # r1 = (a0 + a1) * (b0 + b1) - v0 - v1
-  f.c1 += f.c0 # r1 = a0 + a1
-  t = b0
-  t.c0 += l.z  # t = b0 + b1
-  f.c1 *= t    # r2 = (a0 + a1)(b0 + b1)
-  f.c1 -= v0
-  f.c1 -= v1   # r2 = (a0 + a1)(b0 + b1) - v0 - v1
+    # r1 = (a0 + a1) * (b0 + b1) - v0 - v1
+    f.c1 += f.c0 # r1 = a0 + a1
+    t = b0
+    t.c0 += l.z  # t = b0 + b1
+    f.c1 *= t    # r2 = (a0 + a1)(b0 + b1)
+    f.c1 -= v0
+    f.c1 -= v1   # r2 = (a0 + a1)(b0 + b1) - v0 - v1
 
-  # r0 = ξ a2 b1 + v0
-  f.c0.mul_sparse_by_y0(f.c2, l.z)
-  f.c0 *= SexticNonResidue
-  f.c0 += v0
+    # r0 = ξ a2 b1 + v0
+    f.c0.mul_sparse_by_x0(f.c2, l.z)
+    f.c0 *= SexticNonResidue
+    f.c0 += v0
 
-  # r2 = a2 b0 + v1
-  f.c2 *= b0
-  f.c2 += v1
+    # r2 = a2 b0 + v1
+    f.c2 *= b0
+    f.c2 += v1
+
+  else: # Lazy reduction
+    var V0{.noInit.}, V1{.noInit.}, f2x{.noInit.}: doublePrec(Fp4[C])
+    var t{.noInit.}: Fp2[C]
+
+    V0.prod2x_disjoint(f.c0, l.x, l.y)
+    V1.mul2x_sparse_by_x0(f.c1, l.z)
+
+    # r1 = (a0 + a1) * (b0 + b1) - v0 - v1
+    f.c1 += f.c0 # TODO: lazy sumUnr
+    t.sum(l.x, l.z)                   # b0 is (x, y)
+    f2x.prod2x_disjoint(f.c1, t, l.y) # b1 is (z, 0)
+    f2x.diff2xMod(f2x, V0)
+    f2x.diff2xMod(f2x, V1)
+    f.c1.redc2x(f2x)
+
+    # r0 = ξ a2 b1 + v0
+    f2x.mul2x_sparse_by_x0(f.c2, l.z)
+    f2x.prod2x(f2x, SexticNonResidue)
+    f2x.sum2xMod(f2x, V0)
+    f.c0.redc2x(f2x)
+
+    # r2 = a2 b0 + v1
+    f2x.prod2x_disjoint(f.c2, l.x, l.y)
+    f2x.sum2xMod(f2x, V1)
+    f.c2.redc2x(f2x)
 
 func mul_sparse_by_line_xy000z*[C: static Curve](
        f: var Fp12[C], l: Line[Fp2[C]]) =

--- a/constantine/pairing/mul_fp12_by_lines.nim
+++ b/constantine/pairing/mul_fp12_by_lines.nim
@@ -165,8 +165,12 @@ func mul_sparse_by_line_xyz000*[C: static Curve](
     V1.mul2x_sparse_by_x0(f.c1, l.z)
 
     # r1 = (a0 + a1) * (b0 + b1) - v0 - v1
-    f.c1 += f.c0                      # TODO: lazy sumUnr
-    t.sum(l.x, l.z)                   # b0 is (x, y)
+    when false:                       # TODO: what's the condition?
+      f.c1.sumUnr(f.c1, f.c0)
+      t.sumUnr(l.x, l.z)              # b0 is (x, y)
+    else:
+      f.c1.sum(f.c1, f.c0)
+      t.sum(l.x, l.z)                 # b0 is (x, y)
     f2x.prod2x_disjoint(f.c1, t, l.y) # b1 is (z, 0)
     f2x.diff2xMod(f2x, V0)
     f2x.diff2xMod(f2x, V1)
@@ -244,8 +248,12 @@ func mul_sparse_by_line_xy000z*[C: static Curve](
     V2.mul2x_sparse_by_0y(f.c2, l.z)
 
     # r2 = (a0 + a2) * (b0 + b2) - v0 - v2
-    f.c2 += f.c0                      # TODO: lazy sumUnr
-    t.sum(l.y, l.z)                   # b0 is (x, y)
+    when false:                       # TODO: what's the condition
+      f.c2.sumUnr(f.c2, f.c0)
+      t.sumUnr(l.y, l.z)              # b0 is (x, y)
+    else:
+      f.c2.sum(f.c2, f.c0)
+      t.sum(l.y, l.z)                 # b0 is (x, y)
     f2x.prod2x_disjoint(f.c2, l.x, t) # b2 is (0, z)
     f2x.diff2xMod(f2x, V0)
     f2x.diff2xMod(f2x, V2)

--- a/constantine/pairing/mul_fp6_by_lines.nim
+++ b/constantine/pairing/mul_fp6_by_lines.nim
@@ -26,10 +26,10 @@ import
 
 func mul_sparse_by_line_xyz000*[C: static Curve](
        f: var Fp6[C], l: Line[Fp[C]]) =
-  ## Sparse multiplication of an 𝔽p12 element
-  ## by a sparse 𝔽p12 element coming from an D-Twist line function.
+  ## Sparse multiplication of an 𝔽p6 element
+  ## by a sparse 𝔽p6 element coming from an D-Twist line function.
   ## The sparse element is represented by a packed Line type
-  ## with coordinates (x,y,z) matching 𝔽p12 coordinates xyz000
+  ## with coordinates (x,y,z) matching 𝔽p6 coordinates xyz000
 
   static:
     doAssert C.getSexticTwist() == D_Twist

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -239,17 +239,17 @@ func prod*(r: var ExtensionField, a: ExtensionField, b: static int) =
 # ############################################################
 
 type
-  QuadraticExt2x[F] = object
+  QuadraticExt2x*[F] = object
     ## Quadratic Extension field for lazy reduced fields
-    coords: array[2, F]
+    coords*: array[2, F]
 
-  CubicExt2x[F] = object
+  CubicExt2x*[F] = object
     ## Cubic Extension field for lazy reduced fields
-    coords: array[3, F]
+    coords*: array[3, F]
 
-  ExtensionField2x[F] = QuadraticExt2x[F] or CubicExt2x[F]
+  ExtensionField2x*[F] = QuadraticExt2x[F] or CubicExt2x[F]
 
-template doublePrec(T: type ExtensionField): type =
+template doublePrec*(T: type ExtensionField): type =
   # For now naive unrolling, recursive template don't match
   # and I don't want to deal with types in macros
   when T is QuadraticExt:
@@ -283,18 +283,18 @@ func has2extraBits(E: type ExtensionField): bool =
 template C(E: type ExtensionField2x): Curve =
   E.F.C
 
-template c0(a: ExtensionField2x): auto =
+template c0*(a: ExtensionField2x): auto =
   a.coords[0]
-template c1(a: ExtensionField2x): auto =
+template c1*(a: ExtensionField2x): auto =
   a.coords[1]
-template c2(a: CubicExt2x): auto =
+template c2*(a: CubicExt2x): auto =
   a.coords[2]
 
-template `c0=`(a: var ExtensionField2x, v: auto) =
+template `c0=`*(a: var ExtensionField2x, v: auto) =
   a.coords[0] = v
-template `c1=`(a: var ExtensionField2x, v: auto) =
+template `c1=`*(a: var ExtensionField2x, v: auto) =
   a.coords[1] = v
-template `c2=`(a: var CubicExt2x, v: auto) =
+template `c2=`*(a: var CubicExt2x, v: auto) =
   a.coords[2] = v
 
 # Initialization
@@ -308,32 +308,32 @@ func setZero*(a: var ExtensionField2x) =
 # Abelian group
 # -------------------------------------------------------------------
 
-func sumUnr(r: var ExtensionField, a, b: ExtensionField) =
+func sumUnr*(r: var ExtensionField, a, b: ExtensionField) =
   ## Sum ``a`` and ``b`` into ``r``
   staticFor i, 0, a.coords.len:
     r.coords[i].sumUnr(a.coords[i], b.coords[i])
 
-func diff2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func diff2xUnr*(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-precision substraction without reduction
   staticFor i, 0, a.coords.len:
     r.coords[i].diff2xUnr(a.coords[i], b.coords[i])
 
-func diff2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func diff2xMod*(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-precision modular substraction
   staticFor i, 0, a.coords.len:
     r.coords[i].diff2xMod(a.coords[i], b.coords[i])
 
-func sum2xUnr(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func sum2xUnr*(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-precision addition without reduction
   staticFor i, 0, a.coords.len:
     r.coords[i].sum2xUnr(a.coords[i], b.coords[i])
 
-func sum2xMod(r: var ExtensionField2x, a, b: ExtensionField2x) =
+func sum2xMod*(r: var ExtensionField2x, a, b: ExtensionField2x) =
   ## Double-precision modular addition
   staticFor i, 0, a.coords.len:
     r.coords[i].sum2xMod(a.coords[i], b.coords[i])
 
-func neg2xMod(r: var ExtensionField2x, a: ExtensionField2x) =
+func neg2xMod*(r: var ExtensionField2x, a: ExtensionField2x) =
   ## Double-precision modular negation
   staticFor i, 0, a.coords.len:
     r.coords[i].neg2xMod(a.coords[i], b.coords[i])
@@ -341,7 +341,7 @@ func neg2xMod(r: var ExtensionField2x, a: ExtensionField2x) =
 # Reductions
 # -------------------------------------------------------------------
 
-func redc2x(r: var ExtensionField, a: ExtensionField2x) =
+func redc2x*(r: var ExtensionField, a: ExtensionField2x) =
   ## Reduction
   staticFor i, 0, a.coords.len:
     r.coords[i].redc2x(a.coords[i])
@@ -349,7 +349,7 @@ func redc2x(r: var ExtensionField, a: ExtensionField2x) =
 # Multiplication by a small integer known at compile-time
 # -------------------------------------------------------------------
 
-func prod2x(r: var ExtensionField2x, a: ExtensionField2x, b: static int) =
+func prod2x*(r: var ExtensionField2x, a: ExtensionField2x, b: static int) =
   ## Multiplication by a small integer known at compile-time
   for i in 0 ..< a.coords.len:
     r.coords[i].prod2x(a.coords[i], b)
@@ -363,7 +363,7 @@ func prod2x(r: var FpDbl, a: FpDbl, _: type NonResidue){.inline.} =
   static: doAssert FpDbl.C.getNonResidueFp() != -1, "𝔽p2 should be specialized for complex extension"
   r.prod2x(a, FpDbl.C.getNonResidueFp())
 
-func prod2x[C: static Curve](
+func prod2x*[C: static Curve](
        r: var QuadraticExt2x[FpDbl[C]],
        a: QuadraticExt2x[FpDbl[C]],
        _: type NonResidue) {.inline.} =
@@ -413,7 +413,7 @@ func prod2x[C: static Curve](
       else:
         {.error: "Unimplemented".}
 
-func prod2x(
+func prod2x*(
        r: var QuadraticExt2x,
        a: QuadraticExt2x,
        _: type NonResidue) {.inline.} =
@@ -423,7 +423,7 @@ func prod2x(
   r.c0.prod2x(a.c1, NonResidue)
   `=`(r.c1, t) # "r.c1 = t", is refused by the compiler.
 
-func prod2x(
+func prod2x*(
        r: var CubicExt2x,
        a: CubicExt2x,
        _: type NonResidue) {.inline.} =
@@ -445,8 +445,8 @@ func prod2x(
 # Forward declarations
 # ----------------------------------------------------------------------
 
-func prod2x(r: var QuadraticExt2x, a, b: QuadraticExt)
-func square2x(r: var QuadraticExt2x, a: QuadraticExt)
+func prod2x*(r: var QuadraticExt2x, a, b: QuadraticExt)
+func square2x*(r: var QuadraticExt2x, a: QuadraticExt)
 
 # Commutative ring implementation for complex quadratic extension fields
 # ----------------------------------------------------------------------
@@ -511,7 +511,7 @@ func square2x_complex(r: var QuadraticExt2x, a: QuadraticExt) =
 # - cyclotomic square in Fp2 -> Fp6 -> Fp12 towering
 #   needs Fp4 as special case
 
-func prod2x_disjoint[Fdbl, F](
+func prod2x_disjoint*[Fdbl, F](
        r: var QuadraticExt2x[FDbl],
        a: QuadraticExt[F],
        b0, b1: F) =
@@ -538,7 +538,7 @@ func prod2x_disjoint[Fdbl, F](
   r.c0.prod2x(V1, NonResidue)   # r0 = β a1 b1
   r.c0.sum2xMod(r.c0, V0)       # r0 = a0 b0 + β a1 b1
 
-func square2x_disjoint[Fdbl, F](
+func square2x_disjoint*[Fdbl, F](
        r: var QuadraticExt2x[FDbl],
        a0, a1: F) =
   ## Return (a0, a1)² in r
@@ -560,6 +560,69 @@ func square2x_disjoint[Fdbl, F](
   r.c1.square2x(t)
   r.c1.diff2xMod(r.c1, V0)
   r.c1.diff2xMod(r.c1, V1)
+
+# Sparse multiplication
+# -------------------------------------------------------------------
+
+func mul2x_sparse_by_x0*[Fdbl, F](
+       r: var QuadraticExt2x[Fdbl], a: QuadraticExt[F],
+       sparseB: auto) =
+  ## Multiply `a` by `b` with sparse coordinates (x, 0)
+  ## On a generic quadratic extension field
+  # Algorithm (with β the non-residue in the base field)
+  #
+  # r0 = a0 b0 + β a1 b1
+  # r1 = (a0 + a1) (b0 + b1) - a0 b0 - a1 b1 (Karatsuba)
+  #
+  # with b1 = 0, hence
+  #
+  # r0 = a0 b0
+  # r1 = (a0 + a1) b0 - a0 b0 = a1 b0
+  static: doAssert Fdbl is doublePrec(F)
+
+  when typeof(sparseB) is typeof(a):
+    template b(): untyped = sparseB.c0
+  elif typeof(sparseB) is typeof(a.c0):
+    template b(): untyped = sparseB
+  else:
+    {.error: "sparseB type is " & $typeof(sparseB) &
+      " which does not match with either a (" & $typeof(a) &
+      ") or a.c0 (" & $typeof(a.c0) & ")".}
+
+  r.c0.prod2x(a.c0, b)
+  r.c1.prod2x(a.c1, b)
+
+func mul2x_sparse_by_0y*[Fdbl, F](
+       r: var QuadraticExt2x[Fdbl], a: QuadraticExt[F],
+       sparseB: auto) =
+  ## Multiply `a` by `b` with sparse coordinates (0, y)
+  ## On a generic quadratic extension field
+  # Algorithm (with β the non-residue in the base field)
+  #
+  # r0 = a0 b0 + β a1 b1
+  # r1 = (a0 + a1) (b0 + b1) - a0 b0 - a1 b1 (Karatsuba)
+  #
+  # with b0 = 0, hence
+  #
+  # r0 = β a1 b1
+  # r1 = (a0 + a1) b1 - a1 b1 = a0 b1
+  static: doAssert Fdbl is doublePrec(F)
+
+  when typeof(sparseB) is typeof(a):
+    template b(): untyped = sparseB.c1
+  elif typeof(sparseB) is typeof(a.c0):
+    template b(): untyped = sparseB
+  else:
+    {.error: "sparseB type is " & $typeof(sparseB) &
+      " which does not match with either a (" & $typeof(a) &
+      ") or a.c0 (" & $typeof(a.c0) & ")".}
+
+  r.c0.prod2x(a.c1, b)
+  r.c0.prod2x(r.c0, NonResidue)
+  r.c1.prod2x(a.c0, b)
+
+# Inversion
+# -------------------------------------------------------------------
 
 func inv2xImpl(r: var QuadraticExt, a: QuadraticExt) =
   ## Compute the multiplicative inverse of ``a``
@@ -592,14 +655,14 @@ func inv2xImpl(r: var QuadraticExt, a: QuadraticExt) =
 # Dispatch
 # ----------------------------------------------------------------------
 
-func prod2x(r: var QuadraticExt2x, a, b: QuadraticExt) =
+func prod2x*(r: var QuadraticExt2x, a, b: QuadraticExt) =
   mixin fromComplexExtension
   when a.fromComplexExtension():
     r.prod2x_complex(a, b)
   else:
     r.prod2x_disjoint(a, b.c0, b.c1)
 
-func square2x(r: var QuadraticExt2x, a: QuadraticExt) =
+func square2x*(r: var QuadraticExt2x, a: QuadraticExt) =
   mixin fromComplexExtension
   when a.fromComplexExtension():
     r.square2x_complex(a)
@@ -648,12 +711,9 @@ func square2x_Chung_Hasan_SQR2(r: var CubicExt2x, a: CubicExt) =
   m12.prod2x(m12, NonResidue)
   r.c0.sum2xMod(r.c0, m12)
 
-func prod2x(r: var CubicExt2x, a, b: CubicExt) =
+func prod2xImpl(r: var CubicExt2x, a, b: CubicExt) =
   var V0 {.noInit.}, V1 {.noInit.}, V2 {.noinit.}: typeof(r.c0)
   var t0 {.noInit.}, t1 {.noInit.}: typeof(a.c0)
-
-  # TODO: The delayed reductions are deactivated, they work for all curves
-  # except for BN254_Snarks in the FP2 -> Fp4 -> Fp12 towering
 
   V0.prod2x(a.c0, b.c0)
   V1.prod2x(a.c1, b.c1)
@@ -696,6 +756,17 @@ func prod2x(r: var CubicExt2x, a, b: CubicExt) =
   r.c2.diff2xMod(r.c2, V0)
   r.c2.diff2xMod(r.c2, V2)
   r.c2.sum2xMod(r.c2, V1)
+
+# Dispatch
+# ----------------------------------------------------------------------
+
+func square2x*(r: var CubicExt2x, a: CubicExt) {.inline.} =
+  ## Returns r = a²
+  square2x_Chung_Hasan_SQR2(r, a)
+
+func prod2x*(r: var CubicExt2x, a, b: CubicExt) {.inline.} =
+  ## Returns r = ab
+  prod2xImpl(r, a, b)
 
 # ############################################################
 #                                                            #
@@ -938,7 +1009,10 @@ func prod_generic(r: var QuadraticExt, a, b: QuadraticExt) =
   v1 *= NonResidue
   r.c0.sum(v0, v1)
 
-func mul_sparse_generic_by_x0(r: var QuadraticExt, a, sparseB: QuadraticExt) =
+# Sparse multiplication
+# -------------------------------------------------------------------
+
+func mul_sparse_generic_by_x0(r: var QuadraticExt, a: QuadraticExt, sparseB: auto) =
   ## Multiply `a` by `b` with sparse coordinates (x, 0)
   ## On a generic quadratic extension field
   # Algorithm (with β the non-residue in the base field)
@@ -950,10 +1024,17 @@ func mul_sparse_generic_by_x0(r: var QuadraticExt, a, sparseB: QuadraticExt) =
   #
   # r0 = a0 b0
   # r1 = (a0 + a1) b0 - a0 b0 = a1 b0
-  template b(): untyped = sparseB
+  when typeof(sparseB) is typeof(a):
+    template b(): untyped = sparseB.c0
+  elif typeof(sparseB) is typeof(a.c0):
+    template b(): untyped = sparseB
+  else:
+    {.error: "sparseB type is " & $typeof(sparseB) &
+      " which does not match with either a (" & $typeof(a) &
+      ") or a.c0 (" & $typeof(a.c0) & ")".}
 
-  r.c0.prod(a.c0, b.c0)
-  r.c1.prod(a.c1, b.c0)
+  r.c0.prod(a.c0, b)
+  r.c1.prod(a.c1, b)
 
 func mul_sparse_generic_by_0y(
        r: var QuadraticExt, a: QuadraticExt,
@@ -1007,6 +1088,9 @@ func mul_sparse_generic_by_0y(
   r.c1.prod(a.c0, b)
   # aliasing: a unneeded now
   r.c0.prod(t, NonResidue)
+
+# Inversion
+# -------------------------------------------------------------------
 
 func invImpl(r: var QuadraticExt, a: QuadraticExt) =
   ## Compute the multiplicative inverse of ``a``
@@ -1287,6 +1371,12 @@ func prodImpl(r: var CubicExt, a, b: CubicExt) =
 
   # Finish r₀
   r.c0.sum(t0, v0)
+
+# Sparse multiplication
+# -------------------------------------------------------------------
+
+# Inversion
+# -------------------------------------------------------------------
 
 func invImpl(r: var CubicExt, a: CubicExt) =
   ## Compute the multiplicative inverse of ``a``

--- a/constantine/tower_field_extensions/extension_fields.nim
+++ b/constantine/tower_field_extensions/extension_fields.nim
@@ -264,19 +264,19 @@ template doublePrec*(T: type ExtensionField): type =
       elif T.F.F is Fp: # Fp6
         CubicExt2x[QuadraticExt2x[doublePrec(T.F.F)]]
 
-func has1extraBit(F: type Fp): bool =
+func has1extraBit*(F: type Fp): bool =
   ## We construct extensions only on Fp (and not Fr)
   getSpareBits(F) >= 1
 
-func has2extraBits(F: type Fp): bool =
+func has2extraBits*(F: type Fp): bool =
   ## We construct extensions only on Fp (and not Fr)
   getSpareBits(F) >= 2
 
-func has1extraBit(E: type ExtensionField): bool =
+func has1extraBit*(E: type ExtensionField): bool =
   ## We construct extensions only on Fp (and not Fr)
   getSpareBits(Fp[E.F.C]) >= 1
 
-func has2extraBits(E: type ExtensionField): bool =
+func has2extraBits*(E: type ExtensionField): bool =
   ## We construct extensions only on Fp (and not Fr)
   getSpareBits(Fp[E.F.C]) >= 2
 

--- a/constantine/tower_field_extensions/tower_instantiation.nim
+++ b/constantine/tower_field_extensions/tower_instantiation.nim
@@ -272,12 +272,6 @@ func `*=`*(a: var Fp2, b: Fp) =
   a.c0 *= b
   a.c1 *= b
 
-func mul_sparse_by_y0*[C: static Curve](r: var Fp4[C], a: Fp4[C], b: Fp2[C]) =
-  ## Sparse multiplication of an Fp4 element
-  ## with coordinates (a₀, a₁) by (b₀, 0)
-  r.c0.prod(a.c0, b)
-  r.c1.prod(a.c1, b)
-
 func mul_sparse_by_0y0*[C: static Curve](r: var Fp6[C], a: Fp6[C], b: Fp2[C]) =
   ## Sparse multiplication of an Fp6 element
   ## with coordinates (a₀, a₁, a₂) by (0, b₁, 0)

--- a/constantine/tower_field_extensions/tower_instantiation.nim
+++ b/constantine/tower_field_extensions/tower_instantiation.nim
@@ -226,7 +226,7 @@ func `*=`*(a: var Fp4, _: type NonResidue) {.inline.} =
   a.prod(a, NonResidue)
 
 func prod*(r: var Fp6, a: Fp6, _: type NonResidue) {.inline.} =
-  ## Multiply an element of 𝔽p4 by the non-residue
+  ## Multiply an element of 𝔽p6 by the non-residue
   ## chosen to construct the next extension or the twist:
   ## - if quadratic non-residue: 𝔽p12
   ## - if cubic non-residue: 𝔽p18
@@ -243,7 +243,7 @@ func prod*(r: var Fp6, a: Fp6, _: type NonResidue) {.inline.} =
   r.c0.prod(t, NonResidue)
 
 func `*=`*(a: var Fp6, _: type NonResidue) {.inline.} =
-  ## Multiply an element of 𝔽p4 by the non-residue
+  ## Multiply an element of 𝔽p6 by the non-residue
   ## chosen to construct the next extension or the twist:
   ## - if quadratic non-residue: 𝔽p12
   ## - if cubic non-residue: 𝔽p18

--- a/tests/t_fp12_exponentiation.nim
+++ b/tests/t_fp12_exponentiation.nim
@@ -68,7 +68,7 @@ proc test_sameBaseProduct(C: static Curve, gen: RandomGen) =
   xapb.powUnsafeExponent(apb, window = 3)
 
   xa *= xb
-  check: bool(xa == xapb)
+  doAssert: bool(xa == xapb)
 
 proc test_powpow(C: static Curve, gen: RandomGen) =
   ## (xᴬ)ᴮ = xᴬᴮ - power of power
@@ -86,7 +86,7 @@ proc test_powpow(C: static Curve, gen: RandomGen) =
   x.powUnsafeExponent(b, window = 3)
 
   y.powUnsafeExponent(ab, window = 3)
-  check: bool(x == y)
+  doAssert: bool(x == y)
 
 proc test_powprod(C: static Curve, gen: RandomGen) =
   ## (xy)ᴬ = xᴬyᴬ - power of product
@@ -105,7 +105,7 @@ proc test_powprod(C: static Curve, gen: RandomGen) =
 
   x *= y
 
-  check: bool(x == xy)
+  doAssert: bool(x == xy)
 
 proc test_pow0(C: static Curve, gen: RandomGen) =
   ## x⁰ = 1
@@ -113,7 +113,7 @@ proc test_pow0(C: static Curve, gen: RandomGen) =
   var a: BigInt[128] # 0-init
 
   x.powUnsafeExponent(a, window=3)
-  check: bool x.isOne()
+  doAssert: bool x.isOne()
 
 proc test_0pow0(C: static Curve, gen: RandomGen) =
   ## 0⁰ = 1
@@ -121,7 +121,7 @@ proc test_0pow0(C: static Curve, gen: RandomGen) =
   var a: BigInt[128] # 0-init
 
   x.powUnsafeExponent(a, window=3)
-  check: bool x.isOne()
+  doAssert: bool x.isOne()
 
 proc test_powinv(C: static Curve, gen: RandomGen) =
   ## xᴬ / xᴮ = xᴬ⁻ᴮ - quotient of power
@@ -150,7 +150,7 @@ proc test_powinv(C: static Curve, gen: RandomGen) =
   discard amb.diff(a, b)
   xamb.powUnsafeExponent(amb, window = 3)
 
-  check: bool(xa == xamb)
+  doAssert: bool(xa == xamb)
 
 proc test_invpow(C: static Curve, gen: RandomGen) =
   ## (x / y)ᴬ = xᴬ / yᴬ - power of quotient
@@ -173,7 +173,7 @@ proc test_invpow(C: static Curve, gen: RandomGen) =
   xqya *= invy
   xqya.powUnsafeExponent(a, window = 3)
 
-  check: bool(xa == xqya)
+  doAssert: bool(xa == xqya)
 
 suite "Exponentiation in 𝔽p12" & " [" & $WordBitwidth & "-bit mode]":
   staticFor(curve, TestCurves):

--- a/tests/t_fp_tower_template.nim
+++ b/tests/t_fp_tower_template.nim
@@ -256,16 +256,22 @@ proc runTowerTests*[N](
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve)):
           r.prod(x, Z)
-          check: bool(r == Z)
+          doAssert bool(r == Z),
+            "\nExpected zero but got (" & $ExtField(ExtDegree, curve) & "): " & x.toHex()
         test(ExtField(ExtDegree, curve)):
           r.prod(Z, x)
-          check: bool(r == Z)
+          doAssert bool(r == Z),
+            "\nExpected zero but got (" & $ExtField(ExtDegree, curve) & "): " & x.toHex()
         test(ExtField(ExtDegree, curve)):
           r.prod(x, O)
-          check: bool(r == x)
+          doAssert bool(r == x),
+            "\n(" & $ExtField(ExtDegree, curve) & "): Expected one: " & O.toHex() & "\n" &
+            "got: " & x.toHex()
         test(ExtField(ExtDegree, curve)):
           r.prod(O, x)
-          check: bool(r == x)
+          doAssert bool(r == x),
+            "\n(" & $ExtField(ExtDegree, curve) & "): Expected one: " & O.toHex() & "\n" &
+            "got: " & x.toHex()
 
     test "Multiplication and Squaring are consistent":
       proc test(Field: typedesc, Iters: static int, gen: static RandomGen) =
@@ -276,7 +282,9 @@ proc runTowerTests*[N](
           rMul.prod(a, a)
           rSqr.square(a)
 
-          doAssert bool(rMul == rSqr), "Failure with a (" & $Field & "): " & a.toHex()
+          doAssert bool(rMul == rSqr), "Failure with a (" & $Field & "): " & a.toHex() & "\n" &
+            "Mul: " & rMul.toHex() & "\n" &
+            "Sqr: " & rSqr.toHex() & "\n"
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)
@@ -295,7 +303,9 @@ proc runTowerTests*[N](
           rSqr.square(a)
           rNegSqr.square(na)
 
-          doAssert bool(rSqr == rNegSqr), "Failure with a (" & $Field & "): " & a.toHex()
+          doAssert bool(rSqr == rNegSqr), "Failure with a (" & $Field & "): " & a.toHex() & "\n" &
+            "Sqr:    " & rSqr.toHex() & "\n" &
+            "SqrNeg: " & rNegSqr.toHex() & "\n"
 
       staticFor(curve, TestCurves):
         test(ExtField(ExtDegree, curve), Iters, gen = Uniform)


### PR DESCRIPTION
This PR continues the work of double precision towering
- https://github.com/mratsim/constantine/pull/72
- https://github.com/mratsim/constantine/pull/144
- https://github.com/mratsim/constantine/pull/148
- https://github.com/mratsim/constantine/pull/155

Hopefully we get so efficient that even BLS24 curves become interesting.

The first commit improves Fp12 multiplication by 5%, which tranlates to about 4% speedup on pairings.

## Fp12 mul, before

![image](https://user-images.githubusercontent.com/22738317/107580743-514c9680-6bf7-11eb-939d-05601ffa3f61.png)

## Fp12 mul after

![image](https://user-images.githubusercontent.com/22738317/107580780-6295a300-6bf7-11eb-974d-7d1c7a78a1f5.png)
