### PR TITLE
hash-to-curve BLS12-381 perf

### DIFF
--- a/benchmarks/bench_fields_template.nim
+++ b/benchmarks/bench_fields_template.nim
@@ -119,33 +119,37 @@ proc invAddChainBench*(T: typedesc, iters: int) =
 
 proc sqrtBench*(T: typedesc, iters: int) =
   let x = rng.random_unsafe(T)
-  bench("Square Root + isSquare (constant-time default impl)", T, iters):
+  bench("Square Root (constant-time default impl)", T, iters):
     var r = x
-    discard r.sqrt_if_square()
+    discard r.sqrt()
 
 proc sqrtP3mod4Bench*(T: typedesc, iters: int) =
+  var r: T
   let x = rng.random_unsafe(T)
-  bench("SquareRoot + isSquare (p ≡ 3 (mod 4) exponentiation)", T, iters):
-    var r = x
-    discard r.sqrt_if_square_p3mod4()
+  bench("SquareRoot (p ≡ 3 (mod 4) exponentiation)", T, iters):
+    r.invsqrt_p3mod4(x)
+    r *= x
 
 proc sqrtAddChainBench*(T: typedesc, iters: int) =
+  var r: T
   let x = rng.random_unsafe(T)
-  bench("SquareRoot + isSquare (addition chain)", T, iters):
-    var r = x
-    discard r.sqrt_if_square_addchain()
+  bench("SquareRoot (addition chain)", T, iters):
+    r.invsqrt_addchain(x)
+    r *= x
 
 proc sqrtTonelliBench*(T: typedesc, iters: int) =
+  var r: T
   let x = rng.random_unsafe(T)
-  bench("SquareRoot + isSquare (constant-time Tonelli-Shanks exponentiation)", T, iters):
-    var r = x
-    discard r.sqrt_if_square_tonelli_shanks(useAddChain = false)
+  bench("SquareRoot (constant-time Tonelli-Shanks exponentiation)", T, iters):
+    r.invsqrt_tonelli_shanks(x, useAddChain = false)
+    r *= x
 
 proc sqrtTonelliAddChainBench*(T: typedesc, iters: int) =
+  var r: T
   let x = rng.random_unsafe(T)
-  bench("SquareRoot + isSquare (constant-time Tonelli-Shanks addchain)", T, iters):
-    var r = x
-    discard r.sqrt_if_square_tonelli_shanks(useAddChain = true)
+  bench("SquareRoot (constant-time Tonelli-Shanks addchain)", T, iters):
+    r.invsqrt_tonelli_shanks(x, useAddChain = true)
+    r *= x
 
 proc powBench*(T: typedesc, iters: int) =
   let x = rng.random_unsafe(T)

--- a/benchmarks/bench_fields_template.nim
+++ b/benchmarks/bench_fields_template.nim
@@ -119,9 +119,9 @@ proc invAddChainBench*(T: typedesc, iters: int) =
 
 proc sqrtBench*(T: typedesc, iters: int) =
   let x = rng.random_unsafe(T)
-  bench("Square Root (constant-time default impl)", T, iters):
+  bench("Square Root + isSquare (constant-time default impl)", T, iters):
     var r = x
-    discard r.sqrt()
+    discard r.sqrt_if_square()
 
 proc sqrtP3mod4Bench*(T: typedesc, iters: int) =
   var r: T

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -263,26 +263,26 @@ proc runTests(requireGMP: bool, dumpCmdFile = false, test32bit = false, testASM 
         flags &= sanitizers
       test flags, td.path, dumpCmdFile
 
-proc buildAllBenches() =
+proc buildAllBenches(useAsm = true) =
   echo "\n\n------------------------------------------------------\n"
   echo "Building benchmarks to ensure they stay relevant ..."
-  buildBench("bench_fp")
-  buildBench("bench_fp_double_precision")
-  buildBench("bench_fp2")
-  buildBench("bench_fp6")
-  buildBench("bench_fp12")
-  buildBench("bench_ec_g1")
-  buildBench("bench_ec_g2")
-  buildBench("bench_pairing_bls12_377")
-  buildBench("bench_pairing_bls12_381")
-  buildBench("bench_pairing_bn254_nogami")
-  buildBench("bench_pairing_bn254_snarks")
-  buildBench("bench_summary_bls12_377")
-  buildBench("bench_summary_bls12_381")
-  buildBench("bench_summary_bn254_nogami")
-  buildBench("bench_summary_bn254_snarks")
-  buildBench("bench_sha256")
-  buildBench("bench_hash_to_curve")
+  buildBench("bench_fp", useAsm = useAsm)
+  buildBench("bench_fp_double_precision", useAsm = useAsm)
+  buildBench("bench_fp2", useAsm = useAsm)
+  buildBench("bench_fp6", useAsm = useAsm)
+  buildBench("bench_fp12", useAsm = useAsm)
+  buildBench("bench_ec_g1", useAsm = useAsm)
+  buildBench("bench_ec_g2", useAsm = useAsm)
+  buildBench("bench_pairing_bls12_377", useAsm = useAsm)
+  buildBench("bench_pairing_bls12_381", useAsm = useAsm)
+  buildBench("bench_pairing_bn254_nogami", useAsm = useAsm)
+  buildBench("bench_pairing_bn254_snarks", useAsm = useAsm)
+  buildBench("bench_summary_bls12_377", useAsm = useAsm)
+  buildBench("bench_summary_bls12_381", useAsm = useAsm)
+  buildBench("bench_summary_bn254_nogami", useAsm = useAsm)
+  buildBench("bench_summary_bn254_snarks", useAsm = useAsm)
+  buildBench("bench_sha256", useAsm = useAsm)
+  buildBench("bench_hash_to_curve", useAsm = useAsm)
   echo "All benchmarks compile successfully."
 
 # Tasks
@@ -308,7 +308,7 @@ task test_no_assembler, "Run all tests":
 
   # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   if not defined(windows) or not (existsEnv"UCPU" or getEnv"UCPU" == "i686"):
-    buildAllBenches()
+    buildAllBenches(useASM = false)
 
 task test_no_gmp, "Run tests that don't require GMP":
   # -d:testingCurves is configured in a *.nim.cfg for convenience
@@ -357,7 +357,7 @@ task test_parallel_no_assembler, "Run all tests (without macro assembler) in par
   # ignore Windows 32-bit for the moment
   # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   if not defined(windows) or not (existsEnv"UCPU" or getEnv"UCPU" == "i686"):
-    buildAllBenches()
+    buildAllBenches(useASM = false)
 
 task test_parallel_no_gmp, "Run all tests in parallel (via GNU parallel)":
   # -d:testingCurves is configured in a *.nim.cfg for convenience
@@ -395,7 +395,7 @@ task test_parallel_no_gmp_no_assembler, "Run all tests in parallel (via GNU para
   # ignore Windows 32-bit for the moment
   # Ensure benchmarks stay relevant. Ignore Windows 32-bit at the moment
   if not defined(windows) or not (existsEnv"UCPU" or getEnv"UCPU" == "i686"):
-    buildAllBenches()
+    buildAllBenches(useASM = false)
 
 # Finite field 𝔽p
 # ------------------------------------------

--- a/constantine/arithmetic/limbs_montgomery.nim
+++ b/constantine/arithmetic/limbs_montgomery.nim
@@ -398,10 +398,12 @@ func montySquare*[N](r: var Limbs[N], a, M: Limbs[N],
         montSquare_CIOS_asm_adx_bmi2(r, a, M, m0ninv, spareBits >= 1)
     else:
       montSquare_CIOS_asm(r, a, M, m0ninv, spareBits >= 1)
-  else:
+  elif UseASM_X86_64:
     var r2x {.noInit.}: Limbs[2*N]
     r2x.square(a)
     r.montyRedc2x(r2x, M, m0ninv, spareBits)
+  else:
+    montyMul(r, a, a, M, m0ninv, spareBits)
 
 func redc*(r: var Limbs, a, one, M: Limbs,
            m0ninv: static BaseType, spareBits: static int) =

--- a/constantine/curves/bls12_381_g2_hash_to_curve.nim
+++ b/constantine/curves/bls12_381_g2_hash_to_curve.nim
@@ -31,7 +31,7 @@ const BLS12_381_h2c_G2_Z* = Fp2[BLS12_381].fromHex(  # -(2 + 𝑖)
   "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaa9",
   "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaaa"
 )
-const BLS12_381_h2c_G2_minusA* = Fp2[BLS12_381].fromHex(  # -240𝑖
+const BLS12_381_h2c_G2_minus_A* = Fp2[BLS12_381].fromHex(  # -240𝑖
   "0x0",
   "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9bb"
 )
@@ -60,22 +60,22 @@ const BLS12_381_h2c_G2_3_isogeny_map_xnum* = [
   # The polynomial is stored as an array of coefficients ordered from k₀ to kₙ
 
   # 1
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6",
     "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97d6"
   ),
   # x
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x0",
     "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71a"
   ),
   # x^2
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71e",
     "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38d"
   ),
   # x^3
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x171d6541fa38ccfaed6dea691f5fb614cb14b4e7f4e810aa22d6108f142b85757098e38d0f671c7188e2aaaaaaaa5ed1",
     "0x0"
   )
@@ -85,17 +85,17 @@ const BLS12_381_h2c_G2_3_isogeny_map_xden* = [
   # The polynomial is stored as an array of coefficients ordered from k₀ to kₙ
 
   # 1
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x0",
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa63"
   ),
   # x
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0xc",
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa9f"
   ),
   # x^2
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x1",
     "0x0"
   )
@@ -105,22 +105,22 @@ const BLS12_381_h2c_G2_3_isogeny_map_ynum* = [
   # The polynomial is stored as an array of coefficients ordered from k₀ to kₙ
 
   # y
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706",
     "0x1530477c7ab4113b59a4c18b076d11930f7da5d4a07f649bf54439d87d27e500fc8c25ebf8c92f6812cfc71c71c6d706"
   ),
   # x*y
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x0",
     "0x5c759507e8e333ebb5b7a9a47d7ed8532c52d39fd3a042a88b58423c50ae15d5c2638e343d9c71c6238aaaaaaaa97be"
   ),
   # x^2*y
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x11560bf17baa99bc32126fced787c88f984f87adf7ae0c7f9a208c6b4f20a4181472aaa9cb8d555526a9ffffffffc71c",
     "0x8ab05f8bdd54cde190937e76bc3e447cc27c3d6fbd7063fcd104635a790520c0a395554e5c6aaaa9354ffffffffe38f"
   ),
   # x^3*y
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x124c9ad43b6cf79bfbf7043de3811ad0761b0f37a1e26286b0e977c69aa274524e79097a56dc4bd9e1b371c71c718b10",
     "0x0"
   )
@@ -130,22 +130,22 @@ const BLS12_381_h2c_G2_3_isogeny_map_yden* = [
   # The polynomial is stored as an array of coefficients ordered from k₀ to kₙ
 
   # 1
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb",
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb"
   ),
   # x
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x0",
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3"
   ),
   # x^2
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x12",
     "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99"
   ),
   # x^3
-  Fp2[BLS12_381].fromHex( 
+  Fp2[BLS12_381].fromHex(
     "0x1",
     "0x0"
   )

--- a/constantine/ec_shortweierstrass.nim
+++ b/constantine/ec_shortweierstrass.nim
@@ -1,0 +1,31 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#                Short Weierstrass Elliptic Curves
+#
+# ############################################################
+
+import
+  elliptic/[
+    ec_shortweierstrass_affine,
+    ec_shortweierstrass_jacobian,
+    ec_shortweierstrass_projective
+  ]
+
+export ec_shortweierstrass_affine, ec_shortweierstrass_jacobian, ec_shortweierstrass_projective
+
+func projectiveFromJacobian*[F; Tw](
+       prj: var ECP_ShortW_Prj[F, Tw],
+       jac: ECP_ShortW_Jac[F, Tw]) {.inline.} =
+  prj.x.prod(jac.x, jac.z)
+  prj.y = jac.y
+  prj.z.square(jac.z)
+  prj.z *= jac.z
+

--- a/constantine/elliptic/ec_shortweierstrass_affine.nim
+++ b/constantine/elliptic/ec_shortweierstrass_affine.nim
@@ -34,6 +34,11 @@ type
 
   SexticNonResidue* = NonResidue
 
+func `==`*(P, Q: ECP_ShortW_Aff): SecretBool =
+  ## Constant-time equality check
+  result = P.x == Q.x
+  result = result and (P.y == Q.y)
+
 func isInf*(P: ECP_ShortW_Aff): SecretBool =
   ## Returns true if P is an infinity point
   ## and false otherwise

--- a/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
+++ b/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
@@ -203,7 +203,7 @@ func mapToIsoCurve_sswuG2_opt9mod16*[C: static Curve](
   # y numerators
   tv2.square(xd)
   gxd.prod(xd, tv2)                         # gxd = xd³
-  tv2 *= h2CConst(C, G2, Aprime_E2)
+  tv2.mulCheckSparse(h2CConst(C, G2, Aprime_E2))
   gx1.square(x1n)
   gx1 += tv2                                # x1n² + A * xd²
   gx1 *= x1n                                # x1n³ + A * x1n * xd²

--- a/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
+++ b/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
@@ -109,8 +109,7 @@ func invsqrt_if_square[C: static Curve](
     t2 *= NonResidue
     t1 -= t2
 
-  # TODO: implement invsqrt alone
-  result = sqrt_invsqrt_if_square(sqrt = r.c1, invsqrt = t3, t1) # 1/sqrt(a0² - β a1²)
+  result = t3.invsqrt_if_square(t1)    # 1/sqrt(a0² - β a1²)
 
   # If input is not a square in Fp2, multiply by 1/Z³
   inp.prod(a, h2cConst(C, G2, inv_Z3)) # inp = a / Z³
@@ -131,8 +130,7 @@ func invsqrt_if_square[C: static Curve](
   t1.ccopy(t2, t1.isZero())
   t1.div2()    # (a0 ± sqrt(a0² - βa1²))/2
 
-  # TODO: implement invsqrt alone
-  sqrt_invsqrt(sqrt = r.c1, invsqrt = r.c0, t1)
+  r.c0.invsqrt(t1)
 
   r.c1 = inp.c1
   r.c1.div2()

--- a/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
+++ b/constantine/hash_to_curve/h2c_map_to_isocurve_swu.nim
@@ -150,19 +150,22 @@ func invsqrt_if_square[C: static Curve](
 
 func mapToIsoCurve_sswuG2_opt9mod16*[C: static Curve](
        xn, xd, yn: var Fp2[C],
-       u: Fp2[C]) =
+       u: Fp2[C], xd3: var Fp2[C]) =
   ## Given G2, the target prime order subgroup of E2 we want to hash to,
   ## this function maps any field element of Fp2 to E'2
   ## a curve isogenous to E2 using the Simplified Shallue-van de Woestijne method.
   ##
   ## This requires p² ≡ 9 (mod 16).
-  #
-  # Input:
-  # - u, an Fp2 element
-  # Output:
-  # - (xn, xd, yn, yd) such that (x', y') = (xn/xd, yn/yd)
-  #   is a point of E'2
-  # - yd is implied to be 1
+  ##
+  ## Input:
+  ## - u, an Fp2 element
+  ## Output:
+  ## - (xn, xd, yn, yd) such that (x', y') = (xn/xd, yn/yd)
+  ##   is a point of E'2
+  ## - yd is implied to be 1
+  ## Scratchspace:
+  ## - xd3 is temporary scratchspace that will hold xd³
+  ##   after execution (which might be useful for Jacobian coordinate conversion)
   #
   # Paper: https://eprint.iacr.org/2019/403
   # Spec: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#appendix-G.2.3
@@ -173,7 +176,6 @@ func mapToIsoCurve_sswuG2_opt9mod16*[C: static Curve](
   var
     uu {.noInit.}, tv2 {.noInit.}: Fp2[C]
     tv4 {.noInit.}, x2n {.noInit.}, gx1 {.noInit.}: Fp2[C]
-    gxd {.noInit.}: Fp2[C]
     y2 {.noInit.}: Fp2[C]
     e1, e2: SecretBool
 
@@ -182,6 +184,7 @@ func mapToIsoCurve_sswuG2_opt9mod16*[C: static Curve](
   template x1n: untyped = xn
   template y1: untyped = yn
   template Zuu: untyped = x2n
+  template gxd: untyped = xd3
 
   # x numerators
   uu.square(u)                      # uu = u²

--- a/constantine/hash_to_curve/hash_to_curve.nim
+++ b/constantine/hash_to_curve/hash_to_curve.nim
@@ -40,19 +40,18 @@ func mapToIsoCurve_sswuG2_opt9mod16[F; Tw: static Twisted](
   var
     xn{.noInit.}, xd{.noInit.}: F
     yn{.noInit.}: F
+    xd3{.noInit.}: F
 
   mapToIsoCurve_sswuG2_opt9mod16(
     xn, xd,
     yn,
-    u
+    u, xd3
   )
 
   # Convert to Jacobian
-  r.z = xd         # Z = xd
-  r.x.prod(xn, xd) # X = xZ² = xn/xd * xd² = xn*xd
-  r.y.square(xd)
-  r.y *= xd
-  r.y *= yn        # Y = yZ³ = yn * xd³
+  r.z = xd          # Z = xd
+  r.x.prod(xn, xd)  # X = xZ² = xn/xd * xd² = xn*xd
+  r.y.prod(yn, xd3) # Y = yZ³ = yn * xd³
 
 func mapToCurve[F; Tw: static Twisted](
        r: var (ECP_ShortW_Prj[F, Tw] or ECP_ShortW_Jac[F, Tw]),
@@ -69,11 +68,12 @@ func mapToCurve[F; Tw: static Twisted](
     var
       xn{.noInit.}, xd{.noInit.}: F
       yn{.noInit.}: F
+      xd3{.noInit.}: F
 
     mapToIsoCurve_sswuG2_opt9mod16(
       xn, xd,
       yn,
-      u
+      u, xd3
     )
 
     # 2. Map from E'2 to E2

--- a/constantine/hash_to_curve/hash_to_curve.nim
+++ b/constantine/hash_to_curve/hash_to_curve.nim
@@ -107,4 +107,4 @@ func hashToCurve*[
   P[1].mapToCurve(u[1])
 
   output.sum(P[0], P[1])
-  output.clearCofactorReference() # TODO - fast cofactor clear
+  output.clearCofactorFast()

--- a/constantine/hash_to_curve/hash_to_curve.nim
+++ b/constantine/hash_to_curve/hash_to_curve.nim
@@ -11,7 +11,10 @@ import
   ../config/[common, curves],
   ../primitives, ../arithmetic, ../towers,
   ../curves/zoo_hash_to_curve,
-  ../elliptic/ec_shortweierstrass_projective,
+  ../elliptic/[
+    ec_shortweierstrass_projective,
+    ec_shortweierstrass_jacobian,
+  ],
   ./h2c_hash_to_field,
   ./h2c_map_to_isocurve_swu,
   ./cofactors,
@@ -35,7 +38,8 @@ import
 # ----------------------------------------------------------------
 
 func mapToCurve[F; Tw: static Twisted](
-       r: var ECP_ShortW_Prj[F, Tw], u: F) =
+       r: var (ECP_ShortW_Prj[F, Tw] or ECP_ShortW_Jac[F, Tw]),
+       u: F) =
   ## Map an element of the
   ## finite or extension field F
   ## to an elliptic curve E

--- a/constantine/hashes/h_sha256.nim
+++ b/constantine/hashes/h_sha256.nim
@@ -315,14 +315,37 @@ func init*(ctx: var Sha256Context) =
   ctx.buf.setZero()
   ctx.bufIdx = 0
 
-  ctx.H[0] = 0x6a09e667'u32;
-  ctx.H[1] = 0xbb67ae85'u32;
-  ctx.H[2] = 0x3c6ef372'u32;
-  ctx.H[3] = 0xa54ff53a'u32;
-  ctx.H[4] = 0x510e527f'u32;
-  ctx.H[5] = 0x9b05688c'u32;
-  ctx.H[6] = 0x1f83d9ab'u32;
-  ctx.H[7] = 0x5be0cd19'u32;
+  ctx.H[0] = 0x6a09e667'u32
+  ctx.H[1] = 0xbb67ae85'u32
+  ctx.H[2] = 0x3c6ef372'u32
+  ctx.H[3] = 0xa54ff53a'u32
+  ctx.H[4] = 0x510e527f'u32
+  ctx.H[5] = 0x9b05688c'u32
+  ctx.H[6] = 0x1f83d9ab'u32
+  ctx.H[7] = 0x5be0cd19'u32
+
+func initZeroPadded*(ctx: var Sha256Context) =
+  ## Initialize a Sha256 context
+  ## with the result of
+  ## ctx.init()
+  ## ctx.update default(array[BlockSize, byte])
+  #
+  # This work arounds `toOpenArray`
+  # not working in the Nim VM, preventing `sha256.update`
+  # at compile-time
+
+  ctx.msgLen = 64
+  ctx.buf.setZero()
+  ctx.bufIdx = 0
+
+  ctx.H[0] = 0xda5698be'u32
+  ctx.H[1] = 0x17b9b469'u32
+  ctx.H[2] = 0x62335799'u32
+  ctx.H[3] = 0x779fbeca'u32
+  ctx.H[4] = 0x8ce5d491'u32
+  ctx.H[5] = 0xc0d26243'u32
+  ctx.H[6] = 0xbafef9ea'u32
+  ctx.H[7] = 0x1837a9d8'u32
 
 func update*[T: char|byte](ctx: var Sha256Context, message: openarray[T]) =
   ## Append a message to a SHA256 context

--- a/constantine/io/endians.nim
+++ b/constantine/io/endians.nim
@@ -77,8 +77,13 @@ func dumpRawInt*[T: byte|char](
     for i in 0'u ..< L:
       dst[cursor+i] = toByte(src shr ((L-i-1) * 8))
 
-func toBytesBE*(num: SomeUnsignedInt): array[sizeof(num), byte] {.inline.}=
-  ## Convert an integer to an array of bytes
+func asBytesBE*[N: static int](
+       r: var array[N, byte],
+       num: SomeUnsignedInt,
+       pos: static int) {.inline.}=
+  ## Store an integer into an array of bytes
+  ## in big endian representation
   const L = sizeof(num)
+  static: doAssert N - (pos + L) >= 0
   for i in 0 ..< L:
-    result[i] = toByte(num shr ((L-1-i) * 8))
+    r[i] = toByte(num shr ((L-1-i) * 8))

--- a/constantine/isogeny/h2c_isogeny_maps.nim
+++ b/constantine/isogeny/h2c_isogeny_maps.nim
@@ -98,7 +98,7 @@ func h2c_isogeny_map[F](
   ## (rx, ry) with rx = rxn/rxd and ry = ryn/ryd
 
   # xd^e with e in [1, N], for example [xd, xd², xd³]
-  var xd_pow: array[isodegree, F]
+  var xd_pow{.noInit.}: array[isodegree, F]
   xd_pow[0] = xd
   for i in 1 ..< xd_pow.len:
     xd_pow[i].prod(xd_pow[i-1], xd)

--- a/constantine/isogeny/h2c_isogeny_maps.nim
+++ b/constantine/isogeny/h2c_isogeny_maps.nim
@@ -98,10 +98,12 @@ func h2c_isogeny_map[F](
   ## (rx, ry) with rx = rxn/rxd and ry = ryn/ryd
 
   # xd^e with e in [1, N], for example [xd, xd², xd³]
+  static: doAssert isodegree >= 2
   var xd_pow{.noInit.}: array[isodegree, F]
   xd_pow[0] = xd
-  for i in 1 ..< xd_pow.len:
-    xd_pow[i].prod(xd_pow[i-1], xd)
+  xd_pow[1].square(xd_pow[0])
+  for i in 2 ..< xd_pow.len:
+    xd_pow[i].prod(xd_pow[i-1], xd_pow[0])
 
   rxn.poly_eval_horner_scaled(
     xn, xd_pow,
@@ -216,7 +218,7 @@ func h2c_isogeny_map*[F; Tw: static Twisted](
 
   # Z²^e with e in [1, N], for example [Z², Z⁴, Z⁶]
   static: doAssert isodegree >= 2
-  var ZZpow: array[isodegree, F]
+  var ZZpow{.noInit.}: array[isodegree, F]
   ZZpow[0].square(P.z)
   ZZpow[1].square(ZZpow[0])
   for i in 2 ..< ZZpow.len:

--- a/constantine/tower_field_extensions/square_root_fp2.nim
+++ b/constantine/tower_field_extensions/square_root_fp2.nim
@@ -133,10 +133,8 @@ func sqrt_if_square_opt(a: var Fp2): SecretBool =
   t1.ccopy(t2, t1.isZero())
   t1.div2()                           # (a0 ± sqrt(a0² - β a1²))/2
 
-  # TODO: implement invsqrt alone
   # t1 being an actual sqrt will be tested in sqrt_rotate_extension
-  # 1/sqrt((a0 ± sqrt(a0² - β b²))/2)
-  sqrt_invsqrt(sqrt = cand.c1, invsqrt = cand.c0, t1) # we only want invsqrt = cand.c0
+  cand.c0.invsqrt(t1)                 # 1/sqrt((a0 ± sqrt(a0² - β b²))/2)
 
   cand.c1 = a.c1
   cand.c1.div2()

--- a/sage/derive_hash_to_curve.sage
+++ b/sage/derive_hash_to_curve.sage
@@ -181,7 +181,7 @@ def genBLS12381G2_H2C_constants(curve_config):
   buf += field_to_nim(Z, 'Fp2', curve_name, comment_right = "-(2 + 𝑖)")
   buf += '\n'
 
-  buf += f'const {curve_name}_h2c_G2_minusA* = '
+  buf += f'const {curve_name}_h2c_G2_minus_A* = '
   buf += field_to_nim(minus_A, 'Fp2', curve_name, comment_right = "-240𝑖")
   buf += '\n'
 

--- a/tests/t_finite_fields_sqrt.nim
+++ b/tests/t_finite_fields_sqrt.nim
@@ -80,7 +80,6 @@ proc exhaustiveCheck(C: static Curve, modulus: static int) =
         check:
           bool not a.isSquare()
           bool not a.sqrt_if_square()
-          bool (a == a2) # a shouldn't be modified
 
 template testImpl(a: untyped): untyped {.dirty.} =
   var na{.noInit.}: typeof(a)

--- a/tests/t_fp_tower_frobenius_template.nim
+++ b/tests/t_fp_tower_frobenius_template.nim
@@ -61,7 +61,7 @@ proc runFrobeniusTowerTests*[N](
     ) =
   # Random seed for reproducibility
   var rng: RngState
-  let seed = 0 # uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+  let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
   rng.seed(seed)
   echo moduleName, " xoshiro512** seed: ", seed
 


### PR DESCRIPTION
- [x] Fp square no-assembly: split from non-4 non-6 limbs fallback (40% speedup)
- [x] Fast clear cofactor using endomorphism acceleration (5x speedup)
- [x] Fuse mapping 2 points to curve and then adding them
- [x] small optims: noinit, sparse mul
- [x] dedicated invsqrt + cleanup of the squareroot file
- [x] reduce array copies overhead in hash to field  