### PR TITLE
Low-level refactor part 2

### DIFF
--- a/constantine/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
@@ -38,7 +38,7 @@ static: doAssert UseASM_X86_64
 macro mulMont_CIOS_sparebit_gen[N: static int](
         r_PIR: var Limbs[N], a_PIR, b_PIR,
         M_PIR: Limbs[N], m0ninv_REG: BaseType,
-        skipReduction: static bool
+        skipFinalSub: static bool
       ): untyped =
   ## Generate an optimized Montgomery Multiplication kernel
   ## using the CIOS method
@@ -175,7 +175,7 @@ macro mulMont_CIOS_sparebit_gen[N: static int](
   ctx.mov rax, r # move r away from scratchspace that will be used for final substraction
   let r2 = rax.asArrayAddr(len = N)
 
-  if skipReduction:
+  if skipFinalSub:
     for i in 0 ..< N:
       ctx.mov r2[i], t[i]
   else:
@@ -185,14 +185,14 @@ macro mulMont_CIOS_sparebit_gen[N: static int](
     )
   result.add ctx.generate()
 
-func mulMont_CIOS_sparebit_asm*(r: var Limbs, a, b, M: Limbs, m0ninv: BaseType, skipReduction: static bool = false) =
+func mulMont_CIOS_sparebit_asm*(r: var Limbs, a, b, M: Limbs, m0ninv: BaseType, skipFinalSub: static bool = false) =
   ## Constant-time Montgomery multiplication
-  ## If "skipReduction" is set
+  ## If "skipFinalSub" is set
   ## the result is in the range [0, 2M)
   ## otherwise the result is in the range [0, M)
   ## 
   ## This procedure can only be called if the modulus doesn't use the full bitwidth of its underlying representation
-  r.mulMont_CIOS_sparebit_gen(a, b, M, m0ninv, skipReduction)
+  r.mulMont_CIOS_sparebit_gen(a, b, M, m0ninv, skipFinalSub)
 
 # Montgomery Squaring
 # ------------------------------------------------------------
@@ -209,8 +209,8 @@ func squareMont_CIOS_asm*[N](
        r: var Limbs[N],
        a, M: Limbs[N],
        m0ninv: BaseType,
-       hasSpareBit, skipReduction: static bool) =
+       hasSpareBit, skipFinalSub: static bool) =
   ## Constant-time modular squaring
   var r2x {.noInit.}: Limbs[2*N]
   r2x.square_asm_inline(a)
-  r.redcMont_asm_inline(r2x, M, m0ninv, hasSpareBit, skipReduction)
+  r.redcMont_asm_inline(r2x, M, m0ninv, hasSpareBit, skipFinalSub)

--- a/constantine/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
@@ -179,7 +179,7 @@ proc partialRedx(
 macro mulMont_CIOS_sparebit_adx_gen[N: static int](
         r_PIR: var Limbs[N], a_PIR, b_PIR,
         M_PIR: Limbs[N], m0ninv_REG: BaseType,
-        skipReduction: static bool): untyped =
+        skipFinalSub: static bool): untyped =
   ## Generate an optimized Montgomery Multiplication kernel
   ## using the CIOS method
   ## This requires the most significant word of the Modulus
@@ -268,7 +268,7 @@ macro mulMont_CIOS_sparebit_adx_gen[N: static int](
       lo, C
     )
 
-  if skipReduction:
+  if skipFinalSub:
     for i in 0 ..< N:
       ctx.mov r[i], t[i]
   else:
@@ -279,14 +279,14 @@ macro mulMont_CIOS_sparebit_adx_gen[N: static int](
 
   result.add ctx.generate
 
-func mulMont_CIOS_sparebit_asm_adx*(r: var Limbs, a, b, M: Limbs, m0ninv: BaseType, skipReduction: static bool = false) =
+func mulMont_CIOS_sparebit_asm_adx*(r: var Limbs, a, b, M: Limbs, m0ninv: BaseType, skipFinalSub: static bool = false) =
   ## Constant-time Montgomery multiplication
-  ## If "skipReduction" is set
+  ## If "skipFinalSub" is set
   ## the result is in the range [0, 2M)
   ## otherwise the result is in the range [0, M)
   ## 
   ## This procedure can only be called if the modulus doesn't use the full bitwidth of its underlying representation
-  r.mulMont_CIOS_sparebit_adx_gen(a, b, M, m0ninv, skipReduction)
+  r.mulMont_CIOS_sparebit_adx_gen(a, b, M, m0ninv, skipFinalSub)
 
 # Montgomery Squaring
 # ------------------------------------------------------------
@@ -295,8 +295,8 @@ func squareMont_CIOS_asm_adx*[N](
        r: var Limbs[N],
        a, M: Limbs[N],
        m0ninv: BaseType,
-       hasSpareBit, skipReduction: static bool) =
+       hasSpareBit, skipFinalSub: static bool) =
   ## Constant-time modular squaring
   var r2x {.noInit.}: Limbs[2*N]
   r2x.square_asm_adx_inline(a)
-  r.redcMont_asm_adx(r2x, M, m0ninv, hasSpareBit, skipReduction)
+  r.redcMont_asm_adx(r2x, M, m0ninv, hasSpareBit, skipFinalSub)

--- a/constantine/arithmetic/assembly/limbs_asm_redc_mont_x86.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_redc_mont_x86.nim
@@ -34,7 +34,7 @@ macro redc2xMont_gen*[N: static int](
        a_PIR: array[N*2, SecretWord],
        M_PIR: array[N, SecretWord],
        m0ninv_REG: BaseType,
-       hasSpareBit, skipReduction: static bool
+       hasSpareBit, skipFinalSub: static bool
       ) =
 
   # No register spilling handling
@@ -153,7 +153,7 @@ macro redc2xMont_gen*[N: static int](
   # v is invalidated from now on
   let t = repackRegisters(v, u[N], u[N+1])
   
-  if hasSpareBit and skipReduction:
+  if hasSpareBit and skipFinalSub:
     for i in 0 ..< N:
       ctx.mov r[i], t[i]
   elif hasSpareBit:
@@ -170,22 +170,22 @@ func redcMont_asm_inline*[N: static int](
        M: array[N, SecretWord],
        m0ninv: BaseType,
        hasSpareBit: static bool,
-       skipReduction: static bool = false
+       skipFinalSub: static bool = false
       ) {.inline.} =
   ## Constant-time Montgomery reduction
   ## Inline-version
-  redc2xMont_gen(r, a, M, m0ninv, hasSpareBit, skipReduction)
+  redc2xMont_gen(r, a, M, m0ninv, hasSpareBit, skipFinalSub)
 
 func redcMont_asm*[N: static int](
        r: var array[N, SecretWord],
        a: array[N*2, SecretWord],
        M: array[N, SecretWord],
        m0ninv: BaseType,
-       hasSpareBit, skipReduction: static bool
+       hasSpareBit, skipFinalSub: static bool
       ) =
   ## Constant-time Montgomery reduction
   static: doAssert UseASM_X86_64, "This requires x86-64."
-  redcMont_asm_inline(r, a, M, m0ninv, hasSpareBit, skipReduction)
+  redcMont_asm_inline(r, a, M, m0ninv, hasSpareBit, skipFinalSub)
 
 # Montgomery conversion
 # ----------------------------------------------------------
@@ -351,8 +351,8 @@ when isMainModule:
     var a_sqr{.noInit.}, na_sqr{.noInit.}: Limbs[2]
     var a_sqr_comba{.noInit.}, na_sqr_comba{.noInit.}: Limbs[2]
 
-    a_sqr.redcMont_asm(adbl_sqr, M, 1, hasSpareBit = false, skipReduction = false)
-    na_sqr.redcMont_asm(nadbl_sqr, M, 1, hasSpareBit = false, skipReduction = false)
+    a_sqr.redcMont_asm(adbl_sqr, M, 1, hasSpareBit = false, skipFinalSub = false)
+    na_sqr.redcMont_asm(nadbl_sqr, M, 1, hasSpareBit = false, skipFinalSub = false)
     a_sqr_comba.redc2xMont_Comba(adbl_sqr, M, 1)
     na_sqr_comba.redc2xMont_Comba(nadbl_sqr, M, 1)
 

--- a/constantine/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
+++ b/constantine/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
@@ -38,7 +38,7 @@ macro redc2xMont_adx_gen[N: static int](
        a_PIR: array[N*2, SecretWord],
        M_PIR: array[N, SecretWord],
        m0ninv_REG: BaseType,
-       hasSpareBit, skipReduction: static bool
+       hasSpareBit, skipFinalSub: static bool
       ) =
 
   # No register spilling handling
@@ -131,7 +131,7 @@ macro redc2xMont_adx_gen[N: static int](
 
   let t = repackRegisters(v, u[N])
 
-  if hasSpareBit and skipReduction:
+  if hasSpareBit and skipFinalSub:
     for i in 0 ..< N:
       ctx.mov r[i], t[i]
   elif hasSpareBit:
@@ -148,11 +148,11 @@ func redcMont_asm_adx_inline*[N: static int](
        M: array[N, SecretWord],
        m0ninv: BaseType,
        hasSpareBit: static bool,
-       skipReduction: static bool = false
+       skipFinalSub: static bool = false
       ) {.inline.} =
   ## Constant-time Montgomery reduction
   ## Inline-version
-  redc2xMont_adx_gen(r, a, M, m0ninv, hasSpareBit, skipReduction)
+  redc2xMont_adx_gen(r, a, M, m0ninv, hasSpareBit, skipFinalSub)
 
 func redcMont_asm_adx*[N: static int](
        r: var array[N, SecretWord],
@@ -160,10 +160,10 @@ func redcMont_asm_adx*[N: static int](
        M: array[N, SecretWord],
        m0ninv: BaseType,
        hasSpareBit: static bool,
-       skipReduction: static bool = false
+       skipFinalSub: static bool = false
       ) =
   ## Constant-time Montgomery reduction
-  redcMont_asm_adx_inline(r, a, M, m0ninv, hasSpareBit, skipReduction)
+  redcMont_asm_adx_inline(r, a, M, m0ninv, hasSpareBit, skipFinalSub)
 
 
 # Montgomery conversion

--- a/constantine/arithmetic/bigints_montgomery.nim
+++ b/constantine/arithmetic/bigints_montgomery.nim
@@ -24,7 +24,7 @@ import
 #
 # ############################################################
 
-func getMont*(mres: var BigInt, a, N, r2modM: BigInt, m0ninv: static BaseType, spareBits: static int) =
+func getMont*(mres: var BigInt, a, N, r2modM: BigInt, m0ninv: BaseType, spareBits: static int) =
   ## Convert a BigInt from its natural representation
   ## to the Montgomery residue form
   ##
@@ -41,7 +41,7 @@ func getMont*(mres: var BigInt, a, N, r2modM: BigInt, m0ninv: static BaseType, s
   ## and R = (2^WordBitWidth)^W
   getMont(mres.limbs, a.limbs, N.limbs, r2modM.limbs, m0ninv, spareBits)
 
-func fromMont*[mBits](r: var BigInt[mBits], a, M: BigInt[mBits], m0ninv: static BaseType, spareBits: static int) =
+func fromMont*[mBits](r: var BigInt[mBits], a, M: BigInt[mBits], m0ninv: BaseType, spareBits: static int) =
   ## Convert a BigInt from its Montgomery residue form
   ## to the natural representation
   ##
@@ -52,20 +52,20 @@ func fromMont*[mBits](r: var BigInt[mBits], a, M: BigInt[mBits], m0ninv: static 
   fromMont(r.limbs, a.limbs, M.limbs, m0ninv, spareBits)
 
 func mulMont*(r: var BigInt, a, b, M: BigInt, negInvModWord: static BaseType,
-              spareBits: static int, skipReduction: static bool = false) =
+              spareBits: static int, skipFinalSub: static bool = false) =
   ## Compute r <- a*b (mod M) in the Montgomery domain
   ##
   ## This resets r to zero before processing. Use {.noInit.}
   ## to avoid duplicating with Nim zero-init policy
-  mulMont(r.limbs, a.limbs, b.limbs, M.limbs, negInvModWord, spareBits, skipReduction)
+  mulMont(r.limbs, a.limbs, b.limbs, M.limbs, negInvModWord, spareBits, skipFinalSub)
 
 func squareMont*(r: var BigInt, a, M: BigInt, negInvModWord: static BaseType,
-                 spareBits: static int, skipReduction: static bool = false) =
+                 spareBits: static int, skipFinalSub: static bool = false) =
   ## Compute r <- a^2 (mod M) in the Montgomery domain
   ##
   ## This resets r to zero before processing. Use {.noInit.}
   ## to avoid duplicating with Nim zero-init policy
-  squareMont(r.limbs, a.limbs, M.limbs, negInvModWord, spareBits, skipReduction)
+  squareMont(r.limbs, a.limbs, M.limbs, negInvModWord, spareBits, skipFinalSub)
 
 func powMont*[mBits: static int](
        a: var BigInt[mBits], exponent: openarray[byte],

--- a/constantine/arithmetic/finite_fields_square_root.nim
+++ b/constantine/arithmetic/finite_fields_square_root.nim
@@ -194,13 +194,14 @@ func invsqrt_tonelli_shanks_pre(
   t.square(z)
   t *= a
   r = z
-  var b = t
-  var root = Fp.C.tonelliShanks(root_of_unity)
+  var b {.noInit.} = t
+  var root {.noInit.} = Fp.C.tonelliShanks(root_of_unity)
 
   var buf {.noInit.}: Fp
 
   for i in countdown(e, 2, 1):
-    b.square_repeated(i-2)
+    if i-2 >= 1:
+      b.square_repeated(i-2)
 
     let bNotOne = not b.isOne()
     buf.prod(r, root)

--- a/constantine/curves/bls12_377_sqrt.nim
+++ b/constantine/curves/bls12_377_sqrt.nim
@@ -28,7 +28,7 @@ const
 
 func precompute_tonelli_shanks_addchain*(
        r: var Fp[BLS12_377],
-       a: Fp[BLS12_377]) =
+       a: Fp[BLS12_377]) {.addchain.} =
   ## Does a^BLS12_377_TonelliShanks_exponent
   ## via an addition-chain
 

--- a/constantine/curves/bls12_381_sqrt.nim
+++ b/constantine/curves/bls12_381_sqrt.nim
@@ -16,7 +16,7 @@ import
 #
 # ############################################################
 
-func invsqrt_addchain*(r: var Fp[BLS12_381], a: Fp[BLS12_381]) =
+func invsqrt_addchain*(r: var Fp[BLS12_381], a: Fp[BLS12_381]) {.addchain.} =
   var
     x10       {.noInit.}: Fp[BLS12_381]
     x100      {.noInit.}: Fp[BLS12_381]

--- a/constantine/curves/bn254_nogami_sqrt.nim
+++ b/constantine/curves/bn254_nogami_sqrt.nim
@@ -16,7 +16,7 @@ import
 #
 # ############################################################
 
-func invsqrt_addchain*(r: var Fp[BN254_Nogami], a: Fp[BN254_Nogami]) =
+func invsqrt_addchain*(r: var Fp[BN254_Nogami], a: Fp[BN254_Nogami]) {.addchain.} =
   var
     x10 {.noInit.}: Fp[BN254_Nogami]
     x11 {.noInit.}: Fp[BN254_Nogami]

--- a/constantine/curves/bn254_snarks_sqrt.nim
+++ b/constantine/curves/bn254_snarks_sqrt.nim
@@ -16,7 +16,7 @@ import
 #
 # ############################################################
 
-func invsqrt_addchain*(r: var Fp[BN254_Snarks], a: Fp[BN254_Snarks]) =
+func invsqrt_addchain*(r: var Fp[BN254_Snarks], a: Fp[BN254_Snarks]) {.addchain.} =
   var
     x10       {.noInit.}: Fp[BN254_Snarks]
     x11       {.noInit.}: Fp[BN254_Snarks]

--- a/constantine/curves/bw6_761_sqrt.nim
+++ b/constantine/curves/bw6_761_sqrt.nim
@@ -16,7 +16,7 @@ import
 #
 # ############################################################
 
-func invsqrt_addchain*(r: var Fp[BW6_761], a: Fp[BW6_761]) =
+func invsqrt_addchain*(r: var Fp[BW6_761], a: Fp[BW6_761]) {.addchain.} =
   var
     x10       {.noInit.}: Fp[BW6_761]
     x11       {.noInit.}: Fp[BW6_761]

--- a/constantine/elliptic/ec_shortweierstrass_projective.nim
+++ b/constantine/elliptic/ec_shortweierstrass_projective.nim
@@ -220,7 +220,7 @@ func sum*[F; G: static Subgroup](
       t4 *= SexticNonResidue
     x3.sum(P.x, P.z)          # 14. X₃ <- X₁ + Z₁
     y3.sum(Q.x, Q.z)          # 15. Y₃ <- X₂ + Z₂
-    x3 *= y3                  # 16. X₃ <- X₃ Y₃     X₃ = (X₁Z₁)(X₂Z₂)
+    x3 *= y3                  # 16. X₃ <- X₃ Y₃     X₃ = (X₁+Z₁)(X₂+Z₂)
     y3.sum(t0, t2)            # 17. Y₃ <- t₀ + t₂   Y₃ = X₁ X₂ + Z₁ Z₂
     y3.diff(x3, y3)           # 18. Y₃ <- X₃ - Y₃   Y₃ = (X₁ + Z₁)(X₂ + Z₂) - (X₁ X₂ + Z₁ Z₂) = X₁Z₂ + X₂Z₁
     when G == G2 and F.C.getSexticTwist() == D_Twist:

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -84,7 +84,7 @@ The optimizations can be of algebraic, algorithmic or "implementation details" n
   - [ ] NAF recoding
   - [ ] windowed-NAF recoding
   - [ ] SIMD vectorized select in window algorithm
-  - [ ] Montgomery Multiplication with no final substraction,
+  - [x] Montgomery Multiplication with no final substraction,
     - Bos and Montgomery, https://eprint.iacr.org/2017/1057.pdf
       - Colin D Walter, https://colinandmargaret.co.uk/Research/CDW_ELL_99.pdf
       - Hachez and Quisquater, https://link.springer.com/content/pdf/10.1007%2F3-540-44499-8_23.pdf


### PR DESCRIPTION
This builds on top of #175 and closes #133

This accelerates reduces BLS12-381 square root computations cost by ~13.5% 

- Before 
![image](https://user-images.githubusercontent.com/22738317/153861449-6174151e-3a92-4bbe-ac12-1b1d9361bec5.png)
- After 
![image](https://user-images.githubusercontent.com/22738317/153861502-a9ae715c-7e5d-4317-9720-1b44841dfddd.png)

Those are a bottleneck in:
- Signature and Public key decompression (and in Ethereum everything comes from the network compressed), https://github.com/status-im/nimbus-eth2/pull/3387#discussion_r805749053
- hashing a message to the curve for its signature and verification.
  - Hence people are optimizing the heck out of it in Solidity: https://github.com/ChihChengLiang/modexp, used in this optimistic rollup project https://github.com/thehubbleproject/hubble-contracts/blob/cc3aa97d3d47b30516ad73077a8f6e8c6e834bab/contracts/libs/ModExp.sol#L332-L340
- test suite! Creating any random point for fuzzing requires either sqrt or the 5x more expensive scalar multiplication.  And tests already take a while ....

