### PR TITLE
Poly1305 Message Authentication Code

### DIFF
--- a/benchmarks/bench_poly1305.nim
+++ b/benchmarks/bench_poly1305.nim
@@ -1,0 +1,65 @@
+import
+  # Internals
+  ../constantine/mac/mac_poly1305,
+  # Helpers
+  ../helpers/prng_unsafe,
+  ./bench_blueprint,
+  # C API
+  system/ansi_c
+
+proc separator*() = separator(69)
+
+# --------------------------------------------------------------------
+
+proc report(op: string, bytes: int, startTime, stopTime: MonoTime, startClk, stopClk: int64, iters: int) =
+  let ns = inNanoseconds((stopTime-startTime) div iters)
+  let throughput = 1e9 / float64(ns)
+  when SupportsGetTicks:
+    let cycles = (stopClk - startClk) div iters
+    let cyclePerByte = cycles.float64 / bytes.float64
+    echo &"{op:<30}     {throughput:>15.3f} ops/s    {ns:>9} ns/op    {cycles:>10} cycles    {cyclePerByte:>5.2f} cycles/byte"
+  else:
+    echo &"{op:<30}     {throughput:>15.3f} ops/s    {ns:>9} ns/op"
+
+template bench(op: string, bytes: int, iters: int, body: untyped): untyped =
+  measure(iters, startTime, stopTime, startClk, stopClk, body)
+  report(op, bytes, startTime, stopTime, startClk, stopClk, iters)
+
+proc benchPoly1305_constantine[T](msg: openarray[T], msgComment: string, iters: int) =
+  var tag: array[16, byte]
+  let ikm = [
+      byte 0x85, 0xd6, 0xbe, 0x78, 0x57, 0x55, 0x6d, 0x33,
+           0x7f, 0x44, 0x52, 0xfe, 0x42, 0xd5, 0x06, 0xa8,
+           0x01, 0x03, 0x80, 0x8a, 0xfb, 0x0d, 0xb2, 0xfd,
+           0x4a, 0xbf, 0xf6, 0xaf, 0x41, 0x49, 0xf5, 0x1b
+    ]
+  bench("Poly1305 - Constantine - " & msgComment, msg.len, iters):
+    poly1305.auth(tag, msg, ikm)
+
+when isMainModule:
+  proc main() =
+    block:
+      let msg32B = rng.random_byte_seq(32)
+      benchPoly1305_constantine(msg32B, "32B", 100)
+    block:
+      let msg64B = rng.random_byte_seq(64)
+      benchPoly1305_constantine(msg64B, "64B", 100)
+    block:
+      let msg128B = rng.random_byte_seq(128)
+      benchPoly1305_constantine(msg128B, "128B", 100)
+    block:
+      let msg576B = rng.random_byte_seq(576)
+      benchPoly1305_constantine(msg576B, "576B", 50)
+    block:
+      let msg8192B = rng.random_byte_seq(8192)
+      benchPoly1305_constantine(msg8192B, "8192B", 25)
+    block:
+      let msg1MB = rng.random_byte_seq(1_000_000)
+      benchPoly1305_constantine(msg1MB, "1MB", 16)
+    block:
+      let msg10MB = rng.random_byte_seq(10_000_000)
+      benchPoly1305_constantine(msg10MB, "10MB", 16)
+    block:
+      let msg100MB = rng.random_byte_seq(100_000_000)
+      benchPoly1305_constantine(msg100MB, "100MB", 3)
+  main()

--- a/benchmarks/bench_sha256.nim
+++ b/benchmarks/bench_sha256.nim
@@ -69,17 +69,33 @@ proc benchSHA256_openssl[T](msg: openarray[T], msgComment: string, iters: int) =
 when isMainModule:
   proc main() =
     block:
-      let msg128B = rng.random_byte_seq(32)
-      benchSHA256_constantine(msg128B, "32B", 32)
-      benchSHA256_openssl(msg128B, "32B", 32)
+      let msg32B = rng.random_byte_seq(32)
+      benchSHA256_constantine(msg32B, "32B", 100)
+      benchSHA256_openssl(msg32B, "32B", 100)
+    block:
+      let msg64B = rng.random_byte_seq(64)
+      benchSHA256_constantine(msg64B, "64B", 100)
+      benchSHA256_openssl(msg64B, "64B", 100)
     block:
       let msg128B = rng.random_byte_seq(128)
-      benchSHA256_constantine(msg128B, "128B", 128)
-      benchSHA256_openssl(msg128B, "128B", 128)
+      benchSHA256_constantine(msg128B, "128B", 100)
+      benchSHA256_openssl(msg128B, "128B", 100)
     block:
-      let msg5MB = rng.random_byte_seq(5_000_000)
-      benchSHA256_constantine(msg5MB, "5MB", 16)
-      benchSHA256_openssl(msg5MB, "5MB", 16)
+      let msg576B = rng.random_byte_seq(576)
+      benchSHA256_constantine(msg576B, "576B", 50)
+      benchSHA256_openssl(msg576B, "576B", 50)
+    block:
+      let msg8192B = rng.random_byte_seq(8192)
+      benchSHA256_constantine(msg8192B, "8192B", 25)
+      benchSHA256_openssl(msg8192B, "8192B", 25)
+    block:
+      let msg1MB = rng.random_byte_seq(1_000_000)
+      benchSHA256_constantine(msg1MB, "1MB", 16)
+      benchSHA256_openssl(msg1MB, "1MB", 16)
+    block:
+      let msg10MB = rng.random_byte_seq(10_000_000)
+      benchSHA256_constantine(msg10MB, "10MB", 16)
+      benchSHA256_openssl(msg10MB, "10MB", 16)
     block:
       let msg100MB = rng.random_byte_seq(100_000_000)
       benchSHA256_constantine(msg100MB, "100MB", 3)

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -192,6 +192,10 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ----------------------------------------------------------
   ("tests/t_cipher_chacha20.nim", false),
 
+  # Message Authentication Code
+  # ----------------------------------------------------------
+  ("tests/t_mac_poly1305.nim", false),
+
   # Protocols
   # ----------------------------------------------------------
   ("tests/t_ethereum_evm_precompiles.nim", false),

--- a/constantine/hashes.nim
+++ b/constantine/hashes.nim
@@ -58,7 +58,7 @@ func hash*[DigestSize: static int, T: char|byte](
 func hash*[T: char|byte](
        HashKind: type CryptoHash,
        message: openarray[T],
-       clearmem = false): array[HashKind.sizeInBytes, byte] =
+       clearmem = false): array[HashKind.sizeInBytes, byte] {.noInit.} =
   ## Produce a digest from a message
   HashKind.hash(result, message, clearMem)
 

--- a/constantine/hashes/h_sha256.nim
+++ b/constantine/hashes/h_sha256.nim
@@ -51,10 +51,6 @@ type
 {.push raises: [].}
 {.push checks: off.}
 
-func setZero[N](a: var array[N, SomeNumber]){.inline.} =
-  for i in 0 ..< a.len:
-    a[i] = 0
-
 template rotr(x, n: uint32): uint32 =
   ## Rotate right the bits
   # We always use it with constants in 0 ..< 32
@@ -272,24 +268,6 @@ func dumpHash(
     digest.dumpRawInt(H[i], dstIdx, bigEndian)
     dstIdx += uint sizeof(uint32)
 
-func copy[N: static int, T: byte|char](
-       dst: var array[N, byte],
-       dStart: SomeInteger,
-       src: openArray[T],
-       sStart: SomeInteger,
-       len: SomeInteger
-     ) =
-  ## Copy dst[dStart ..< dStart+len] = src[sStart ..< sStart+len]
-  ## Unlike the standard library, this cannot throw
-  ## even a defect.
-  ## It also handles copy of char into byte arrays
-  debug:
-    doAssert 0 <= dStart and dStart+len <= dst.len.uint
-    doAssert 0 <= sStart and sStart+len <= src.len.uint
-
-  for i in 0 ..< len:
-    dst[dStart + i] = byte src[sStart + i]
-
 func hashBuffer(ctx: var Sha256Context) =
   discard ctx.H.hashMessageBlocks(ctx.buf)
   ctx.buf.setZero()
@@ -445,4 +423,7 @@ func clear*(ctx: var Sha256Context) =
   ## For passwords and secret keys, you MUST NOT use raw SHA-256
   ## use a Key Derivation Function instead (KDF)
   # TODO: ensure compiler cannot optimize the code away
+  ctx.H.setZero()
   ctx.buf.setZero()
+  ctx.msgLen = 0
+  ctx.bufIdx = 0

--- a/constantine/mac/mac_poly1305.nim
+++ b/constantine/mac/mac_poly1305.nim
@@ -1,0 +1,324 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../platforms/abstractions,
+  ../math/arithmetic/bigints,
+  ../math/arithmetic/limbs_extmul,
+  ../math/arithmetic/assembly/limbs_asm_modular_x86,
+  ../math/io/io_bigints
+
+
+import # debug
+  ../math/arithmetic/[limbs_division, limbs],
+  ../math/config/type_bigint
+
+# ############################################################
+#
+#               Poly1305 Message Authentication Code
+#
+# ############################################################
+
+const P1305 = BigInt[130].fromHex"0x3fffffffffffffffffffffffffffffffb"
+
+# # TODO: fast reduction
+# func partialReduce_1305[N1, N2: static int](r: var Limbs[N1], a: Limbs[N2]) =
+#   ## The prime 2¹³⁰-5 has a special form 2ᵐ-c
+#   ## called "Crandall prime" or Pseudo-Mersenne Prime
+#   ## in the litterature
+#   ## which allows fast reduction from the fact that
+#   ##        2ᵐ-c ≡  0     (mod p)
+#   ##   <=>  2ᵐ   ≡  c     (mod p)   [1]
+#   ##   <=> a2ᵐ+b ≡ ac + b (mod p)
+#   ## 
+#   ## This partially reduces the input in range [0, 2¹³⁰)
+#   ##
+#   ## Assuming 64-bit words,
+#   ##   N1 = 3 words (192-bit necessary for 2¹³⁰-5)
+#   ##   N2 = 5 words (320-bit necessary for 2²⁶⁰-5*2¹³⁰+25)
+#   ## Assuming 32-bit words,
+#   ##   N1 = 5 words (160-bit necessary for 2¹³⁰-5)
+#   ##   N2 = 9 words (288-bit necessary for 2²⁶⁰-5*2¹³⁰+25)
+#   ## 
+#   ## from 64-bit, starting from [1]
+#   ##   2ᵐ      ≡  c     (mod p)
+#   ##   2¹³⁰    ≡  5     (mod p)
+#   ## 2¹³⁰.2⁶²  ≡  5.2⁶² (mod p)
+#   ##   2¹⁹²    ≡  5.2⁶² (mod p)
+#   ## 
+#   ## Hence if we call a the [2¹⁹², 2²⁶⁰) range
+#   ## and b the [0, 2¹⁹²) range
+#   ## we have
+#   ## a2¹⁹²+b ≡ a.5.2⁶² + b (mod p)
+#   ## 
+#   ## Then we can handle the highest word which has
+#   ## 62 bits that should be folded back as well
+#   ## 
+#   ## Similarly for 32-bit
+#   ##   2¹⁶⁰    ≡  5.2³⁰ (mod p)
+#   ## and we need to fold back the top 30 bits
+#   const bits = 130
+#   const c = SecretWord 5
+#   const excessBits = wordsRequired(bits)*WordBitWidth - bits
+#   const cExcess = c shl excessBits # Unfortunately on 64-bit 5.2⁶² requires 65-bit :/ 
+
+#   static: doAssert excessBits == 62
+
+#   r.setZero() # debug
+#   var hi: SecretWord
+
+#   # First reduction pass, fold everything greater than 2¹⁹² (or 2¹⁶⁰)
+#   # into the lower bits
+#   muladd1(hi, r[0], a[N1], cExcess, a[0])
+#   staticFor i, 1, N2-N1:
+#     muladd2(hi, r[i], a[i+N1], cExcess, a[i], hi)
+
+
+#   # Since for Poly1305 N2 < 2*N1, there is no carry for the last limb
+#   static: doAssert N2 < 2*N1
+#   hi += a[N1-1]
+#   # Now `hi` stores a'.2¹³⁰ + b'.
+#   # a' should be folded back to the lower bits
+#   # After folding, the result is in range [0, 2¹³⁰)
+
+#   # b': Mask out the top bits that will be folded
+#   r[N1-1] = hi and (MaxWord shr excessBits)
+#   # a': Fold the top bits into lower bits
+#   hi = hi shr (WordBitwidth - excessBits)
+#   hi *= c # Cannot overflow
+
+#   # Second pass, fold everything greater than 2¹³⁰-1
+#   # into the lower bits
+#   var carry: Carry
+#   addC(carry, r[0], r[0], hi, Carry(0))
+#   staticFor i, 1, N1:
+#     addC(carry, r[i], r[i], Zero, carry)
+
+# func finalReduce_1305[N: static int](a: var Limbs[N]) =
+#   ## Maps an input in redundant representation [0, 2¹³¹-10)
+#   ## to the canonical representation in [0, 2¹³⁰-5)
+#   # Algorithm:
+#   # 1. substract p = 2¹³⁰-5
+#   # 2. if borrow, add back p.
+#   when UseASM_X86_32 and a.len <= 6:
+#     submod_asm(a, a, P1305.limbs, P1305.limbs)
+#   else:
+#     let underflowed = sub(a, P1305.limbs)
+#     discard cadd(a, P1305.limbs, underflowed)
+
+const BlockSize = 16
+
+type Poly1305_CTX = object
+  acc: BigInt[130]
+  r, s: BigInt[128]
+  buf: array[BlockSize, byte]
+  msgLen: uint64
+  bufIdx: uint8
+
+type poly1305* = Poly1305_CTX
+
+func macMessageBlocks[T: byte|char](
+       acc: var BigInt[130],
+       r: BigInt[128],
+       message: openArray[T],
+       blockSize = BlockSize): uint =
+  ## Authenticate a message block by block
+  ## Poly1305 block size is 16 bytes.
+  ## Return the number of bytes processed.
+  ##
+  ## If hashing one partial block,
+  ## set blocksize to the remaining bytes to process
+
+  result = 0
+  let numBlocks = int(message.len.uint div BlockSize)
+  if numBlocks == 0:
+    return 0
+
+  # Ensure there is a spare bit to handle carries when adding 2 numbers
+  const bits = 130
+  const excessBits = wordsRequired(bits)*WordBitWidth - bits
+  
+   # acc+input can use up to 131-bit
+  static: doAssert excessBits >= 1
+
+  var input {.noInit.}: BigInt[130]
+  # r is 128-bit
+  var t{.noInit.}: BigInt[131+128]
+
+  for curBlock in 0 ..< numBlocks:
+    # range [0, 2¹²⁸-1)
+    when T is byte:
+      input.unmarshal(
+        message.toOpenArray(curBlock*BlockSize, curBlock*BlockSize + BlockSize - 1),
+        littleEndian
+      )
+    else:
+      input.unmarshal(
+        message.toOpenArrayByte(curBlock*BlockSize, curBlock*BlockSize + BlockSize - 1),
+        littleEndian
+      )
+    input.setBit(8*blockSize) # range [2¹²⁸, 2¹²⁸+2¹²⁸-1)
+    acc += input              # range [2¹²⁸, 2¹³⁰-1+2¹²⁸+2¹²⁸-1)
+    t.prod(acc, r)            # range [2²⁵⁶, (2¹²⁸-1)(2¹³⁰+2(2¹²⁸-1)))
+    
+    # TODO: fast reduction
+    acc.limbs.reduce(t.limbs, 131+128, P1305.limbs, 130)
+
+  return BlockSize * numBlocks.uint
+
+func macBuffer(ctx: var Poly1305_CTX, blockSize: int) =
+  discard ctx.acc.macMessageBlocks(
+    ctx.r, ctx.buf, blockSize
+  )
+  ctx.buf.setZero()
+  ctx.bufIdx = 0
+
+# Public API
+# ----------------------------------------------------------------
+
+func init*(ctx: var Poly1305_CTX, nonReusedKey: array[32, byte]) =
+  ## Initialize Poly1305 MAC (Message Authentication Code) context.
+  ## nonReusedKey is an unique not-reused pre-shared key
+  ## between the parties that want to authenticate messages between each other
+  ctx.acc.setZero()
+  
+  const clamp = BigInt[128].fromHex"0x0ffffffc0ffffffc0ffffffc0fffffff"
+  ctx.r.unmarshal(nonReusedKey.toOpenArray(0, 15), littleEndian)
+  staticFor i, 0, ctx.r.limbs.len:
+    ctx.r.limbs[i] = ctx.r.limbs[i] and clamp.limbs[i]
+
+  ctx.s.unmarshal(nonReusedKey.toOpenArray(16, 31), littleEndian)
+  ctx.buf.setZero()
+  ctx.msgLen = 0
+  ctx.bufIdx = 0
+
+func update*[T: char|byte](ctx: var Poly1305_CTX, message: openArray[T]) =
+  ## Append a message to a Poly1305 authentication context.
+  ## for incremental Poly1305 computation
+  ##
+  ## Security note: the tail of your message might be stored
+  ## in an internal buffer.
+  ## if sensitive content is used, ensure that
+  ## `ctx.finish(...)` and `ctx.clear()` are called as soon as possible.
+  ## Additionally ensure that the message(s) passed were stored
+  ## in memory considered secure for your threat model.
+
+  debug:
+    doAssert: 0 <= ctx.bufIdx and ctx.bufIdx.int < ctx.buf.len
+    for i in ctx.bufIdx ..< ctx.buf.len:
+      doAssert ctx.buf[i] == 0
+
+  if message.len == 0:
+    return
+
+  var # Message processing state machine
+    cur = 0'u
+    bytesLeft = message.len.uint
+  
+  ctx.msgLen += bytesLeft
+
+  if ctx.bufIdx != 0: # Previous partial update
+    let bufIdx = ctx.bufIdx.uint
+    let free = ctx.buf.sizeof().uint - bufIdx
+
+    if free > bytesLeft:
+      # Enough free space, store in buffer
+      ctx.buf.copy(dStart = bufIdx, message, sStart = 0, len = bytesLeft)
+      ctx.bufIdx += bytesLeft.uint8
+      return
+    else:
+      # Fill the buffer and do one sha256 hash
+      ctx.buf.copy(dStart = bufIdx, message, sStart = 0, len = free)
+      ctx.macBuffer(blockSize = BlockSize)
+
+      # Update message state for further processing
+      cur = free
+      bytesLeft -= free
+  
+  # Process n blocks (16 bytes each)
+  let consumed = ctx.acc.macMessageBlocks(
+    ctx.r, 
+    message.toOpenArray(int cur, message.len-1),
+    blockSize = BlockSize
+  )
+  cur += consumed
+  bytesLeft -= consumed
+
+  if bytesLeft != 0:
+    # Store the tail in buffer
+    debug: # TODO: state machine formal verification - https://nim-lang.org/docs/drnim.html
+      doAssert ctx.bufIdx == 0
+      doAssert cur + bytesLeft == message.len.uint
+
+    ctx.buf.copy(dStart = 0'u, message, sStart = cur, len = bytesLeft)
+    ctx.bufIdx = uint8 bytesLeft
+
+func finish*(ctx: var Poly1305_CTX, tag: var array[16, byte]) =
+  ## Finalize a Poly1305 authentication
+  ## and output an authentication tag to the `tag` buffer
+  ##
+  ## Security note: this does not clear the internal context.
+  ## if sensitive content is used, use "ctx.clear()"
+  ## and also make sure that the message(s) passed were stored
+  ## in memory considered secure for your threat model.
+
+  debug:
+    doAssert: 0 <= ctx.bufIdx and ctx.bufIdx.int < ctx.buf.len
+    for i in ctx.bufIdx ..< ctx.buf.len:
+      doAssert ctx.buf[i] == 0
+
+  if ctx.bufIdx != 0:
+    ctx.macBuffer(blockSize = ctx.bufIdx.int)
+  
+  # Starting from now, we only care about the 128 least significant bits
+  var acc128{.noInit.}: BigInt[128]
+  acc128.copyTruncatedFrom(ctx.acc)
+  acc128 += ctx.s
+
+  tag.marshal(acc128, littleEndian)
+
+  debug:
+    doAssert ctx.bufIdx == 0
+    for i in 0 ..< ctx.buf.len:
+      doAssert ctx.buf[i] == 0
+
+func clear*(ctx: var Poly1305_CTX) =
+  ## Clear the context internal buffers
+  # TODO: ensure compiler cannot optimize the code away
+  ctx.acc.setZero()
+  ctx.r.setZero()
+  ctx.s.setZero()
+  ctx.buf.setZero()
+  ctx.msgLen = 0
+  ctx.bufIdx = 0
+
+func authenticate*[T: char, byte](
+       _: type poly1305,
+       tag: var array[16, byte],
+       message: openArray[T],
+       nonReusedKey: array[32, byte],
+       clearMem = false) =
+  ## Produce an authentication tag from a message
+  ## and a preshared unique non-reused secret key
+  
+  var ctx {.noInit.}: poly1305
+  ctx.init(nonReusedKey)
+  ctx.update(message)
+  ctx.finish(tag)
+
+  if clearMem:
+    ctx.clear()
+
+func authenticate*[T: char, byte](
+       _: type poly1305,
+       message: openArray[T],
+       nonReusedKey: array[32, byte],
+       clearMem = false): array[16, byte]{.noInit.}=
+  ## Produce an authentication tag from a message
+  ## and a preshared unique non-reused secret key
+  poly1305.authenticate(result, message, nonReusedKey, clearMem)

--- a/constantine/mac/mac_poly1305.nim
+++ b/constantine/mac/mac_poly1305.nim
@@ -9,14 +9,14 @@
 import
   ../platforms/abstractions,
   ../math/arithmetic/bigints,
-  ../math/arithmetic/limbs_extmul,
-  ../math/arithmetic/assembly/limbs_asm_modular_x86,
+  ../math/arithmetic/[limbs, limbs_extmul],
   ../math/io/io_bigints
 
+when UseASM_X86_64:
+  import ../math/arithmetic/assembly/limbs_asm_modular_x86
 
-import # debug
-  ../math/arithmetic/[limbs_division, limbs],
-  ../math/config/type_bigint
+# No exceptions allowed
+{.push raises: [].}
 
 # ############################################################
 #

--- a/constantine/math/arithmetic/bigints.nim
+++ b/constantine/math/arithmetic/bigints.nim
@@ -344,6 +344,16 @@ func bit0*(a: BigInt): Ct[uint8] =
   ## Access the least significant bit
   ct(a.limbs[0] and One, uint8)
 
+func setBit*[bits: static int](a: var BigInt[bits], index: int) =
+  ## Set an individual bit of `a` to 1.
+  ## This has no effect if it is already 1
+  const SlotShift = log2_vartime(WordBitWidth.uint32)
+  const SelectMask = WordBitWidth - 1
+
+  let slot = a.limbs[index shr SlotShift].addr
+  let shifted = One shl (index and SelectMask)
+  slot[] = slot[] or shifted
+
 # Multiplication by small cosntants
 # ------------------------------------------------------------
 

--- a/constantine/platforms/abstractions.nim
+++ b/constantine/platforms/abstractions.nim
@@ -57,13 +57,3 @@ const
 const CttASM {.booldefine.} = true
 const UseASM_X86_32* = CttASM and X86 and GCC_Compatible
 const UseASM_X86_64* = WordBitWidth == 64 and UseASM_X86_32
-
-# ############################################################
-#
-#                  Instrumentation
-#
-# ############################################################
-
-template debug*(body: untyped): untyped =
-  when defined(debugConstantine):
-    body

--- a/constantine/platforms/constant_time/ct_routines.nim
+++ b/constantine/platforms/constant_time/ct_routines.nim
@@ -104,6 +104,11 @@ template `*`*[T: Ct](x, y: T): T =
   # but this is not always true, especially on ARMv7 and ARMv9
   fmap(x, `*`, y)
 
+template `*=`*[T: Ct](x, y: T) =
+  # Warning ⚠️ : We assume that mul hardware multiplication is constant time
+  # but this is not always true, especially on ARMv7 and ARMv9
+  fmapAsgn(x, `*=`, y)
+
 # We don't implement div/mod as we can't assume the hardware implementation
 # is constant-time
 

--- a/constantine/platforms/primitives.nim
+++ b/constantine/platforms/primitives.nim
@@ -33,3 +33,41 @@ export
 when X86 and GCC_Compatible:
   import isa/[cpuinfo_x86, macro_assembler_x86]
   export cpuinfo_x86, macro_assembler_x86
+
+# ############################################################
+#
+#                      Instrumentation
+#
+# ############################################################
+
+template debug*(body: untyped): untyped =
+  when defined(debugConstantine):
+    body
+
+# ############################################################
+#
+#                         Buffers
+#
+# ############################################################
+
+func setZero*[N](a: var array[N, SomeNumber]){.inline.} =
+  for i in 0 ..< a.len:
+    a[i] = 0
+
+func copy*[N: static int, T: byte|char](
+       dst: var array[N, byte],
+       dStart: SomeInteger,
+       src: openArray[T],
+       sStart: SomeInteger,
+       len: SomeInteger
+     ) {.inline.} =
+  ## Copy dst[dStart ..< dStart+len] = src[sStart ..< sStart+len]
+  ## Unlike the standard library, this cannot throw
+  ## even a defect.
+  ## It also handles copy of char into byte arrays
+  debug:
+    doAssert 0 <= dStart and dStart+len <= dst.len.uint, "dStart: " & $dStart & ", dStart+len: " & $(dStart+len) & ", dst.len: " & $dst.len
+    doAssert 0 <= sStart and sStart+len <= src.len.uint, "sStart: " & $sStart & ", sStart+len: " & $(sStart+len) & ", src.len: " & $src.len
+
+  for i in 0 ..< len:
+    dst[dStart + i] = byte src[sStart + i]

--- a/tests/t_mac_poly1305.nim
+++ b/tests/t_mac_poly1305.nim
@@ -26,6 +26,6 @@ suite "[Message Authentication Code] Poly1305":
     ]
 
     var tag: array[16, byte]
-    poly1305.authenticate(tag, message, ikm)
+    poly1305.auth(tag, message, ikm)
 
     doAssert tag == expectedTag

--- a/tests/t_mac_poly1305.nim
+++ b/tests/t_mac_poly1305.nim
@@ -1,0 +1,31 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/unittest,
+  ../constantine/mac/mac_poly1305
+
+suite "[Message Authentication Code] Poly1305":
+  test "Test vector 1 - RFC8439":
+    let ikm = [
+      byte 0x85, 0xd6, 0xbe, 0x78, 0x57, 0x55, 0x6d, 0x33,
+           0x7f, 0x44, 0x52, 0xfe, 0x42, 0xd5, 0x06, 0xa8,
+           0x01, 0x03, 0x80, 0x8a, 0xfb, 0x0d, 0xb2, 0xfd,
+           0x4a, 0xbf, 0xf6, 0xaf, 0x41, 0x49, 0xf5, 0x1b
+    ]
+    let message = "Cryptographic Forum Research Group"
+
+    let expectedTag = [
+      byte 0xa8, 0x06, 0x1d, 0xc1, 0x30, 0x51, 0x36, 0xc6,
+           0xc2, 0x2b, 0x8b, 0xaf, 0x0c, 0x01, 0x27, 0xa9
+    ]
+
+    var tag: array[16, byte]
+    poly1305.authenticate(tag, message, ikm)
+
+    doAssert tag == expectedTag


### PR DESCRIPTION
This adds a 1-1 translation of the spec https://datatracker.ietf.org/doc/html/rfc8439 for Poly1305.

No optimization done besides exploiting the fact that 2¹³⁰-5 is pseudo-Mersenne for fast reduction.

In particular, the last limbs has 62 bits unused which can be repurposed for an unsaturated representation that doesn't need to be slowed down by carry dependency chains.

Future TODO:
- Implement Chacha20+Poly1305 AEAD
- Optimized Poly1305 and vectorized Poly1305
- Find out how to call OpenSSL internal implementation for differential fuzzing