### PR TITLE
Pasta curves

### DIFF
--- a/benchmarks/bench_ec_g1.nim
+++ b/benchmarks/bench_ec_g1.nim
@@ -37,6 +37,8 @@ const AvailableCurves = [
   # Edwards25519,
   # P256,
   # Secp256k1,
+  Pallas,
+  Vesta,
   BLS12_377,
   BLS12_381,
 ]

--- a/benchmarks/bench_summary_pasta.nim
+++ b/benchmarks/bench_summary_pasta.nim
@@ -10,60 +10,49 @@ import
   # Internals
   ../constantine/math/config/curves,
   ../constantine/math/arithmetic,
-  ../constantine/math/io/io_bigints,
-  ../constantine/math/curves/zoo_square_roots,
+  ../constantine/math/extension_fields,
   # Helpers
   ../helpers/static_for,
-  ./bench_fields_template
+  ./bench_summary_template,
+  # Standard library
+  std/strutils
 
 # ############################################################
 #
-#                  Benchmark of 𝔽p
+#            Benchmark of Pallas and Vesta curves
 #
 # ############################################################
 
 
-const Iters = 100_000
-const ExponentIters = 100
+const Iters = 5000
 const AvailableCurves = [
-  # P224,
-  BN254_Nogami,
-  BN254_Snarks,
-  Edwards25519,
-  Bandersnatch,
-  Pallas,
-  Vesta,
-  P256,
-  Secp256k1,
-  BLS12_377,
-  BLS12_381,
-  BW6_761
+  Pallas, Vesta
 ]
+
 
 proc main() =
   separator()
   staticFor i, 0, AvailableCurves.len:
     const curve = AvailableCurves[i]
-    addBench(Fp[curve], Iters)
-    subBench(Fp[curve], Iters)
-    negBench(Fp[curve], Iters)
-    ccopyBench(Fp[curve], Iters)
-    div2Bench(Fp[curve], Iters)
+
+    mulBench(Fr[curve], Iters)
+    sqrBench(Fr[curve], Iters)
+    separator()
     mulBench(Fp[curve], Iters)
     sqrBench(Fp[curve], Iters)
-    smallSeparator()
-    mulUnrBench(Fp[curve], Iters)
-    sqrUnrBench(Fp[curve], Iters)
-    smallSeparator()
-    toBigBench(Fp[curve], Iters)
-    toFieldBench(Fp[curve], Iters)
-    smallSeparator()
-    invBench(Fp[curve], ExponentIters)
-    sqrtBench(Fp[curve], ExponentIters)
-    sqrtRatioBench(Fp[curve], ExponentIters)
-    # Exponentiation by a "secret" of size ~the curve order
-    powBench(Fp[curve], ExponentIters)
-    powUnsafeBench(Fp[curve], ExponentIters)
+    invBench(Fp[curve], Iters)
+    sqrtBench(Fp[curve], Iters)
+    separator()
+    addBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    mixedAddBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    doublingBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    separator()
+    addBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    mixedAddBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    doublingBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    separator()
+    scalarMulBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    scalarMulBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
     separator()
 
 main()

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -146,6 +146,8 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/math/t_ec_sage_bn254_snarks.nim", false),
   ("tests/math/t_ec_sage_bls12_377.nim", false),
   ("tests/math/t_ec_sage_bls12_381.nim", false),
+  ("tests/math/t_ec_sage_pallas.nim", false),
+  ("tests/math/t_ec_sage_vesta.nim", false),
   # Edge cases highlighted by past bugs
   # ----------------------------------------------------------
   ("tests/math/t_ec_shortw_prj_edge_cases.nim", false),
@@ -731,6 +733,23 @@ task bench_summary_bn254_snarks_gcc_noasm, "Run summary benchmarks for BN254-Sna
 
 task bench_summary_bn254_snarks_clang_noasm, "Run summary benchmarks for BN254-Snarks - Clang no Assembly":
   runBench("bench_summary_bn254_snarks", "clang", useAsm = false)
+
+# --
+
+task bench_summary_pasta, "Run summary benchmarks for the Pasta curves - Default compiler":
+  runBench("bench_summary_pasta")
+
+task bench_summary_pasta_gcc, "Run summary benchmarks for the Pasta curves - GCC":
+  runBench("bench_summary_pasta", "gcc")
+
+task bench_summary_pasta_clang, "Run summary benchmarks for the Pasta curves - Clang":
+  runBench("bench_summary_pasta", "clang")
+
+task bench_summary_pasta_gcc_noasm, "Run summary benchmarks for the Pasta curves - GCC no Assembly":
+  runBench("bench_summary_pasta", "gcc", useAsm = false)
+
+task bench_summary_pasta_clang_noasm, "Run summary benchmarks for the Pasta curves - Clang no Assembly":
+  runBench("bench_summary_pasta", "clang", useAsm = false)
 
 # Hashes
 # ------------------------------------------

--- a/constantine/math/arithmetic/finite_fields.nim
+++ b/constantine/math/arithmetic/finite_fields.nim
@@ -508,6 +508,13 @@ func `*=`*(a: var FF, b: static int) =
     t += a       # 3
     t.double()   # 6
     a.double(t)   # 12
+  elif b == 15:
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t += a       # 3
+    a.double(t)  # 6
+    a.double()   # 12
+    a += t       # 15
   else:
     {.error: "Multiplication by this small int not implemented".}
 

--- a/constantine/math/config/curves_declaration.nim
+++ b/constantine/math/config/curves_declaration.nim
@@ -168,6 +168,23 @@ declareCurves:
     coef_a: -1
     coef_d: "0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3"
 
+  curve Pallas: # https://github.com/zcash/pasta
+    bitwidth: 255
+    modulus: "0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001"
+    order: "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001"
+    orderBitwidth: 255
+    eq_form: ShortWeierstrass
+    coef_a: 0
+    coef_b: 5
+  curve Vesta: # https://github.com/zcash/pasta
+    bitwidth: 255
+    modulus: "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001"
+    order: "0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001"
+    orderBitwidth: 255
+    eq_form: ShortWeierstrass
+    coef_a: 0
+    coef_b: 5
+
   curve P256: # secp256r1 / NIST P-256
     bitwidth: 256
     modulus: "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"

--- a/constantine/math/curves/pallas_endomorphisms.nim
+++ b/constantine/math/curves/pallas_endomorphisms.nim
@@ -1,0 +1,33 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../config/curves,
+  ../io/[io_bigints, io_fields]
+
+# Pallas G1
+# ------------------------------------------------------------
+
+const Pallas_cubicRootOfUnity_mod_p* =
+  Fp[Pallas].fromHex"0x2d33357cb532458ed3552a23a8554e5005270d29d19fc7d27b7fd22f0201b547"
+
+const Pallas_Lattice_G1* = (
+  # (BigInt, isNeg)
+  ((BigInt[127].fromHex"0x49e69d1640a899538cb1279300000000", true),
+   (BigInt[127].fromHex"0x49e69d1640f049157fcae1c700000001", false)),
+  ((BigInt[128].fromHex"0x93cd3a2c8198e2690c7c095a00000001", false),
+   (BigInt[127].fromHex"0x49e69d1640a899538cb1279300000000", false))
+)
+
+const Pallas_Babai_G1* = (
+  # (BigInt, isNeg)
+  (BigInt[129].fromHex"0x1279a745902a2654e32c49e4bffffffff", true),
+  (BigInt[129].fromHex"0x1279a745903c12455ff2b871c00000003", false)
+)
+
+

--- a/constantine/math/curves/pallas_sqrt.nim
+++ b/constantine/math/curves/pallas_sqrt.nim
@@ -1,0 +1,21 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../config/curves,
+  ../io/[io_bigints, io_fields],
+  ../arithmetic/finite_fields
+
+const
+  # with e = 2adicity
+  # p == s * 2^e + 1
+  # root_of_unity = smallest_quadratic_nonresidue^s
+  # exponent = (p-1-2^e)/2^e / 2
+  Pallas_TonelliShanks_exponent* = BigInt[222].fromHex"0x2000000000000000000000000000000011234c7e04a67c8dcc969876"
+  Pallas_TonelliShanks_twoAdicity* = 32
+  Pallas_TonelliShanks_root_of_unity* = Fp[Pallas].fromHex"0x2bce74deac30ebda362120830561f81aea322bf2b7bb7584bdad6fabd87ea32f"

--- a/constantine/math/curves/pallas_subgroups.nim
+++ b/constantine/math/curves/pallas_subgroups.nim
@@ -1,0 +1,44 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../platforms/abstractions,
+  ../config/curves,
+  ../arithmetic,
+  ../extension_fields,
+  ../ec_shortweierstrass,
+  ../io/io_bigints
+
+# ############################################################
+#
+#                Clear Cofactor - Naive
+#
+# ############################################################
+
+const Cofactor_Eff_Pallas_G1 = BigInt[1].fromHex"0x1"
+
+func clearCofactorReference*(P: var ECP_ShortW_Prj[Fp[Pallas], G1]) {.inline.} =
+  ## Clear the cofactor of Pallas G1
+  ## The Pasta curves have a prime-order group so this is a no-op
+  discard
+
+# ############################################################
+#
+#                Subgroup checks
+#
+# ############################################################
+
+func isInSubgroup*(P: ECP_ShortW[Fp[Pallas], G1]): SecretBool {.inline.} =
+  ## Returns true if P is in G1 subgroup, i.e. P is a point of order r.
+  ## A point may be on a curve but not on the prime order r subgroup.
+  ## Not checking subgroup exposes a protocol to small subgroup attacks.
+  ## This is a no-op as on G1, all points are in the correct subgroup.
+  ## 
+  ## Warning ⚠: Assumes that P is on curve
+  return CtTrue

--- a/constantine/math/curves/vesta_endomorphisms.nim
+++ b/constantine/math/curves/vesta_endomorphisms.nim
@@ -1,0 +1,33 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../config/curves,
+  ../io/[io_bigints, io_fields]
+
+# Vesta G1
+# ------------------------------------------------------------
+
+const Vesta_cubicRootOfUnity_mod_p* =
+  Fp[Vesta].fromHex"0x397e65a7d7c1ad71aee24b27e308f0a61259527ec1d4752e619d1840af55f1b1"
+
+const Vesta_Lattice_G1* = (
+  # (BigInt, isNeg)
+  ((BigInt[127].fromHex"0x49e69d1640a899538cb1279300000001", true),
+   (BigInt[127].fromHex"0x49e69d1640f049157fcae1c700000000", false)),
+  ((BigInt[128].fromHex"0x93cd3a2c8198e2690c7c095a00000001", false),
+   (BigInt[127].fromHex"0x49e69d1640a899538cb1279300000001", false))
+)
+
+const Vesta_Babai_G1* = (
+  # (BigInt, isNeg)
+  (BigInt[129].fromHex"0x1279a745902a2654e32c49e4c00000003", true),
+  (BigInt[129].fromHex"0x1279a745903c12455ff2b871bffffffff", false)
+)
+
+

--- a/constantine/math/curves/vesta_sqrt.nim
+++ b/constantine/math/curves/vesta_sqrt.nim
@@ -1,0 +1,21 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../config/curves,
+  ../io/[io_bigints, io_fields],
+  ../arithmetic/finite_fields
+
+const
+  # with e = 2adicity
+  # p == s * 2^e + 1
+  # root_of_unity = smallest_quadratic_nonresidue^s
+  # exponent = (p-1-2^e)/2^e / 2
+  Vesta_TonelliShanks_exponent* = BigInt[222].fromHex"0x2000000000000000000000000000000011234c7e04ca546ec6237590"
+  Vesta_TonelliShanks_twoAdicity* = 32
+  Vesta_TonelliShanks_root_of_unity* = Fp[Vesta].fromHex"0x2de6a9b8746d3f589e5c4dfd492ae26e9bb97ea3c106f049a70e2c1102b6d05f"

--- a/constantine/math/curves/vesta_subgroups.nim
+++ b/constantine/math/curves/vesta_subgroups.nim
@@ -1,0 +1,44 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../platforms/abstractions,
+  ../config/curves,
+  ../arithmetic,
+  ../extension_fields,
+  ../ec_shortweierstrass,
+  ../io/io_bigints
+
+# ############################################################
+#
+#                Clear Cofactor - Naive
+#
+# ############################################################
+
+const Cofactor_Eff_Pallas_G1 = BigInt[1].fromHex"0x1"
+
+func clearCofactorReference*(P: var ECP_ShortW_Prj[Fp[Pallas], G1]) {.inline.} =
+  ## Clear the cofactor of Pallas G1
+  ## The Pasta curves have a prime-order group so this is a no-op
+  discard
+
+# ############################################################
+#
+#                Subgroup checks
+#
+# ############################################################
+
+func isInSubgroup*(P: ECP_ShortW[Fp[Pallas], G1]): SecretBool {.inline.} =
+  ## Returns true if P is in G1 subgroup, i.e. P is a point of order r.
+  ## A point may be on a curve but not on the prime order r subgroup.
+  ## Not checking subgroup exposes a protocol to small subgroup attacks.
+  ## This is a no-op as on G1, all points are in the correct subgroup.
+  ## 
+  ## Warning ⚠: Assumes that P is on curve
+  return CtTrue

--- a/constantine/math/curves/zoo_endomorphisms.nim
+++ b/constantine/math/curves/zoo_endomorphisms.nim
@@ -14,7 +14,9 @@ import
   ./bls12_381_endomorphisms,
   ./bn254_nogami_endomorphisms,
   ./bn254_snarks_endomorphisms,
-  ./bw6_761_endomorphisms
+  ./bw6_761_endomorphisms,
+  ./pallas_endomorphisms,
+  ./vesta_endomorphisms
 
 {.experimental: "dynamicBindSym".}
 
@@ -43,5 +45,7 @@ func hasEndomorphismAcceleration*(C: static Curve): bool =
     BN254_Snarks,
     BLS12_377,
     BLS12_381,
-    BW6_761
+    BW6_761,
+    Pallas,
+    Vesta
   }

--- a/constantine/math/curves/zoo_square_roots.nim
+++ b/constantine/math/curves/zoo_square_roots.nim
@@ -16,7 +16,9 @@ import
   ./bw6_761_sqrt,
   ./curve25519_sqrt,
   ./jubjub_sqrt,
-  ./bandersnatch_sqrt
+  ./bandersnatch_sqrt,
+  ./pallas_sqrt,
+  ./vesta_sqrt
 
 export
   bls12_377_sqrt,
@@ -24,7 +26,11 @@ export
   bn254_nogami_sqrt,
   bn254_snarks_sqrt,
   bw6_761_sqrt,
-  curve25519_sqrt
+  curve25519_sqrt,
+  jubjub_sqrt,
+  bandersnatch_sqrt,
+  pallas_sqrt,
+  vesta_sqrt
 
 func hasSqrtAddchain*(C: static Curve): static bool =
   when C in {BLS12_381, BN254_Nogami, BN254_Snarks, BW6_761, Edwards25519}:

--- a/constantine/math/curves/zoo_subgroups.nim
+++ b/constantine/math/curves/zoo_subgroups.nim
@@ -13,7 +13,9 @@ import
   ./bls12_381_subgroups,
   ./bn254_nogami_subgroups,
   ./bn254_snarks_subgroups,
-  ./bw6_761_subgroups
+  ./bw6_761_subgroups,
+  ./pallas_subgroups,
+  ./vesta_subgroups
 
 export
   bls12_377_subgroups,

--- a/sage/curves.sage
+++ b/sage/curves.sage
@@ -152,5 +152,27 @@ Curves = {
       'SNR_Fp': -4,
       'twist': 'M_Twist'
     }
+  },
+  'Pallas': {
+    'field': {
+      'modulus': Integer('0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001'),
+      'order': Integer('0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001')
+    },
+    'curve': {
+      'form': 'short_weierstrass',
+      'a': 0,
+      'b': 5
+    }
+  },
+  'Vesta': {
+    'field': {
+      'modulus':  Integer('0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001'),
+      'order': Integer('0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001'),
+    },
+    'curve': {
+      'form': 'short_weierstrass',
+      'a': 0,
+      'b': 5
+    }
   }
 }

--- a/sage/derive_endomorphisms.sage
+++ b/sage/derive_endomorphisms.sage
@@ -121,6 +121,7 @@ def genCubicRootEndo(curve_name, curve_config):
   G1 = EllipticCurve(Fp, [0, b])
   print('Computing cofactor')
   cofactor = G1.order() // r
+  print('cofactor: 0x' + Integer(cofactor).hex())
 
   # slow for large inputs - https://pari.math.u-bordeaux.fr/archives/pari-dev-0412/msg00020.html
   if curve_name != 'BW6_761':

--- a/tests/math/t_ec_sage_pallas.nim
+++ b/tests/math/t_ec_sage_pallas.nim
@@ -1,0 +1,26 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../constantine/math/config/curves,
+  ../../constantine/math/extension_fields,
+  ../../constantine/math/elliptic/ec_shortweierstrass_jacobian,
+  ../../constantine/math/elliptic/ec_shortweierstrass_projective,
+  # Test utilities
+  ./t_ec_sage_template
+
+run_scalar_mul_test_vs_sage(
+  ECP_ShortW_Prj[Fp[Pallas], G1],
+  "t_ec_sage_pallas_g1_projective"
+)
+
+run_scalar_mul_test_vs_sage(
+  ECP_ShortW_Jac[Fp[Pallas], G1],
+  "t_ec_sage_pallas_g1_jacobian"
+)

--- a/tests/math/t_ec_sage_vesta.nim
+++ b/tests/math/t_ec_sage_vesta.nim
@@ -1,0 +1,26 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../constantine/math/config/curves,
+  ../../constantine/math/extension_fields,
+  ../../constantine/math/elliptic/ec_shortweierstrass_jacobian,
+  ../../constantine/math/elliptic/ec_shortweierstrass_projective,
+  # Test utilities
+  ./t_ec_sage_template
+
+run_scalar_mul_test_vs_sage(
+  ECP_ShortW_Prj[Fp[Vesta], G1],
+  "t_ec_sage_vesta_g1_projective"
+)
+
+run_scalar_mul_test_vs_sage(
+  ECP_ShortW_Jac[Fp[Vesta], G1],
+  "t_ec_sage_vesta_g1_jacobian"
+)

--- a/tests/math/t_ec_shortw_jac_g1_add_double.nim
+++ b/tests/math/t_ec_shortw_jac_g1_add_double.nim
@@ -14,7 +14,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 8
+  Iters = 6
 
 run_EC_addition_tests(
     ec = ECP_ShortW_Jac[Fp[BN254_Snarks], G1],
@@ -37,5 +37,17 @@ run_EC_addition_tests(
 run_EC_addition_tests(
     ec = ECP_ShortW_Jac[Fp[BW6_761], G1],
     Iters = Iters,
-    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $BLS12_377
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $BW6_761
+  )
+
+run_EC_addition_tests(
+    ec = ECP_ShortW_Jac[Fp[Pallas], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $Pallas
+  )
+
+run_EC_addition_tests(
+    ec = ECP_ShortW_Jac[Fp[Vesta], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_jac_g1_mixed_add.nim
+++ b/tests/math/t_ec_shortw_jac_g1_mixed_add.nim
@@ -15,7 +15,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 6
 
 run_EC_mixed_add_impl(
     ec = ECP_ShortW_Jac[Fp[BN254_Snarks], G1],
@@ -39,4 +39,16 @@ run_EC_mixed_add_impl(
     ec = ECP_ShortW_Jac[Fp[BW6_761], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BW6_761
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[Pallas], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $Pallas
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Jac[Fp[Vesta], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_jac_g1_mul_distri.nim
+++ b/tests/math/t_ec_shortw_jac_g1_mul_distri.nim
@@ -14,7 +14,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
   ItersMul = Iters div 4
 
 run_EC_mul_distributive_tests(
@@ -38,5 +38,17 @@ run_EC_mul_distributive_tests(
 run_EC_mul_distributive_tests(
     ec = ECP_ShortW_Jac[Fp[BW6_761], G1],
     ItersMul = ItersMul,
-    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $BLS12_377
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $BW6_761
+  )
+
+run_EC_mul_distributive_tests(
+    ec = ECP_ShortW_Jac[Fp[Pallas], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $Pallas
+  )
+
+run_EC_mul_distributive_tests(
+    ec = ECP_ShortW_Jac[Fp[Vesta], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_jac_g1_mul_sanity.nim
+++ b/tests/math/t_ec_shortw_jac_g1_mul_sanity.nim
@@ -20,7 +20,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
   ItersMul = Iters div 4
 
 run_EC_mul_sanity_tests(

--- a/tests/math/t_ec_shortw_jac_g1_mul_vs_ref.nim
+++ b/tests/math/t_ec_shortw_jac_g1_mul_vs_ref.nim
@@ -14,7 +14,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
   ItersMul = Iters div 4
 
 run_EC_mul_vs_ref_impl(
@@ -38,5 +38,17 @@ run_EC_mul_vs_ref_impl(
 run_EC_mul_vs_ref_impl(
     ec = ECP_ShortW_Jac[Fp[BW6_761], G1],
     ItersMul = ItersMul,
-    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $BLS12_377
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $BW6_761
+  )
+
+run_EC_mul_vs_ref_impl(
+    ec = ECP_ShortW_Jac[Fp[Pallas], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $Pallas
+  )
+
+run_EC_mul_vs_ref_impl(
+    ec = ECP_ShortW_Jac[Fp[Vesta], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_prj_g1_add_double.nim
+++ b/tests/math/t_ec_shortw_prj_g1_add_double.nim
@@ -39,3 +39,15 @@ run_EC_addition_tests(
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_projective_g1_add_double_" & $BW6_761
   )
+
+run_EC_addition_tests(
+    ec = ECP_ShortW_Prj[Fp[Pallas], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_g1_add_double_" & $Pallas
+  )
+
+run_EC_addition_tests(
+    ec = ECP_ShortW_Prj[Fp[Vesta], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_g1_add_double_" & $Vesta
+  )

--- a/tests/math/t_ec_shortw_prj_g1_mixed_add.nim
+++ b/tests/math/t_ec_shortw_prj_g1_mixed_add.nim
@@ -15,7 +15,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
 
 run_EC_mixed_add_impl(
     ec = ECP_ShortW_Prj[Fp[BN254_Snarks], G1],
@@ -39,4 +39,16 @@ run_EC_mixed_add_impl(
     ec = ECP_ShortW_Prj[Fp[BW6_761], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_projective_mixed_add_" & $BW6_761
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Prj[Fp[Pallas], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_mixed_add_" & $Pallas
+  )
+
+run_EC_mixed_add_impl(
+    ec = ECP_ShortW_Prj[Fp[Vesta], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_mixed_add_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_prj_g1_mul_distri.nim
+++ b/tests/math/t_ec_shortw_prj_g1_mul_distri.nim
@@ -14,7 +14,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
   ItersMul = Iters div 4
 
 run_EC_mul_distributive_tests(
@@ -39,4 +39,16 @@ run_EC_mul_distributive_tests(
     ec = ECP_ShortW_Prj[Fp[BW6_761], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_distributive_" & $BW6_761
+  )
+
+run_EC_mul_distributive_tests(
+    ec = ECP_ShortW_Prj[Fp[Pallas], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_distributive_" & $Pallas
+  )
+
+run_EC_mul_distributive_tests(
+    ec = ECP_ShortW_Prj[Fp[Vesta], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_distributive_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_prj_g1_mul_sanity.nim
+++ b/tests/math/t_ec_shortw_prj_g1_mul_sanity.nim
@@ -20,7 +20,7 @@ import
   ./t_ec_template
 
 const
-  Iters = 12
+  Iters = 8
   ItersMul = Iters div 4
 
 run_EC_mul_sanity_tests(
@@ -89,4 +89,16 @@ run_EC_mul_sanity_tests(
     ec = ECP_ShortW_Prj[Fp[BW6_761], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_sanity_" & $BW6_761
+  )
+
+run_EC_mul_sanity_tests(
+    ec = ECP_ShortW_Prj[Fp[Pallas], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_sanity_" & $Pallas
+  )
+
+run_EC_mul_sanity_tests(
+    ec = ECP_ShortW_Prj[Fp[Vesta], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_sanity_" & $Vesta
   )

--- a/tests/math/t_ec_shortw_prj_g1_mul_vs_ref.nim
+++ b/tests/math/t_ec_shortw_prj_g1_mul_vs_ref.nim
@@ -40,3 +40,15 @@ run_EC_mul_vs_ref_impl(
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_vs_ref_" & $BW6_761
   )
+
+run_EC_mul_vs_ref_impl(
+    ec = ECP_ShortW_Prj[Fp[Pallas], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_vs_ref_" & $Pallas
+  )
+
+run_EC_mul_vs_ref_impl(
+    ec = ECP_ShortW_Prj[Fp[Vesta], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_vs_ref_" & $Vesta
+  )

--- a/tests/math/t_finite_fields_double_precision.nim
+++ b/tests/math/t_finite_fields_double_precision.nim
@@ -17,7 +17,7 @@ import
   # Test utilities
   ../../helpers/prng_unsafe
 
-const Iters = 24
+const Iters = 12
 
 var rng: RngState
 let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
@@ -174,6 +174,22 @@ suite "Field Addition/Substraction/Negation via double-precision field elements"
     for _ in 0 ..< Iters:
       addsubneg_random_long01Seq(Bandersnatch)
 
+  test "With Pallas field modulus":
+    for _ in 0 ..< Iters:
+      addsubneg_random_unsafe(Pallas)
+    for _ in 0 ..< Iters:
+      addsubneg_randomHighHammingWeight(Pallas)
+    for _ in 0 ..< Iters:
+      addsubneg_random_long01Seq(Pallas)
+
+  test "With Vesta field modulus":
+    for _ in 0 ..< Iters:
+      addsubneg_random_unsafe(Vesta)
+    for _ in 0 ..< Iters:
+      addsubneg_randomHighHammingWeight(Vesta)
+    for _ in 0 ..< Iters:
+      addsubneg_random_long01Seq(Vesta)
+
   test "Negate 0 returns 0 (unique Montgomery repr)":
     var a: FpDbl[BN254_Snarks]
     var r {.noInit.}: FpDbl[BN254_Snarks]
@@ -230,6 +246,22 @@ suite "Field Multiplication via double-precision field elements is consistent wi
     for _ in 0 ..< Iters:
       mul_random_long01Seq(Bandersnatch)
 
+  test "With Pallas field modulus":
+    for _ in 0 ..< Iters:
+      mul_random_unsafe(Pallas)
+    for _ in 0 ..< Iters:
+      mul_randomHighHammingWeight(Pallas)
+    for _ in 0 ..< Iters:
+      mul_random_long01Seq(Pallas)
+
+  test "With Vesta field modulus":
+    for _ in 0 ..< Iters:
+      mul_random_unsafe(Vesta)
+    for _ in 0 ..< Iters:
+      mul_randomHighHammingWeight(Vesta)
+    for _ in 0 ..< Iters:
+      mul_random_long01Seq(Vesta)
+
 suite "Field Squaring via double-precision field elements is consistent with single-width." & " [" & $WordBitwidth & "-bit mode]":
   test "With P-224 field modulus":
     for _ in 0 ..< Iters:
@@ -278,3 +310,19 @@ suite "Field Squaring via double-precision field elements is consistent with sin
       sqr_randomHighHammingWeight(Bandersnatch)
     for _ in 0 ..< Iters:
       sqr_random_long01Seq(Bandersnatch)
+
+  test "With Pallas field modulus":
+    for _ in 0 ..< Iters:
+      sqr_random_unsafe(Pallas)
+    for _ in 0 ..< Iters:
+      sqr_randomHighHammingWeight(Pallas)
+    for _ in 0 ..< Iters:
+      sqr_random_long01Seq(Pallas)
+
+  test "With Vesta field modulus":
+    for _ in 0 ..< Iters:
+      sqr_random_unsafe(Vesta)
+    for _ in 0 ..< Iters:
+      sqr_randomHighHammingWeight(Vesta)
+    for _ in 0 ..< Iters:
+      sqr_random_long01Seq(Vesta)

--- a/tests/math/t_finite_fields_mulsquare.nim
+++ b/tests/math/t_finite_fields_mulsquare.nim
@@ -17,7 +17,7 @@ import
   # Test utilities
   ../../helpers/prng_unsafe
 
-const Iters = 24
+const Iters = 12
 
 var rng: RngState
 let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
@@ -88,6 +88,8 @@ proc mainSanity() =
     sanity BLS12_381
     sanity Edwards25519
     sanity Bandersnatch
+    sanity Pallas
+    sanity Vesta
 
 mainSanity()
 
@@ -187,6 +189,22 @@ suite "Random Modular Squaring is consistent with Modular Multiplication" & " ["
       randomHighHammingWeight(Bandersnatch)
     for _ in 0 ..< Iters:
       random_long01Seq(Bandersnatch)
+
+  test "Random squaring mod Pallas [FastSquaring = " & $(Fp[Pallas].getSpareBits() >= 2) & "]":
+    for _ in 0 ..< Iters:
+      randomCurve(Pallas)
+    for _ in 0 ..< Iters:
+      randomHighHammingWeight(Pallas)
+    for _ in 0 ..< Iters:
+      random_long01Seq(Pallas)
+
+  test "Random squaring mod Vesta [FastSquaring = " & $(Fp[Vesta].getSpareBits() >= 2) & "]":
+    for _ in 0 ..< Iters:
+      randomCurve(Vesta)
+    for _ in 0 ..< Iters:
+      randomHighHammingWeight(Vesta)
+    for _ in 0 ..< Iters:
+      random_long01Seq(Vesta)
 
 suite "Modular squaring - bugs highlighted by property-based testing":
   test "a² == (-a)² on for Fp[2^127 - 1] - #61":

--- a/tests/math/t_finite_fields_powinv.nim
+++ b/tests/math/t_finite_fields_powinv.nim
@@ -199,6 +199,8 @@ proc main() =
     testRandomDiv2 BLS12_377
     testRandomDiv2 BLS12_381
     testRandomDiv2 Bandersnatch
+    testRandomDiv2 Pallas
+    testRandomDiv2 Vesta
 
   suite "Modular inversion over prime fields" & " [" & $WordBitwidth & "-bit mode]":
     test "Specific tests on Fp[BLS12_381]":
@@ -287,6 +289,8 @@ proc main() =
     testRandomInv BLS12_377
     testRandomInv BLS12_381
     testRandomInv Bandersnatch
+    testRandomInv Pallas
+    testRandomInv Vesta
 
 main()
 

--- a/tests/math/t_finite_fields_sqrt.nim
+++ b/tests/math/t_finite_fields_sqrt.nim
@@ -158,11 +158,15 @@ proc main() =
     randomSqrtCheck Edwards25519
     randomSqrtCheck Jubjub
     randomSqrtCheck Bandersnatch
+    randomSqrtCheck Pallas
+    randomSqrtCheck Vesta
   
   suite "Modular sqrt(u/v)" & " [" & $WordBitwidth & "-bit mode]":
     randomSqrtRatioCheck Edwards25519
     randomSqrtRatioCheck Jubjub
     randomSqrtRatioCheck Bandersnatch
+    randomSqrtRatioCheck Pallas
+    randomSqrtRatioCheck Vesta
 
   suite "Modular square root - 32-bit bugs highlighted by property-based testing " & " [" & $WordBitwidth & "-bit mode]":
     # test "FKM12_447 - #30": - Deactivated, we don't support the curve as no one uses it.

--- a/tests/math/t_finite_fields_vs_gmp.nim
+++ b/tests/math/t_finite_fields_vs_gmp.nim
@@ -24,7 +24,7 @@ var RNG {.compileTime.} = initRand(1234)
 const AvailableCurves = [
   P224,
   BN254_Nogami, BN254_Snarks,
-  P256, Secp256k1, Edwards25519, Bandersnatch,
+  P256, Secp256k1, Edwards25519, Bandersnatch, Pallas, Vesta,
   BLS12_377, BLS12_381, BW6_761
 ]
 

--- a/tests/math/t_fp_cubic_root.nim
+++ b/tests/math/t_fp_cubic_root.nim
@@ -27,5 +27,7 @@ proc main() =
     checkCubeRootOfUnity(BN254_Snarks)
     checkCubeRootOfUnity(BLS12_377)
     checkCubeRootOfUnity(BLS12_381)
+    checkCubeRootOfUnity(Pallas)
+    checkCubeRootOfUnity(Vesta)
 
 main()

--- a/tests/math/vectors/tv_Pallas_scalar_mul_G1.json
+++ b/tests/math/vectors/tv_Pallas_scalar_mul_G1.json
@@ -1,0 +1,492 @@
+{
+  "curve": "Pallas",
+  "group": "G1",
+  "modulus": "0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001",
+  "order": "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x5",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0x2af47c3ff9dabccced9746e19855a9438098be6d734f07d1c069aa1bd05b8d87",
+        "y": "0xd4d00c2bece9774e429677e1d4e8d7cb72317a9d426eb03acc93d4e0b1be032"
+      },
+      "scalar": "0x2f2dbce8c1edac90d102e7c33f3fad94304eaff4a67a018cae678774d377f6cd",
+      "Q": {
+        "x": "0x63e38e922ada06c14cf4f0ef18a695fef169ea6d9e6cb69596e7e2dcb9e45c6",
+        "y": "0x101554460360632edc1edeebd218a1d77b654366482c8b19215b1761f6f4d72b"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0x36999dea7f4411360a02b8228e4251896c9492ff93a69ba3720da0cd46a04e83",
+        "y": "0x3611e94b3a435ed32398ffd862868d785310bd3b0feaee78951b0b455f761970"
+      },
+      "scalar": "0x22ce839b19dac61c5e77877fc6fef40f363b164b501dfbdbc09e17ea51d6beb0",
+      "Q": {
+        "x": "0x2eed553a9d1c97cac65db6ec5e2c3de9c1edd02b3c313a850167262cd124be80",
+        "y": "0x61e768a15e5794f5d40b28f7533adc4560e948e8fe01a8b9d36f9d47d2e2cd"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0x4e77ed8679d8e880034590d16c007bbabc6c65ed870a263b5d1ce7375c18fd7",
+        "y": "0x31df558c0b8758337d92a5ced71e476ba1b5eb0e52e64a68970a57f9ed7de0e3"
+      },
+      "scalar": "0xcf49334389129f3902ba6140660c431a56811b53de01d043e924711bd341e53",
+      "Q": {
+        "x": "0x6d722ca19aecc6f35cdd038f92f856f1701941a6529f3a87caab21cddeb46e7",
+        "y": "0xabe9a08048589a00a4ce4508e8f6c84f1992ad9e8762be047a20d49b5de50dd"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0x1d9125819a5f1c68c1bfec7780a1ebd279739383f2698eeefbba745b3e717fd5",
+        "y": "0x1c65e80e9e0289e770292e241369e4f8d6940ab73a77b09c59b6da631663e176"
+      },
+      "scalar": "0x1a5e139daa2638b7ac3d7d4aa9eff7a12e93dc85db0f9676e5f19fb86d6273e9",
+      "Q": {
+        "x": "0x161bf981167f99bf9fd423f111d65ed23f01cffb16337bfee220dbf0080b1d15",
+        "y": "0xc73900006524b106cc888f4ba6e55c3c2b1d4c490e3641beb3c72976246c9c5"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0x290a47f32df8d037353fd0bdc6d0febc88c9e1bc568d72c80c58438f6295dc59",
+        "y": "0x1ad890756e24c22f3c1aa590a473efa5e262f3b305b80b73b3fabaaf0c179a9a"
+      },
+      "scalar": "0x708b5a1148f76bdf14f752268eafb065c7272721784a8c6bd3a5fa736332b94",
+      "Q": {
+        "x": "0x1010d4485dc96189b886c4d0a6e5cb3af3d4c0b41c8d8df661a71f64959a6cc4",
+        "y": "0x14819b9b2c44715bc2de8348b458cb0242be623dc9d3231d513326db9ea8f015"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x60ebc47caee5579e5c96f1ca7b206862c2cf3ce21d79182d58b140074b7bd34",
+        "y": "0x10574ac428a17f07cfbf58d362fb989024dd4b8baf5d6dc4e1a4fecd8c5b0d69"
+      },
+      "scalar": "0x26479726cf5f33ebf21d2c0ba56e1c39fd0e75b1623d3ab160fed44a37ee1bda",
+      "Q": {
+        "x": "0x5b4f916198f9cb3528f9e21c9e01b6253c74c844464b01a271fc1a84b6aa1ea",
+        "y": "0xf0a95a2f5f123b4b504c1894410774da520b4a01ec663ca3671b5eacbef2fc5"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0x4a5e465224ad7d89266c28d1289098f03226fa84e7905b0df4e1f6cc4e2e897",
+        "y": "0x38842bffc633a75cff2ab4fe9ef5395d00555926146a4c7d2ebb67377cd4ee7a"
+      },
+      "scalar": "0x74fc1c66a933e9ad5732235e93cec84ae8db3104348bf24312ffcdf8e0e78a9",
+      "Q": {
+        "x": "0x1ee9b4d272769c3c8fab1d747d9fe3ea1a19f8ecf256ae70c54d0d0eedcf944",
+        "y": "0x434197b62e823c2442ea24473dc9b124744ed5d74cdcf44b9df163905d18bd8"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0x4dcb94ef4b418fc9eb7d7b7f44ed1c4357fa71695ad59299d4404c55a295d64",
+        "y": "0x1fdd76d370c37a9b73dbfd34c616a647434013f1fa48324e589f2fa181ee3df0"
+      },
+      "scalar": "0x1652a6af65163b5d5f2d01c8fcde010d11f3f0f250a2cc84b8bc13dd9083356c",
+      "Q": {
+        "x": "0xe5ff9baa77851908cdc436d0d05680d38e74797cffda32323e89fff9b3acfbb",
+        "y": "0x161cf8bed7187e3e8ee5bac1dcdb0fa9f1e340487b0e38d831062a7d02280978"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0x261a46c92d424ec4205cc62599b1cff4c7ceaaacc6f1df842689ac863edf4d6b",
+        "y": "0x21c4a02ab5fcf8bd5c3b7ac5b2f67a2ad46c73e32b08098b559c595f84ed1076"
+      },
+      "scalar": "0x1f7306b51f2a882cc4c7915f0eea2218b0089d6a71bb41c911faf48cab4f7ac7",
+      "Q": {
+        "x": "0x2fd22f01b7f6a1ea6a08fcf1a90aefca476bbfca0a656b39e7aa6bac87078e98",
+        "y": "0x107531f5fb6c03bc951817309ec6de7266babedda476271774bb1806edba39f1"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0x47663865ea0317455f6d5ae6853938a8fd832b055fb8d4d0544dc4733be5873",
+        "y": "0x1d02d331353678fa4258ebc14270ad05d25aa2adebe96a87eca89fc263b0fc0d"
+      },
+      "scalar": "0x29a1123c440cbd0fdc4cc55f1163deec34684839c549f63e2b67043d5c6a3b7a",
+      "Q": {
+        "x": "0x252b34c871d5ed7bac3d9cdadf69a669d583643939aee1bfea4d4a5cb11d66de",
+        "y": "0x10e3326ce48b3570c7a33505d46355788933df8e98d5dbe650841b8d0c7766ea"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0x6aa1a26fb01317874bc884137be3ec9d5cc946b3bc90b1a182dd6c8b24d1637",
+        "y": "0x2febb7751b653797b6255c8c6db30fe9212090d3ea52b0b6a80d262d32e7d41a"
+      },
+      "scalar": "0x17233894f9c958d92de37902e1912f818468d2e0228f4bc48f0849e2e721cdae",
+      "Q": {
+        "x": "0x3794dc29819819fcd271dbbbf388dd35a76c1a2ab12d440af61b823149a51300",
+        "y": "0xcb0288afb7963c0c2a8dc6254dddaee781b9f60e41d1835c25869a501ff50ca"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0x1dcc96a9258e687fc9887ca2362b71c50539c881d43097a0578b58c487fd26ca",
+        "y": "0xbaa9ba0c8306073327f8889c50cbb1af27e771ff20ce9484255e4763c1e5ffb"
+      },
+      "scalar": "0xc447303d4bc2adea7b0a0db92822b6c2638691e4388df93f567e11edd6f23",
+      "Q": {
+        "x": "0x199bf85a7955865d07634326b3c0e7bf291e01639f256d81b044148129263c32",
+        "y": "0xe5fad7e1fbea35ad76eb9840900f50aebd8f2b372c15ecf9ec3ed7c36e3d996"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0x1bffe656e3723d9be238d0610c7236d5549dfe43817b51a5cc6f5fdd6964a7d2",
+        "y": "0x2a879909024c7a6618f9d540d71a683557319fd30baaabbb7f64944ae6c802b"
+      },
+      "scalar": "0x2162dd568cb4ec5f039a2cf378f20b3c3e10bdba4a877e80f4f4c4627163d414",
+      "Q": {
+        "x": "0x18d196b23a0dc2289dc71f31f2322ed6c6fe788a861d109ec3634452d6a12f4",
+        "y": "0x947641a14eacead13f09bd0eea14c72374696447d77e5b60a0d1f0fa570bbf3"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0x1e15e96d3cb602604a06c597bc2a75e078b15d7c2df37ce42bde69ca13599811",
+        "y": "0x7a674cd317090dc05f848a75a795657d5757ec82028a788a5c1f4c1f30ec62a"
+      },
+      "scalar": "0xe3117289fc8499db75ae19842f14dc8274af3e92e28716b76d2adc2f4b9b9e7",
+      "Q": {
+        "x": "0x25aa05297627d0e3b983c98eb9f9a75ae40823e5e0a1643c42755aca1e91ec01",
+        "y": "0x18567ab9e115dfc4bee45a778be6bbb5728314c03ee6b3397e16d423d855df7d"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0x1490b23f45da5ad607639073a076ee8aeb56262bfd4f6dc6e138425eaee9c9ae",
+        "y": "0xd4edea175e89789da3e2f261383c1fb506ce47cf3472fe07b85f01f121b7de8"
+      },
+      "scalar": "0xaaf36853d0be46585a3d75afc6649bd5eef2db0d92ab3b1f8eb4a3930d98f81",
+      "Q": {
+        "x": "0x3acf6a6af3aa4554343a72d2c6ebeb9ec3958f19e38c145853435b94de81c770",
+        "y": "0x23c18409dd856db14c87e3143d0cd6656fab1a8acff30accd5f4af9eae90c8cd"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0x3a19d667722142069dd8d0f55ec1a33f93383842931692b0b8e0edd32ed3afe5",
+        "y": "0x22fdef87984ffa7130dedb72b95394b1a6d21e9a586c4fec57e02b929bb94add"
+      },
+      "scalar": "0x12186f74887ae51975dd3a8dc177ae15bc2aeea4fcffb633ff6f5db5622690c1",
+      "Q": {
+        "x": "0x258560681b64d86ed475fef5b5cb171b03d697003ad84e78acc1ebf6a88e0b63",
+        "y": "0x2fe0069f3ec21b6eb8445f6088f7ee6fac5f53c991f842b82545fc9d3f79cf65"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0x2200663cdc8dd561f57694f9f4a32f114e56bf756c8a2ba87df8329a10aa4b12",
+        "y": "0x456b179884d0a1bd7ae211fc18098eecf00b821c8ba0524c3dffc42a403a7bc"
+      },
+      "scalar": "0x2aa663ee85268585b47107252e4d978951d7200f3184d49635554f6bcf20978d",
+      "Q": {
+        "x": "0x2bd36e55f897cdbe8094d2f9ca406408afd992679d89379cd141178a49db8cbd",
+        "y": "0x28a207587cdd420c2dd7ef20e8e3f04f6eabd323c881fb27a89fb1c98f55c501"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0x24c9f16d760ae783b91cb825b46ad015e45e924b32a562e931783f6c7ec63dca",
+        "y": "0x3661c531c4bc7a7a1e96d71de81f44a59e9cb1e8d09b153eabce96abea932881"
+      },
+      "scalar": "0x1589e516816c1535dc5836f0ba51bf862b70ad57b005f9c8a4a7fcfbd451c8d3",
+      "Q": {
+        "x": "0x2e123272172cbf5701444efaefaf609420fd2ade1001b97725ecb7d56a0cdc6c",
+        "y": "0x2c4e79c81bf1b2336f8e4aa40a986187b5fa18ced6e479e2edc245241d61c89a"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0x3df0683e82f694e040910e68a54baac4a378d52cfee4aa7335550e8d68ad1c6e",
+        "y": "0x370646bde9e00e05a74b8a483f460550a2720a4f0a9f7beb92ce5491f693a25c"
+      },
+      "scalar": "0x1b3477283988f2af3457fefd358545c6c936c6ccd08c0a6d6b2fbfe1ad2c5d76",
+      "Q": {
+        "x": "0x1c02b13390d6897c802df68954b6514584888cca039a4bf283e7cd9ab13df96",
+        "y": "0x2469c1a57192da7a572089c8da82caf41c3445a5cf8c531e385f6c81096a2b41"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0x1577cace09797a29e6aa061e256705e8d1cc9656a652590fa0a42550d009adb3",
+        "y": "0x35172db9be3ad8669395577371c0de7f7faaf795e936a46a152154bfe8941663"
+      },
+      "scalar": "0x28d55f2d1442cd8e3c214282d56a2b893785cf1a4d174c63c3129362844cc400",
+      "Q": {
+        "x": "0x907f51f0945081738beda8d053e543928a6cb770893dd3ade09bbb66d9737bb",
+        "y": "0x2043cbe4c22b86ffe16061626975426e62d27a8cf1df2f549946c8d6315626e4"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0x186cf81a6b1503eef66d7e53525577620ac8049000ba2771d604034ce96bc261",
+        "y": "0x155cacf753c137e3515976dd23e6552a5f26ab4bfe79b0b60acd9a75fdc8d221"
+      },
+      "scalar": "0x2b98a51bc3ee524b4be51b806f6ac5c22c2a99e433ab2e80c3e3947e4d79bc71",
+      "Q": {
+        "x": "0x3138443221e88f2e5fe801d7b2f3a12b5c1abdc42ef480d0382ddfa7f621f725",
+        "y": "0x1eb91d16ec9593061287912cbffa45b3c14e2ef430ba5ea7ac5481a9cb98fdeb"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0x1a40fd31eb1a813026ed20c3aaac9a1547196f5c9075e9c9e66bd668d4a24546",
+        "y": "0x19ebbbcd62f5df086049cb5cf14b50d246118f0f6b98a377e527358eacfce9df"
+      },
+      "scalar": "0x2cf445370b49c002b74f08059a6a88b004c9a9a71d596073e5d8f1eea9e7b4fa",
+      "Q": {
+        "x": "0x154b10311277f0c22cda903c62bb00cc64cb62568dc4cb2cb7650309474a821f",
+        "y": "0x2f80caea32674644165c41a0d13fb9de21d4cb9c45786fd45e6d2934be58a97f"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x397cd9b92bbb24d7428543ec9e65b94cdeeb4e73178805d68bf8a3af2864f3ba",
+        "y": "0x2469453fff56403da13dab62c3fba4bfde51a7cedf35d518d6c8f8caa47b99e0"
+      },
+      "scalar": "0x15d0e4b9b99c880f0572a66c39f5ee0e67d82c46813f79c2cd7e2c3460041e86",
+      "Q": {
+        "x": "0x33c55b1dcd0b909e6f407e357326ea4d85177a6677f081a689053ddcf943762f",
+        "y": "0x1051c642cc8d88d02fcb92d0ddcb1c4fa29f45caa78fde2845013fb1e905bc50"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0x2e5a99d7240122f31cb14dd1992829797f938efb160e01110567e752e0551e99",
+        "y": "0x11943af2229d48e75e48ce151e20305bbd23a85f429357bbde58619af0c3839f"
+      },
+      "scalar": "0x251bc0b63854c5f16edaef18308e29ee1e83cbf1e03091c1f0d1a32a30b6f84e",
+      "Q": {
+        "x": "0x15e2fa7f36db56bf7b875b581f8289ebdb99f7e4feb036c2bc545c42ef83eda6",
+        "y": "0x203aa5609e88ab14bfc847eeba22d8913b8fb5dde9bd7d580836b9040a9a8ff9"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0x68b98202a3eb8afb4b5accb359743a00a96e4e3dddfd5a0dd6a1ac15f163db4",
+        "y": "0x2f2181044e1142bbbcbbbe859d57a699bd6cb5847723b4afd4923f47a8753e30"
+      },
+      "scalar": "0x350bd7ea5026ef342c59323e636fda3a29f8317365975cbd3dd49b9efaddbdc0",
+      "Q": {
+        "x": "0x164e7e2e6e0e8c8f121c0c4da44c91b5d05f00dcdb8dfc3737b7859c20791941",
+        "y": "0xb4566c1d399e8c97ffcf42330e7c5f97fd99d829e6a5873bb7b1796b3988102"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0x6ac37c299c47db983bafc9706a79af8ada2e55c35ce4a9a85a8fd066651d5d1",
+        "y": "0x218702da40124c73e7a6bf7bc3e9ed3456366ca6a47f386a3f74746d7b4f7acf"
+      },
+      "scalar": "0x75b0882340f6e12c4f42c30061879c49e7b8aac4624ac8f9ec5a8e597f49016",
+      "Q": {
+        "x": "0x3523a3975ac48cab53a8a389244dc74672bdce72214729aeacf6fca30ee8a8cf",
+        "y": "0x1202be86c6343c2f889f5e517d4cc33cb193f3348b3d81152dce812c0ed875fd"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0x87f2513d7746fe7975b2c2239bec5fddf94c7aab24f4ef408fced40edba551f",
+        "y": "0x384ca15309b55753d82e75b62350ae1c20a0c04ae051132aaecee2d710b7be8a"
+      },
+      "scalar": "0x5a7fffbdb16d74245e3fecbea1da2d32ad3673d26c942ef8acc773c271d6779",
+      "Q": {
+        "x": "0x24b3a6833013960f196af3c45397a00dc512523f31244744835743f872c000ee",
+        "y": "0xf083ea36ee6475de78a109413e689fe57e746e7dd686d107c29b6b9f5eada6e"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0x192b763dd3d423fe9c543b396c469f49b3dba4db0964213207901f39d4c458f6",
+        "y": "0xb41032769e3a81200d14401311457e1f7185edd6cbe9f9c309716a3db45af0a"
+      },
+      "scalar": "0xfca9bb91281b91307d1db8874ad2f2f0f108bd619cfb9f93a034834c6f878",
+      "Q": {
+        "x": "0x7f7c76541d6e1a84f042941c0af27807de70e825d73059c966060ad85d4954d",
+        "y": "0x1e0244866bdb403013638855d536c28ed6c00eb5095e87675e1e48b9adba3941"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0x19d1ea1b4a65a578cc4af0350a1a42a350cd4103112c9eaf976c57da8bcf166e",
+        "y": "0xaeebf1f86156788a62aeba79af614fb8bc97ccbb7e8df1be9906f7247b9fdc9"
+      },
+      "scalar": "0x3f9ca99fb9499b37cbeb1bea63009250f9859f8b4218e67973428989411fd3ff",
+      "Q": {
+        "x": "0x36d84afb48f2843c48514987f7b2a1e0c46e65ef55a986ffc9002a879bf55215",
+        "y": "0x75644e13e78da4a4501ff3754e5363c7feebb604bbc120d8f5d2191586f74e1"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0x3a143ff9bfbe38a03ebb6ce043ceb2371a999f5b1a4798c0848e5dfadcbfdcf9",
+        "y": "0x33e4a3a2657df140989a0c5730719d340040087a98c6100f0bd38d37990f3a64"
+      },
+      "scalar": "0x3e7f18a78ad98fd7240345518a73b5bce00b64020e47f2905258ce8523173271",
+      "Q": {
+        "x": "0x180d4185dd4b79226169c5536d97143302f91cbb062c587db05131c1e9fb248e",
+        "y": "0x1dbe8ca1ec5e31189385277581d4fb2cc920bc0aa52bde63f013e19e3cc0f297"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0x107f5bbb35eb735c320fa0666d1c04ee6ecdda94e889c7caa328e21ac9fc1ff2",
+        "y": "0x2faa567eb241186ac9bef699d00653c851c04f44b56f190eae696b109d10b162"
+      },
+      "scalar": "0x22cba76072845f8d5d45aa4ce2efa998fc66ee686c61a8f4538552a9e6f2b794",
+      "Q": {
+        "x": "0x1c671cd70eecc9dc03bf0f516f8afb7893ca0c69b35feeff492a9e4ba21ad245",
+        "y": "0x208fb4c2d387f81de0edfb26a695ee4cb55055d4c3fc1085952aaac0864d37a1"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0x127b80b03442fcf798c027868ea60005a83e1ab73753dd6924df875e34fc64b7",
+        "y": "0x1301db1b1ed61ad3bffc49397fe625521c728b45c1134148484b783ad4b8e461"
+      },
+      "scalar": "0x16feb08c254b0cfb2b34eefa14aa1de6f6e3c4129c0f753fb74425b8bf833667",
+      "Q": {
+        "x": "0x1d2c6bd03b6a18e8c3f0fbd61dd5123225e1156676279419de2a3cf652400a50",
+        "y": "0x31af18dd8e0da7717900eb0aee193568a9c280939c7f740c5d28a29529b3b056"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0x145d95d63e7fdb1bf979ee636bde96267a4b0ca230c8815e2f25b9b412360e6",
+        "y": "0x1c190d719720cac0d68ac6d7587f0bdabd1c7b1b25cdf65aec05bdb410f9d11b"
+      },
+      "scalar": "0x37d4c0fe4655ae5b3f12536374727ad3d0aef1d5c450e4fb5ff63aa48b0860c7",
+      "Q": {
+        "x": "0x1f8437284ca13c3ef39d602d93f062234b3572161837508f971c4049b8203ff9",
+        "y": "0x793242b1d5040af27dd9c400f569df4b4719022dc614a75f5d4b8364677cdd1"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0x1232f94004be88e7a778496195885d8f3d5fac8eb9a996b011b8138b826783ea",
+        "y": "0x2044b0488c79772be3c6009d1c6451ce4802c7245022031f1e6e64ead2d670a8"
+      },
+      "scalar": "0x2c3496e3c96a539d25869b0434e903e460989f1123193bd9dabdf4c8f974c66a",
+      "Q": {
+        "x": "0x971748d2b6f15ab8482e8bf1d9358678890873d88ebd9866ddb24a202d3038",
+        "y": "0x26c6c184e258b0040b4210f8e2eefd61ae8bfc56bd997a169afceb52fa46629a"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0x6d675b937f933adecd599cefab5369350d26b5d5a12222449feaea114aad041",
+        "y": "0x14047374650b0511df7c8b6caf0afd8fec8918fd714825f79fe8a0739bce3359"
+      },
+      "scalar": "0x2f494cf701e805a50e4574af6fbc5f13245d5d4d4798c6aa93eee63483417f7b",
+      "Q": {
+        "x": "0x27f1b1cc290203baaab63e7f7309ed1408a37c1f42643e07d73e36693c2a633c",
+        "y": "0x3e1c490e55caa115d534596c4de06730bb81738496a0d896046212b0bf9d272a"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0x48a79ffd325ab2786caded069d5edc178be3bd2b2077de76667c844923289e4",
+        "y": "0x16517799bc897f658f9bee4603a88fddfef2c3f9cd6dafa5e31f0f08a3d999a7"
+      },
+      "scalar": "0x15dbdac7570dd4581627833007d2a82a04c79cfdf1ce57a3e55f0abb14a22213",
+      "Q": {
+        "x": "0x2d80072eae7d7439998d725e44c2575c04cd7dfa8b920abc6f35047b993cc894",
+        "y": "0x2d589a844eaa234c88f4a85654b31f2fc1a062abdb0f54028aa95b682a6b5052"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0x17ec08e51a51b66cc4d730c642d171eb090d6e9a8073957a6736e0af0e262bb6",
+        "y": "0x35821a60f2e3d163d146f6a21618922e10f99626311af4af9925a2006326c2ef"
+      },
+      "scalar": "0x36e749e92df47d6454f700df731d407ce9aec35886cb9f927e0215c657ce95c1",
+      "Q": {
+        "x": "0x20744abca2f12abe87d84a998cd2466c8d85d38817020883d51c6092e33207cd",
+        "y": "0x2094575cf9415112d5ba622c2ed854776b983364cd7d426e5c0708d2a5e00daa"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0xa73814ab55d7bc23befa4c97523689d0635e55e526480a62c8a5663522b07dd",
+        "y": "0x17871097c68980fb588a681b8ee2b576d3e6515101f95147a95e8bcfe63f7bca"
+      },
+      "scalar": "0x1ae7d92d79f854b526d9be1cc57b96bbf939432a03af688747e23a910d4db803",
+      "Q": {
+        "x": "0x2277fa3b77b7147e06999e4769bfb783a139bb1e520254a27159edba1773f02d",
+        "y": "0xfb56baf3489588abd024d018b6c75add1e494980a092f492b5254f2c68da63e"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0x31f99fa4af6be5bfa996f34a3243faf641eeb4a441613cee54e9cb6161038bd9",
+        "y": "0x2d2c77e401cac314108db3d8f83a101327089320818460319e930d930fe4fa5c"
+      },
+      "scalar": "0x327880e8329bf792b555787a7285859a0f58d9a409e9efb5f0ff68528217ec4c",
+      "Q": {
+        "x": "0x5eaa66da6a86a7efcef38a8d9a935a637e6c4cc77c578e6da28e5f51713e55a",
+        "y": "0x10f6b57a4c397bfd8ed2fb3beb74ac6dfe71fff36d369989214c158437da2e6b"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0x4725b1fe2201df726e20a3eb0643653015a790f677d2ee13d0b97e55761fc13",
+        "y": "0x2fa9eca778858b463de6ca52b27d353672b6a825e6cc6645e8212a8377ae5c3a"
+      },
+      "scalar": "0xac5049f5882453952031bb8ab471aae495c8cc4553dcc5c4fd27c9d6ddd7414",
+      "Q": {
+        "x": "0x2283e89eba5b9809be6dc95ace04d4b2befca682eb7012d64344967f86d61ffd",
+        "y": "0x27cd3046012b7fba7adee0c313b6ec574b8882aec0e5586f47a9ba839c8efe5c"
+      }
+    }
+  ]
+}

--- a/tests/math/vectors/tv_Vesta_scalar_mul_G1.json
+++ b/tests/math/vectors/tv_Vesta_scalar_mul_G1.json
@@ -1,0 +1,492 @@
+{
+  "curve": "Vesta",
+  "group": "G1",
+  "modulus": "0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001",
+  "order": "0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x5",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0x737833841835082f86ca046b71875b051575072e4d6a4aeedac31eee34b07df",
+        "y": "0x227510143dc2cfa6316530f7207b6e9acf2d5f0c7fe5958d9ba7d60673fe530a"
+      },
+      "scalar": "0x2af47c3ff9dabccced9746e19855a9438098be6d734f07d1c069aa1bd05b8d87",
+      "Q": {
+        "x": "0xdf55c23f4b27f5eb96500187226c88bacf19a5ce3532f8ff0188c2f70f87f99",
+        "y": "0x29a6ec0b21f2a169bea4bb748783448a3ee3b66ab42425de4947e8caf6874acf"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0x2f2dbce8c1edac90d102e7c33f3fad94304eaff4a67a018cae678774d377f6cd",
+        "y": "0x2ef7e48e41750e6316b32fd39bcf5862e0b63cc2da5ae909a6cc53754e1ea3a5"
+      },
+      "scalar": "0x36999dea7f4411360a02b8228e4251896c9492ff93a69ba3720da0cd46a04e83",
+      "Q": {
+        "x": "0xac16fbb452fb40102e6fbe10174450d037358473b36df3f1a2e14adb4276b7b",
+        "y": "0x202afdc4ea232c9f680941bf0a382f007d53f1242c6723820da5134510f5c797"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0x1be5fe508f44313dc9ddb54de269c6424aaf7164dc5e67917066ea5dfa0d0f1e",
+        "y": "0x30e97acfd8ba342840822e66c371c9edbe1c89707c580fe5c63bdbec175a8990"
+      },
+      "scalar": "0x4e77ed8679d8e880034590d16c007bbabc6c65ed870a263b5d1ce7375c18fd7",
+      "Q": {
+        "x": "0x1df9cd87b46679771f7a374c83f781bd7d23f10f965089e29f1e6529b957a5e4",
+        "y": "0x11beed5b903ade8406cb3b48c94d4f8fbab8d426fe8a02b6449c448e0797c712"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0x1d9125819a5f1c68c1bfec7780a1ebd279739383f2698eeefbba745b3e717fd5",
+        "y": "0x31e6b40691229fa8e43071e044e2fd862f25f8d8611d27173599d1c4cd16a23c"
+      },
+      "scalar": "0x1a5e139daa2638b7ac3d7d4aa9eff7a12e93dc85db0f9676e5f19fb86d6273e9",
+      "Q": {
+        "x": "0x3ad4bcdcad50eca077353d18122dc417afdbd4b20d8d11d5c1330457b307e4dc",
+        "y": "0x2d908713a40d8334c196a99d304975b2e4b64f7bd248b21c3593fc0f1fdf0bd5"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0x2ebda6fedee061c78e28d668a26add87007ab0d11ad699cba0cb13ae35b8215b",
+        "y": "0x1fa8a58acfcc5fc0e05bd0365ec5b07c675b8c75a250eb0c8d05d3178a96692c"
+      },
+      "scalar": "0x4dcb94ef4b418fc9eb7d7b7f44ed1c4357fa71695ad59299d4404c55a295d64",
+      "Q": {
+        "x": "0x205e486f4fcf3d3c059df6066ec2187e2bbbe086e6c0c6f82a6f42ccfeb042be",
+        "y": "0x2be5164d55cc9a1fbeeda6bd11704aa5149fa8f0226caf567746aa7bb12a205"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x1f7306b51f2a882cc4c7915f0eea2218b0089d6a71bb41c911faf48cab4f7ac7",
+        "y": "0x177cef21af08d4ee2c74cd2afd61e25e4796be5d658ac292014503b48d61b76c"
+      },
+      "scalar": "0x39f587d67f51ef5c90fe33469dd55b0641eaf4597cfde95f01fe8d0c16613599",
+      "Q": {
+        "x": "0x3b2759aa564e9814bfcc51bb731bab0223a689af24353a9a3ca8e41e95e97b2e",
+        "y": "0x579c5241ca766d68e98f707ca6be02645382d8e5db0e79d270d5ce518a8d954"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0x393a99a2239bc59ae80557dfb0c86a1f86ec92e749c8722a713c953eafd6ca20",
+        "y": "0x41c6c8fddabbb9b8de114a9114a25fd8dfe4989313115c37bb02444abb72781"
+      },
+      "scalar": "0x134d7382392961c26657edebd560350298f9138b82fe22216cc054a39e40d4e3",
+      "Q": {
+        "x": "0x3d5f4d81c3f1c25f870e8d697460534ea9e71e5d3088148c1551bac186464190",
+        "y": "0x3e614a50712fe4b94fb242b3fc3d7ad9b1e57102f4400e4f9cf561dc3a06a521"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0x47663865ea0317455f6d5ae6853938a8fd832b055fb8d4d0544dc4733be5873",
+        "y": "0xed8406ae04029e2f601375fee4d7c4bffe1bcd5de31b807064c7f0af7d10ddc"
+      },
+      "scalar": "0x29a1123c440cbd0fdc4cc55f1163deec34684839c549f63e2b67043d5c6a3b7a",
+      "Q": {
+        "x": "0x2981ec7ab15d8cb4a98182e9ec6432eb99346a1d1f7df4492d3bfbcf5414d056",
+        "y": "0x12c7ecc8ee02aa440ca55ad25a3fe3b43bf1dfc5cfa0e648d167f5f338b98202"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0x6aa1a26fb01317874bc884137be3ec9d5cc946b3bc90b1a182dd6c8b24d1637",
+        "y": "0x3a58a425a3cf3854a523b9a762d1f6bcd3290a2cb280a1d42c92082250313d05"
+      },
+      "scalar": "0x17233894f9c958d92de37902e1912f818468d2e0228f4bc48f0849e2e721cdae",
+      "Q": {
+        "x": "0x26874bacfffec689e3f56b24798912605e68c5516b06f22bf816c87ba560a722",
+        "y": "0x2ad8cce9e2ee3b2b382ede3e62c56eb77e72404237d238201e4f0a03f4675159"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0x2351d82466d3533572ef68839aeb0bc801044c54458c0c0cb27a058faf15dcbf",
+        "y": "0x119d6f7a24a1263068c6d7dcab6d97b13aa1506d3ea0ca019e6cf58b7c3f0002"
+      },
+      "scalar": "0x7aa0a802f6d6eab342473ed2b07313c5b02e2c63f2218e5773df0aa839ce9ba",
+      "Q": {
+        "x": "0x1c3858d9ab2bf6e1a9e04968630df4df688cfa7a5b898a4ebc59fecd18e39b80",
+        "y": "0x5034ad95da30cb2904ce1ee6c1eac37c3e9160285bb74d3cdcc8ef33fa0a022"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0x223cdeed1ce48e22970752bd56cab93d47caa252d52948367b21163591f7b7b1",
+        "y": "0x267e42f9f12355e2ea41ed9401e853fc8c4019cb793d8f4370e2f68bfe2c60f0"
+      },
+      "scalar": "0x1ff9adcbc952cc067aa3ae121a242b478d5ed96da30eb78ac5588964dd0f3405",
+      "Q": {
+        "x": "0x1c71f9f5e8cfa9a54b1f4c0081edb98a8cc175c90bff86a633c4929a4f946c15",
+        "y": "0xf5e596f0418fd636b658c89db5494917ce36bebe551d18da89a0577d775a9ef"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0xc447303d4bc2adea7b0a0db92822b6c2638691e4388df93f567e11edd6f23",
+        "y": "0x1814c2a8a32f7a008ac8ef9abbffbbe0e086a652873d104700956eacd96836fb"
+      },
+      "scalar": "0x135ac8e91e189a485c040d9acc6fcd32f7a1026e23e9e23f7389692541da26ea",
+      "Q": {
+        "x": "0x91abcc90ac367639d282d5a1e45eed84562341d53dfb188df6ddb0e33778c6a",
+        "y": "0x20b45832555acba6ccf51f338a05e9e6f12f7c53041f32bc25d4ce8c305a0ed5"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0x5b725fed62bf2675414c5455c50dcf09e50d5e980d29ae653cdff2e9a67de43",
+        "y": "0xd2d4de1f2fafae36f7aa71d01337993e2fbdba8a5c89ae4e74703bcb01274fc"
+      },
+      "scalar": "0x313aa62ebd61f0885c9bf39e9c6baeeec2ac555d3c6d1802259a4f4c15e0bd3d",
+      "Q": {
+        "x": "0x20b3afc27ca0655f6abd2d4d33432f737409e48ac88098202ecb9e7ad07f543f",
+        "y": "0x2b21ca923d4189c3670f9d5cc02612bfaa3b214429ede92f36b0e0f428734e36"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0x2162dd568cb4ec5f039a2cf378f20b3c3e10bdba4a877e80f4f4c4627163d414",
+        "y": "0x23736f6a4de96ad619a3843142546582197be0ee783ff012624d3c9c1d728729"
+      },
+      "scalar": "0x10f77b832fea71a426b43a8d0894de8263787a26c6a2afda5bd31f967c65383e",
+      "Q": {
+        "x": "0x1b059eafdf29567b27609b6746c1e894bb30b460503636fd340e687560a8ab65",
+        "y": "0x3171daa7c7bd92b48645dbb3ed1220701d1ee3519cdd42fde43820ca001486bb"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0x1e15e96d3cb602604a06c597bc2a75e078b15d7c2df37ce42bde69ca13599811",
+        "y": "0x247e1539463c5314aaf87be6728f7ebdd01a2abcc9d54f93c283bc4479984989"
+      },
+      "scalar": "0xe3117289fc8499db75ae19842f14dc8274af3e92e28716b76d2adc2f4b9b9e7",
+      "Q": {
+        "x": "0x236f9f208e54cd2e3422e5a1c2f2c2e7aeb6afcadc41f3607bcbdcc036f39f1e",
+        "y": "0x208e685a55abb85fe191373516606216ffcc3738f636c06354b069baf0e61c20"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0x1490b23f45da5ad607639073a076ee8aeb56262bfd4f6dc6e138425eaee9c9ae",
+        "y": "0x2946df2734be7cf1746c99c6188faa354ea78e938f3ab6b22119c47d061ea797"
+      },
+      "scalar": "0xaaf36853d0be46585a3d75afc6649bd5eef2db0d92ab3b1f8eb4a3930d98f81",
+      "Q": {
+        "x": "0xbde22cb7d1b912509b19f0a8189312596c6b8ce3332371f6813a100a1136327",
+        "y": "0x18f1b9825a41aa9c502e37249467eb4bdaf632da6c58d5bf65efeba89c01125c"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0x12186f74887ae51975dd3a8dc177ae15bc2aeea4fcffb633ff6f5db5622690c1",
+        "y": "0x9e29b5dd5f84701e3d9ee5ae3502fd14d13ccb71379790695c56865443024f"
+      },
+      "scalar": "0x3053be59ce135c94e4a6f8c72128a68b53d8aec09a30e810c08cad0143ca5e18",
+      "Q": {
+        "x": "0x26e5022fe545395f7c772c48304c15a23204006ecc977bfd145fdc581a53ea52",
+        "y": "0x6fba7e08377deed37ce0e4b15ec78cd91183b17c9ca93037b970612d67aa077"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0x2200663cdc8dd561f57694f9f4a32f114e56bf756c8a2ba87df8329a10aa4b12",
+        "y": "0x1482239cd5bc225c0924d5e0258da343a987062582d25d8f685e1c6959993230"
+      },
+      "scalar": "0x2aa663ee85268585b47107252e4d978951d7200f3184d49635554f6bcf20978d",
+      "Q": {
+        "x": "0x3d2a0a5e0f06343b5d9b96061072dc65894e04a9d82a63b12e454724448a159f",
+        "y": "0x47947c5a76dd904c51d9800f71e5a10e1310728fc8d90eb5f1c9843f1a13afd"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0x24c9f16d760ae783b91cb825b46ad015e45e924b32a562e931783f6c7ec63dca",
+        "y": "0x68c966f8d614fd57a9d7c052bef1d44a4f054c9bfe4d59fd1fd9b8fc641548c"
+      },
+      "scalar": "0x1589e516816c1535dc5836f0ba51bf862b70ad57b005f9c8a4a7fcfbd451c8d3",
+      "Q": {
+        "x": "0x13e6397e50b9561ea2ee029f15e16b6ad5b3bd2817bea925e2ab6a531a7fe686",
+        "y": "0x13429e355d82c0ee58f8346f6af444394a96499087818392c8744b1f3740f752"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0x682f57f204bc2907b42045f9510693a4af18151888ccf75e71c60c663b73662",
+        "y": "0x16805df45e4cd8ad0808830666366f0c2a36ba11c32d1bf6d11f3498f1030daa"
+      },
+      "scalar": "0x18dbaa78cb90cb68b280558d24a58efe56cace6363a11ad876819e86996bd9d3",
+      "Q": {
+        "x": "0x25d6d198668e744fa299fc35052cb6e49896b6750b6aa17b51d187107e3fec98",
+        "y": "0x2ce729270c806a1262ec77c975073c9b893397d1587b0d5706a6848053ebc85"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0x1b3477283988f2af3457fefd358545c6c936c6ccd08c0a6d6b2fbfe1ad2c5d76",
+        "y": "0x2163bb923c8076d64be0e92ba02a79a2e0d6056d94b5c1d0e873be33c499eb9d"
+      },
+      "scalar": "0x1577cace09797a29e6aa061e256705e8d1cc9656a652590fa0a42550d009adb3",
+      "Q": {
+        "x": "0x173787dc097ba37db1cd9beb3b12dbeafcecc7f143d99bb712487d451679e60",
+        "y": "0x3117853a838aa179c92600a8ce816578c7538583b1623b92e917572ecf0efa65"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0x2b98a51bc3ee524b4be51b806f6ac5c22c2a99e433ab2e80c3e3947e4d79bc71",
+        "y": "0x1d8b9fd4e70e009792cbdbc7975cdfcac891bebd00611abe2a9a13a768728556"
+      },
+      "scalar": "0x2f32e37b22e6b2fa24084c299585c90e4a361342dc8d66f509834e0fecebc207",
+      "Q": {
+        "x": "0x1b70aec4b1dcaccef7f58b562382d9f6ba4a5081293fd268cd09cb72ba17c331",
+        "y": "0x37b54e8755330f6459c91d0f288bae7d38548f8ff21280808457540971083347"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x131ecb3afffb09983c2df3d4065c145e9a5c55eee35a0e8ba7e6ca10335ebd0a",
+        "y": "0x2da4291f726cb6524ddd9e723f78f1703a4b048e7e1bb4f511bbae44e87ddb18"
+      },
+      "scalar": "0x1a40fd31eb1a813026ed20c3aaac9a1547196f5c9075e9c9e66bd668d4a24546",
+      "Q": {
+        "x": "0x3f868749eec0e49fb9067fb2c00b9182f6f825cfd8c579a2e2e285d6743598ce",
+        "y": "0x1d35f66f9c58090c12ba6233c6d1a03f3d509502134d031f45431c945b6e9f20"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0x397cd9b92bbb24d7428543ec9e65b94cdeeb4e73178805d68bf8a3af2864f3ba",
+        "y": "0x3dd55afa178c5a4b20ce2c4eeb89d4bbccdfbb988bf3cc3a83b69c3c4485595e"
+      },
+      "scalar": "0x15d0e4b9b99c880f0572a66c39f5ee0e67d82c46813f79c2cd7e2c3460041e86",
+      "Q": {
+        "x": "0x12ac1f9d2f31e3a236de75720dbceaf50f807aca11c8fbea7bc170676b01d702",
+        "y": "0x334d443029db4519fc01857f7df8b33bef4f3a07587055252eebf3d568dcc137"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0x251bc0b63854c5f16edaef18308e29ee1e83cbf1e03091c1f0d1a32a30b6f84e",
+        "y": "0x16f443ac292bca3b759cac9177885cee9cf1443a8bc1f0ef66cd7f2ac7aad9ee"
+      },
+      "scalar": "0x68b98202a3eb8afb4b5accb359743a00a96e4e3dddfd5a0dd6a1ac15f163db4",
+      "Q": {
+        "x": "0xaa75f538ac1c15046e554f7af87956868f35162f54191406c5101c66434229c",
+        "y": "0x2d5b81d1b3b129e9c682d2cd1505fc6e65f57f0603c913382c806e23cf873c60"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0x350bd7ea5026ef342c59323e636fda3a29f8317365975cbd3dd49b9efaddbdc0",
+        "y": "0xe075caac88f5e43a5416222b4a3c9e406dae15603eee40a5c93fd32ff9e59dd"
+      },
+      "scalar": "0x6ac37c299c47db983bafc9706a79af8ada2e55c35ce4a9a85a8fd066651d5d1",
+      "Q": {
+        "x": "0x22a065bfd5f3dc77157def7a5edd6eedd8c4d1b088c07e6926a8e8d2c3a8a35f",
+        "y": "0x2410bb5595747b757ab6b9e4ac23f925cf8a379f302a9e7cfd4a9c8c3e79bb30"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0x75b0882340f6e12c4f42c30061879c49e7b8aac4624ac8f9ec5a8e597f49016",
+        "y": "0xca66a912d664b0c9d5db9eb0cdad75e16220af0f2ed971226c0e6c4e3a125c8"
+      },
+      "scalar": "0xde17547fd694aa85e6e793ff61e58fe244e8637d15a774f25c58989c9e504c2",
+      "Q": {
+        "x": "0x51e1a5f1a59c9e88eb165f762936167bafcd36e4d7b20c703d3775c6d9f7f71",
+        "y": "0x15f1eef9d77448e3d6e5e00aea7bf4ff9704176e9a1797b2d0ff7effa027a811"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0x87f2513d7746fe7975b2c2239bec5fddf94c7aab24f4ef408fced40edba551f",
+        "y": "0x2e0302f618a03f0e73b32ce1d438a3ebc930762a0607dd1eb777b363768be338"
+      },
+      "scalar": "0x5a7fffbdb16d74245e3fecbea1da2d32ad3673d26c942ef8acc773c271d6779",
+      "Q": {
+        "x": "0x4126547e270371f6acef12bcaa15ed4c7759a2cdf7f40805d3e31e772032049",
+        "y": "0x27aa4c8c3da3e174dd4a8c1b67e1e989fc4c2a27a438a40622ec429f2eddc5a"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0xfca9bb91281b91307d1db8874ad2f2f0f108bd619cfb9f93a034834c6f878",
+        "y": "0xa5b7f9ab5f0ebeb511d060d9f8b6056a6d0024b156eecf30bd2c0c909bdc83e"
+      },
+      "scalar": "0x19d1ea1b4a65a578cc4af0350a1a42a350cd4103112c9eaf976c57da8bcf166e",
+      "Q": {
+        "x": "0x34979fc99ce149d9f586d0b63de8147f1af90c3c149dd5d5a3c97697da0ac103",
+        "y": "0xdf81275e4db36e68f41895d7467bfc934a57919db5e002deb36c6d5bd45359d"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0x3f9ca99fb9499b37cbeb1bea63009250f9859f8b4218e67973428989411fd3ff",
+        "y": "0xd152226b266c18324d354827ba692ddd2da6b2ba7659f5f062e35367e46ce13"
+      },
+      "scalar": "0x3a143ff9bfbe38a03ebb6ce043ceb2371a999f5b1a4798c0848e5dfadcbfdcf9",
+      "Q": {
+        "x": "0x35686b1f039662fd63c399cc63f7638454f87a641dd4af877f6da5d6d6bfbe35",
+        "y": "0x2cb98369dc7b098a5c9dfbe20f1664cf51a3df41b2eec0e960c0f543b763b3ba"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0x3e7f18a78ad98fd7240345518a73b5bce00b64020e47f2905258ce8523173271",
+        "y": "0x3142b404ccb490f7d5c0b4994067f6b14eacd51e9217f2eb699cf9aa5906eb36"
+      },
+      "scalar": "0x3e1cfb7f1354525fc9e8032e6c3fd14d4dcf54d2987ee42bf38c6e53cdac95d7",
+      "Q": {
+        "x": "0x15924258d0b2f5ba6bb24eb345ebb24052b5f8b0f3d7a02b04eb1b97c8409032",
+        "y": "0xf060418a2605111b837692449ab781db733fdb6115c04688f278a96e8d8e671"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0x107f5bbb35eb735c320fa0666d1c04ee6ecdda94e889c7caa328e21ac9fc1ff2",
+        "y": "0x325a4b8aba70d089a9bea376eb30007583b0acd8a434ea5c8316a034f89d91c2"
+      },
+      "scalar": "0x22cba76072845f8d5d45aa4ce2efa998fc66ee686c61a8f4538552a9e6f2b794",
+      "Q": {
+        "x": "0x1d455daf6b036e5aca4420ff5cc0450c2bf3dec4746149acff00009cbadbfa1e",
+        "y": "0x385d91063d71530753cdab5682a73a602849dfeb2316abe36e6b4a6e04140b8b"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0x16feb08c254b0cfb2b34eefa14aa1de6f6e3c4129c0f753fb74425b8bf833667",
+        "y": "0x387aadc388415cf5dbc446edd8210453e3a4a800cc26a6c08aeaba1e230b5794"
+      },
+      "scalar": "0x154a12b9452166f5c275aa66bb2edaf61071b2a879410f65c2b41225eae64ab1",
+      "Q": {
+        "x": "0x3b364d6c48326ca2bae59aa9c515ec91db30770813ba1d80c6e0632204fe0ff7",
+        "y": "0x27b44130b481e352e447b04fa130d7412080ccc7f44cad4e439525bac799c8b8"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0x1c3426e28c87c46ebb166e4031cae447f362bff11c0ecd6fa4dbdd1d8c635347",
+        "y": "0x2490ef967538c9ca67e58842e8ea015b165da38d71151aadee204979b600ef72"
+      },
+      "scalar": "0x32e1410e52cc24a3944621abbd99d9f2f17d4008d023f99f8eec38e9554cef6b",
+      "Q": {
+        "x": "0x37821758dbcbe941e80627ee85feaa1957dc8a3b56e62774f460eae694132e9e",
+        "y": "0x39c9a2db16903e3a84d93ebe27380ae10102840c525ca2bd99333700a78e94d3"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0x1232f94004be88e7a778496195885d8f3d5fac8eb9a996b011b8138b826783ea",
+        "y": "0x7a58be0727a4e77b178783519da5ea8a327f9d2e7f1f3faa9eb796bbea47f64"
+      },
+      "scalar": "0x2c3496e3c96a539d25869b0434e903e460989f1123193bd9dabdf4c8f974c66a",
+      "Q": {
+        "x": "0x3cee52bf9f24ec17188fd26bf228079c7831e5b48a8cfec5fa059cb3a643054d",
+        "y": "0x335b6bc890b72d39b3414d0257b6ffb1f00feb0027b035f3d0a785ad67427a1"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0x2f494cf701e805a50e4574af6fbc5f13245d5d4d4798c6aa93eee63483417f7b",
+        "y": "0x1bd2d9692cc0c1fc5514b11203eb1843c2be65183db275c22f36fb737d13ee2b"
+      },
+      "scalar": "0x166c1a2d0e7c76ddd79f1aa27b600a6c9500f638794750401adae2dbecd5c56f",
+      "Q": {
+        "x": "0x1f74b61677333885e53c25578c7a5263ee3de2035b0b2ce0d4f422541cc04ccd",
+        "y": "0x3644c95944634ee9cd2b4c1dfff91fb08d0dffee6f271fc24ed21047392ab73"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0x1ae7d92d79f854b526d9be1cc57b96bbf939432a03af688747e23a910d4db803",
+        "y": "0x9969b2d0c5226a0386bea689873529f4e448f61816b617db65c63681c4e50f5"
+      },
+      "scalar": "0x31f99fa4af6be5bfa996f34a3243faf641eeb4a441613cee54e9cb6161038bd9",
+      "Q": {
+        "x": "0x333a735f6e589501871154d40564abeea4cd04bae148cab18c2b31d718bae9be",
+        "y": "0x9b18cbbb0eaef54479c19bf115eb4425b9a0033d4d03898b7f3f85852bddb91"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0x327880e8329bf792b555787a7285859a0f58d9a409e9efb5f0ff68528217ec4c",
+        "y": "0x1b1d55cfc64e977c55a91c0b3862e090e2f0a1f0696ad38025b06ddd36ace60"
+      },
+      "scalar": "0x4725b1fe2201df726e20a3eb0643653015a790f677d2ee13d0b97e55761fc13",
+      "Q": {
+        "x": "0x12f5cc7eb733c6df53b911ebd875b0b7fec8692a55a537c4be703ee63164a740",
+        "y": "0x25ccf79def6ab4bb0f0d19db04ddb5be2d46757384f9fe0c9fca2ba19094dc41"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0xac5049f5882453952031bb8ab471aae495c8cc4553dcc5c4fd27c9d6ddd7414",
+        "y": "0x338954a1ddc5b91391b4881b48d6b686b5e6a776f32faa8cb6e3e2490695ec54"
+      },
+      "scalar": "0x3a704c1be5ac08ff43834e9190c8dcdd8c5368bb690f8a5c5795d836a68e589d",
+      "Q": {
+        "x": "0x3523c461c262ef4acaa30e85937351a0b0d3a86527791bde0243fbe7f9f4e0bf",
+        "y": "0x122d38ef2cc133ca219510da54c6adc75974b21416017c53cb2bbea812d0f825"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0x236467bf9a78e8c6e113f7beae859a100190bc8ff62ee797b0aac1aeb6420072",
+        "y": "0x1e74eaeea7c4d0b9411f54c7fe32ab3e94b71af281cbdc69931baf46e1747761"
+      },
+      "scalar": "0x1a755936aeffcd6a67252928971c524c21a3bc4d64c1011a5900f99c40bd379",
+      "Q": {
+        "x": "0x77aabf7ff0fcdc2abdbce25ec9bfcc682ebe601f4b9485acbfb07af0ebcc127",
+        "y": "0x31c5672e46b7ae0315a6a258addcdadae279223cfff721ce9aa6910d71101d7"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #141

This implements field and elliptic curve arithmetic for the Pasta curves, including endomorphism acceleration.

Missing:
- Fast square root:
  - Sarkar sqrt procedure from https://github.com/zcash/halo2/issues/72 and https://eprint.iacr.org/2020/1407. Note: this might be tricky to make constant-time
  - or an addition chain
- Hashing to curve: Halo2 uses Blake2b hash function which is not implemented  