### PR TITLE
Add multipairing for BN curves

### DIFF
--- a/benchmarks/bench_pairing_bn254_nogami.nim
+++ b/benchmarks/bench_pairing_bn254_nogami.nim
@@ -58,6 +58,12 @@ proc main() =
     separator()
     pairingBNBench(curve, Iters)
     separator()
+    staticFor j, 2, 4:
+      pairing_multisingle_BNBench(curve, j, Iters div j)
+      pairing_multipairing_BNBench(curve, j, Iters div j)
+    separator()
+    staticFor j, 4, 9:
+      pairing_multipairing_BNBench(curve, j, Iters div j)
 
 main()
 notes()

--- a/benchmarks/bench_pairing_bn254_snarks.nim
+++ b/benchmarks/bench_pairing_bn254_snarks.nim
@@ -58,6 +58,12 @@ proc main() =
     separator()
     pairingBNBench(curve, Iters)
     separator()
+    staticFor j, 2, 4:
+      pairing_multisingle_BNBench(curve, j, Iters div j)
+      pairing_multipairing_BNBench(curve, j, Iters div j)
+    separator()
+    staticFor j, 4, 9:
+      pairing_multipairing_BNBench(curve, j, Iters div j)
 
 main()
 notes()

--- a/benchmarks/bench_pairing_template.nim
+++ b/benchmarks/bench_pairing_template.nim
@@ -233,10 +233,6 @@ proc pairingBLS12Bench*(C: static Curve, iters: int) =
     f.pairing_bls12(P, Q)
 
 proc pairing_multisingle_BLS12Bench*(C: static Curve, N: static int, iters: int) =
-  let
-    P = rng.random_point(ECP_ShortW_Aff[Fp[C], G1])
-    Q = rng.random_point(ECP_ShortW_Aff[Fp2[C], G2])
-
   var
     Ps {.noInit.}: array[N, ECP_ShortW_Aff[Fp[C], G1]]
     Qs {.noInit.}: array[N, ECP_ShortW_Aff[Fp2[C], G2]]
@@ -277,3 +273,36 @@ proc pairingBNBench*(C: static Curve, iters: int) =
   var f: Fp12[C]
   bench("Pairing BN", C, iters):
     f.pairing_bn(P, Q)
+
+proc pairing_multisingle_BNBench*(C: static Curve, N: static int, iters: int) =
+  var
+    Ps {.noInit.}: array[N, ECP_ShortW_Aff[Fp[C], G1]]
+    Qs {.noInit.}: array[N, ECP_ShortW_Aff[Fp2[C], G2]]
+
+    GTs {.noInit.}: array[N, Fp12[C]]
+
+  for i in 0 ..< N:
+    Ps[i] = rng.random_unsafe(typeof(Ps[0]))
+    Qs[i] = rng.random_unsafe(typeof(Qs[0]))
+
+  var f: Fp12[C]
+  bench("Pairing BN non-batched: " & $N, C, iters):
+    for i in 0 ..< N:
+      GTs[i].pairing_bn(Ps[i], Qs[i])
+
+    f = GTs[0]
+    for i in 1 ..< N:
+      f *= GTs[i]
+
+proc pairing_multipairing_BNBench*(C: static Curve, N: static int, iters: int) =
+  var
+    Ps {.noInit.}: array[N, ECP_ShortW_Aff[Fp[C], G1]]
+    Qs {.noInit.}: array[N, ECP_ShortW_Aff[Fp2[C], G2]]
+
+  for i in 0 ..< N:
+    Ps[i] = rng.random_unsafe(typeof(Ps[0]))
+    Qs[i] = rng.random_unsafe(typeof(Qs[0]))
+
+  var f: Fp12[C]
+  bench("Pairing BN batched:     " & $N, C, iters):
+    f.pairing_bn(Ps, Qs)

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -175,6 +175,11 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/math/t_pairing_bn254_snarks_optate.nim", false),
   ("tests/math/t_pairing_bls12_377_optate.nim", false),
   ("tests/math/t_pairing_bls12_381_optate.nim", false),
+
+  # Multi-Pairing
+  # ----------------------------------------------------------
+  ("tests/math/t_pairing_bn254_nogami_multi.nim", false),
+  ("tests/math/t_pairing_bn254_snarks_multi.nim", false),
   ("tests/math/t_pairing_bls12_381_multi.nim", false),
 
   # Prime order fields

--- a/constantine/math/curves/bls12_381_pairing.nim
+++ b/constantine/math/curves/bls12_381_pairing.nim
@@ -81,8 +81,6 @@ func millerLoopAddchain*[N: static int](
   f.miller_accum_double_then_add(Ts, Qs, Ps, 32)              # 0b110100100000000100000000000000000000000000000001
   f.miller_accum_double_then_add(Ts, Qs, Ps, 16, add = false) # 0b1101001000000001000000000000000000000000000000010000000000000000
 
-  # TODO: what is the threshold for Karabina's compressed squarings?
-
 func cycl_exp_by_curve_param_div2*(
        r: var Fp12[BLS12_381], a: Fp12[BLS12_381],
        invert = BLS12_381_pairing_ate_param_isNeg) =

--- a/tests/math/t_pairing_bn254_nogami_multi.nim
+++ b/tests/math/t_pairing_bn254_nogami_multi.nim
@@ -1,0 +1,62 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/[os, times, strformat],
+  # Internals
+  ../../constantine/platforms/abstractions,
+  ../../constantine/math/[arithmetic, extension_fields, ec_shortweierstrass],
+  ../../constantine/math/io/io_extfields,
+  ../../constantine/math/config/curves,
+  ../../constantine/math/pairing/pairing_bn,
+  # Test utilities
+  ../../helpers/prng_unsafe
+
+# Testing multipairing
+# ----------------------------------------------
+
+var rng: RngState
+let timeseed = uint32(toUnix(getTime()) and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+seed(rng, timeseed)
+echo "\n------------------------------------------------------\n"
+echo "test_pairing_bn254_nogami_multi xoshiro512** seed: ", timeseed
+
+proc testMultiPairing(rng: var RngState, N: static int) =
+  var
+    Ps {.noInit.}: array[N, ECP_ShortW_Aff[Fp[BN254_Nogami], G1]]
+    Qs {.noInit.}: array[N, ECP_ShortW_Aff[Fp2[BN254_Nogami], G2]]
+
+    GTs {.noInit.}: array[N, Fp12[BN254_Nogami]]
+
+  for i in 0 ..< N:
+    Ps[i] = rng.random_unsafe(typeof(Ps[0]))
+    Qs[i] = rng.random_unsafe(typeof(Qs[0]))
+
+  # Simple pairing
+  let clockSimpleStart = cpuTime()
+  var GTsimple {.noInit.}: Fp12[BN254_Nogami]
+  for i in 0 ..< N:
+    GTs[i].pairing_bn(Ps[i], Qs[i])
+
+  GTsimple = GTs[0]
+  for i in 1 ..< N:
+    GTsimple *= GTs[i]
+  let clockSimpleStop = cpuTime()
+
+  # Multipairing
+  let clockMultiStart = cpuTime()
+  var GTmulti {.noInit.}: Fp12[BN254_Nogami]
+  GTmulti.pairing_bn(Ps, Qs)
+  let clockMultiStop = cpuTime()
+
+  echo &"N={N}, Simple: {clockSimpleStop - clockSimpleStart:>4.4f}s, Multi: {clockMultiStop - clockMultiStart:>4.4f}s"
+  doAssert bool GTsimple == GTmulti
+
+staticFor i, 1, 17:
+  rng.testMultiPairing(N = i)

--- a/tests/math/t_pairing_bn254_snarks_multi.nim
+++ b/tests/math/t_pairing_bn254_snarks_multi.nim
@@ -1,0 +1,62 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/[os, times, strformat],
+  # Internals
+  ../../constantine/platforms/abstractions,
+  ../../constantine/math/[arithmetic, extension_fields, ec_shortweierstrass],
+  ../../constantine/math/io/io_extfields,
+  ../../constantine/math/config/curves,
+  ../../constantine/math/pairing/pairing_bn,
+  # Test utilities
+  ../../helpers/prng_unsafe
+
+# Testing multipairing
+# ----------------------------------------------
+
+var rng: RngState
+let timeseed = uint32(toUnix(getTime()) and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+seed(rng, timeseed)
+echo "\n------------------------------------------------------\n"
+echo "test_pairing_bn254_snarks_multi xoshiro512** seed: ", timeseed
+
+proc testMultiPairing(rng: var RngState, N: static int) =
+  var
+    Ps {.noInit.}: array[N, ECP_ShortW_Aff[Fp[BN254_Snarks], G1]]
+    Qs {.noInit.}: array[N, ECP_ShortW_Aff[Fp2[BN254_Snarks], G2]]
+
+    GTs {.noInit.}: array[N, Fp12[BN254_Snarks]]
+
+  for i in 0 ..< N:
+    Ps[i] = rng.random_unsafe(typeof(Ps[0]))
+    Qs[i] = rng.random_unsafe(typeof(Qs[0]))
+
+  # Simple pairing
+  let clockSimpleStart = cpuTime()
+  var GTsimple {.noInit.}: Fp12[BN254_Snarks]
+  for i in 0 ..< N:
+    GTs[i].pairing_bn(Ps[i], Qs[i])
+
+  GTsimple = GTs[0]
+  for i in 1 ..< N:
+    GTsimple *= GTs[i]
+  let clockSimpleStop = cpuTime()
+
+  # Multipairing
+  let clockMultiStart = cpuTime()
+  var GTmulti {.noInit.}: Fp12[BN254_Snarks]
+  GTmulti.pairing_bn(Ps, Qs)
+  let clockMultiStop = cpuTime()
+
+  echo &"N={N}, Simple: {clockSimpleStop - clockSimpleStart:>4.4f}s, Multi: {clockMultiStop - clockMultiStart:>4.4f}s"
+  doAssert bool GTsimple == GTmulti
+
+staticFor i, 1, 17:
+  rng.testMultiPairing(N = i)


### PR DESCRIPTION
Batched multipairing:

BN254_Nogami
![image](https://user-images.githubusercontent.com/22738317/167259012-e938af69-ef89-4499-9f99-89270edcdadb.png)

BN254_Snarks
![image](https://user-images.githubusercontent.com/22738317/167259060-69f4222a-8219-4745-9136-638315d3abd9.png)

This will significantly improve Codex performance for Proof-of-Retrievals over BN254_Snarks (https://github.com/status-im/nim-codex/pull/76) cc @cskiraly