### PR TITLE
Bindings autogeneration via Genny

### DIFF
--- a/bindings/constantine_bls12_381.nim
+++ b/bindings/constantine_bls12_381.nim
@@ -1,0 +1,24 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../constantine/math/config/curves,
+  ../constantine/curves_primitives,
+  genny
+
+type
+  bls12381_fr = Fr[BLS12_381]
+  bls12381_fp = Fp[BLS12_381]
+
+exportObject bls12381_fr:
+  procs:
+    neg(bls12381_fr, bls12381_fr)
+    neg(bls12381_fr)
+
+writeFiles("bindings/generated", "ctt_bls12_381")
+include generated/internal

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -333,8 +333,37 @@ proc buildAllBenches(useAsm = true) =
   buildBench("bench_hash_to_curve", useAsm = useAsm)
   echo "All benchmarks compile successfully."
 
+
+proc genBindings(bindingsName: string) =
+  proc compile(libName, bindingsName: string, flags = "") =
+    # -d:danger to avoid boundsCheck, overflowChecks that would trigger exceptions or allocations in a crypto library.
+    #           Those are internally guaranteed at compile-time by fixed-sized array
+    #           and checked at runtime with an appropriate error code if any for user-input.
+    # -gc:arc   Constantine stack allocates everything. Inputs are through unmanaged ptr+len.
+    #           In the future, Constantine might use:
+    #             - heap-allocated sequences and objects manually managed or managed by destructors for multithreading.
+    #             - heap-allocated strings for hex-string or decimal strings
+    exec "nim c -f " & flags & " -d:danger --app:lib --gc:arc --out:" & libName & " --outdir:bindings/generated bindings/" & bindingsName & ".nim"
+
+  when defined(windows):
+    compile bindingsName & ".dll", bindingsName
+
+  elif defined(macosx):
+    compile "lib" & bindingsName & ".dylib.arm", bindingsName, "--cpu:arm64 -l:'-target arm64-apple-macos11' -t:'-target arm64-apple-macos11'"
+    compile "lib" & bindingsName & ".dylib.x64", bindingsName, "--cpu:amd64 -l:'-target x86_64-apple-macos10.12' -t:'-target x86_64-apple-macos10.12'"
+    exec "lipo bindings/generated/lib" & bindingsName & ".dylib.arm " &
+             " bindings/generated/lib" & bindingsName & ".dylib.x64 " &
+             " -output bindings/generated/lib" & bindingsName & ".dylib -create"
+
+  else:
+    compile "lib" & bindingsName & ".so", bindingsName
+
+
 # Tasks
 # ----------------------------------------------------------------
+
+task bindings, "Generate Constantine bindings":
+  genBindings("constantine_bls12_381")
 
 task test, "Run all tests":
   # -d:testingCurves is configured in a *.nim.cfg for convenience


### PR DESCRIPTION
This is a tentative auto-bindings generation using [Genny](https://github.com/treeform/genny) for:
- C
- Nim
- Javascript
- Python

which would fix #98 (library build) and help #54 (fuzzing)

Currently this is blocked by upstream:
- https://github.com/treeform/genny/issues/43: Add support for generics
- https://github.com/treeform/genny/issues/44: Add support for type aliases
- https://github.com/treeform/genny/issues/45: Add support for generic fields
- https://github.com/treeform/genny/issues/46: Add support for distinct base types