### PR TITLE
Batch additions

### DIFF
--- a/benchmarks/bench_ec_g1_batch.nim
+++ b/benchmarks/bench_ec_g1_batch.nim
@@ -48,10 +48,17 @@ proc main() =
     for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
       let batchIters = max(1, Iters div numPoints)
       multiAddBench(ECP_ShortW_Prj[Fp[curve], G1], numPoints, useBatching = false, batchIters)
+    separator()
+    for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
+      let batchIters = max(1, Iters div numPoints)
       multiAddBench(ECP_ShortW_Prj[Fp[curve], G1], numPoints, useBatching = true, batchIters)
+    separator()
     for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
       let batchIters = max(1, Iters div numPoints)
       multiAddBench(ECP_ShortW_Jac[Fp[curve], G1], numPoints, useBatching = false, batchIters)
+    separator()
+    for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
+      let batchIters = max(1, Iters div numPoints)
       multiAddBench(ECP_ShortW_Jac[Fp[curve], G1], numPoints, useBatching = true, batchIters)
     separator()
     separator()

--- a/benchmarks/bench_ec_g1_batch.nim
+++ b/benchmarks/bench_ec_g1_batch.nim
@@ -11,6 +11,7 @@ import
   ../constantine/math/config/curves,
   ../constantine/math/arithmetic,
   ../constantine/math/elliptic/[
+    ec_shortweierstrass_affine,
     ec_shortweierstrass_projective,
     ec_shortweierstrass_jacobian],
   # Helpers

--- a/benchmarks/bench_ec_g1_batch.nim
+++ b/benchmarks/bench_ec_g1_batch.nim
@@ -1,0 +1,60 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../constantine/math/config/curves,
+  ../constantine/math/arithmetic,
+  ../constantine/math/elliptic/[
+    ec_shortweierstrass_projective,
+    ec_shortweierstrass_jacobian],
+  # Helpers
+  ../helpers/static_for,
+  ./bench_elliptic_template,
+  # Standard library
+  std/strutils
+
+# ############################################################
+#
+#               Benchmark of the G1 group of
+#            Short Weierstrass elliptic curves
+#          in (homogeneous) projective coordinates
+#
+# ############################################################
+
+
+const Iters = 10_000
+const AvailableCurves = [
+  # BN254_Snarks,
+  BLS12_381,
+]
+
+proc main() =
+  separator()
+  staticFor i, 0, AvailableCurves.len:
+    const curve = AvailableCurves[i]
+    addBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    addBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    mixedAddBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    mixedAddBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    doublingBench(ECP_ShortW_Prj[Fp[curve], G1], Iters)
+    doublingBench(ECP_ShortW_Jac[Fp[curve], G1], Iters)
+    separator()
+    for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
+      let batchIters = max(1, Iters div numPoints)
+      multiAddBench(ECP_ShortW_Prj[Fp[curve], G1], numPoints, useBatching = false, batchIters)
+      multiAddBench(ECP_ShortW_Prj[Fp[curve], G1], numPoints, useBatching = true, batchIters)
+    for numPoints in [10, 100, 1000, 10000, 100000, 1000000]:
+      let batchIters = max(1, Iters div numPoints)
+      multiAddBench(ECP_ShortW_Jac[Fp[curve], G1], numPoints, useBatching = false, batchIters)
+      multiAddBench(ECP_ShortW_Jac[Fp[curve], G1], numPoints, useBatching = true, batchIters)
+    separator()
+    separator()
+
+main()
+notes()

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -268,7 +268,7 @@ const skipSanitizers = [
   "tests/math/t_ec_sage_bn254_snarks.nim",
   "tests/math/t_ec_sage_bls12_377.nim",
   "tests/math/t_ec_sage_bls12_381.nim",
-  "tests/t_blssig_pop_on_bls12381_g2",
+  "tests/t_blssig_pop_on_bls12381_g2.nim",
   "tests/t_hash_to_field.nim",
   "tests/t_hash_to_curve.nim",
   "tests/t_hash_to_curve_random.nim",

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -275,7 +275,7 @@ const skipSanitizers = [
   "tests/t_mac_poly1305.nim",
   "tests/t_mac_hmac.nim",
   "tests/t_kdf_hkdf.nim",
-  "tests/t_ethereum_eip2333_bls12381_key_derivation"
+  "tests/t_ethereum_eip2333_bls12381_key_derivation.nim"
 ]
 
 when defined(windows):

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -268,6 +268,7 @@ const skipSanitizers = [
   "tests/math/t_ec_sage_bn254_snarks.nim",
   "tests/math/t_ec_sage_bls12_377.nim",
   "tests/math/t_ec_sage_bls12_381.nim",
+  "tests/t_blssig_pop_on_bls12381_g2",
   "tests/t_hash_to_field.nim",
   "tests/t_hash_to_curve.nim",
   "tests/t_hash_to_curve_random.nim",

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -96,13 +96,13 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
 
   # Elliptic curve arithmetic G1
   # ----------------------------------------------------------
-  # ("tests/math/t_ec_shortw_prj_g1_add_double.nim", false),
+  ("tests/math/t_ec_shortw_prj_g1_add_double.nim", false),
   # ("tests/math/t_ec_shortw_prj_g1_mul_sanity.nim", false),
   # ("tests/math/t_ec_shortw_prj_g1_mul_distri.nim", false),
   ("tests/math/t_ec_shortw_prj_g1_mul_vs_ref.nim", false),
   ("tests/math/t_ec_shortw_prj_g1_mixed_add.nim", false),
 
-  # ("tests/math/t_ec_shortw_jac_g1_add_double.nim", false),
+  ("tests/math/t_ec_shortw_jac_g1_add_double.nim", false),
   # ("tests/math/t_ec_shortw_jac_g1_mul_sanity.nim", false),
   # ("tests/math/t_ec_shortw_jac_g1_mul_distri.nim", false),
   ("tests/math/t_ec_shortw_jac_g1_mul_vs_ref.nim", false),
@@ -115,49 +115,49 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
 
   # Elliptic curve arithmetic G2
   # ----------------------------------------------------------
-  # ("tests/math/t_ec_shortw_prj_g2_add_double_bn254_snarks.nim", false),
+  ("tests/math/t_ec_shortw_prj_g2_add_double_bn254_snarks.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_sanity_bn254_snarks.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_distri_bn254_snarks.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mul_vs_ref_bn254_snarks.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mixed_add_bn254_snarks.nim", false),
 
-  # ("tests/math/t_ec_shortw_prj_g2_add_double_bls12_381.nim", false),
+  ("tests/math/t_ec_shortw_prj_g2_add_double_bls12_381.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_sanity_bls12_381.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_distri_bls12_381.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mul_vs_ref_bls12_381.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mixed_add_bls12_381.nim", false),
 
-  # ("tests/math/t_ec_shortw_prj_g2_add_double_bls12_377.nim", false),
+  ("tests/math/t_ec_shortw_prj_g2_add_double_bls12_377.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_sanity_bls12_377.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_distri_bls12_377.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mul_vs_ref_bls12_377.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mixed_add_bls12_377.nim", false),
 
-  # ("tests/math/t_ec_shortw_prj_g2_add_double_bw6_761.nim", false),
+  ("tests/math/t_ec_shortw_prj_g2_add_double_bw6_761.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_sanity_bw6_761.nim", false),
   # ("tests/math/t_ec_shortw_prj_g2_mul_distri_bw6_761.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mul_vs_ref_bw6_761.nim", false),
   ("tests/math/t_ec_shortw_prj_g2_mixed_add_bw6_761.nim", false),
 
-  # ("tests/math/t_ec_shortw_jac_g2_add_double_bn254_snarks.nim", false),
+  ("tests/math/t_ec_shortw_jac_g2_add_double_bn254_snarks.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_sanity_bn254_snarks.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_distri_bn254_snarks.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mul_vs_ref_bn254_snarks.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mixed_add_bn254_snarks.nim", false),
 
-  # ("tests/math/t_ec_shortw_jac_g2_add_double_bls12_381.nim", false),
+  ("tests/math/t_ec_shortw_jac_g2_add_double_bls12_381.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_sanity_bls12_381.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_distri_bls12_381.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mul_vs_ref_bls12_381.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mixed_add_bls12_381.nim", false),
 
-  # ("tests/math/t_ec_shortw_jac_g2_add_double_bls12_377.nim", false),
+  ("tests/math/t_ec_shortw_jac_g2_add_double_bls12_377.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_sanity_bls12_377.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_distri_bls12_377.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mul_vs_ref_bls12_377.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mixed_add_bls12_377.nim", false),
 
-  # ("tests/math/t_ec_shortw_jac_g2_add_double_bw6_761.nim", false),
+  ("tests/math/t_ec_shortw_jac_g2_add_double_bw6_761.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_sanity_bw6_761.nim", false),
   # ("tests/math/t_ec_shortw_jac_g2_mul_distri_bw6_761.nim", false),
   ("tests/math/t_ec_shortw_jac_g2_mul_vs_ref_bw6_761.nim", false),

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -177,6 +177,11 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ----------------------------------------------------------
   ("tests/math/t_ec_shortw_prj_edge_cases.nim", false),
 
+  # Elliptic curve arithmetic - batch computation
+  # ----------------------------------------------------------
+  ("tests/math/t_ec_shortw_prj_g1_batch_add.nim", false),
+  ("tests/math/t_ec_shortw_jac_g1_batch_add.nim", false),
+
   # Subgroups and cofactors
   # ----------------------------------------------------------
   ("tests/math/t_ec_subgroups_bn254_nogami.nim", false),
@@ -232,6 +237,7 @@ const benchDesc = [
   "bench_fp6",
   "bench_fp12",
   "bench_ec_g1",
+  "bench_ec_g1_batch",
   "bench_ec_g2",
   "bench_pairing_bls12_377",
   "bench_pairing_bls12_381",
@@ -302,8 +308,8 @@ template setupCommand(): untyped {.dirty.} =
   var flags = flags
   when not defined(windows):
     # Not available in MinGW https://github.com/libressl-portable/portable/issues/54
-    flags &= " --passC:-fstack-protector-all"
-  let command = "nim " & lang & cc & " " & flags &
+    flags &= " --passC:-fstack-protector-strong"
+  let command = "nim " & lang & cc & " -d:release " & flags &
     " --verbosity:0 --outdir:build/testsuite -r --hints:off --warnings:off " &
     " --nimcache:nimcache/" & path & " " &
     path
@@ -672,37 +678,55 @@ task bench_fp12_clang_noasm, "Run benchmark 𝔽p12 with clang - no Assembly":
 # Elliptic curve G1
 # ------------------------------------------
 
-task bench_ec_g1, "Run benchmark on Elliptic Curve group 𝔾1 - Short Weierstrass with Projective Coordinates - Default compiler":
+task bench_ec_g1, "Run benchmark on Elliptic Curve group 𝔾1 - Default compiler":
   runBench("bench_ec_g1")
 
-task bench_ec_g1_gcc, "Run benchmark on Elliptic Curve group 𝔾1 - Short Weierstrass with Projective Coordinates - GCC":
+task bench_ec_g1_gcc, "Run benchmark on Elliptic Curve group 𝔾1 - GCC":
   runBench("bench_ec_g1", "gcc")
 
-task bench_ec_g1_clang, "Run benchmark on Elliptic Curve group 𝔾1 - Short Weierstrass with Projective Coordinates - Clang":
+task bench_ec_g1_clang, "Run benchmark on Elliptic Curve group 𝔾1 - Clang":
   runBench("bench_ec_g1", "clang")
 
-task bench_ec_g1_gcc_noasm, "Run benchmark on Elliptic Curve group 𝔾1 - Short Weierstrass with Projective Coordinates - GCC no Assembly":
+task bench_ec_g1_gcc_noasm, "Run benchmark on Elliptic Curve group 𝔾1 - GCC no Assembly":
   runBench("bench_ec_g1", "gcc", useAsm = false)
 
-task bench_ec_g1_clang_noasm, "Run benchmark on Elliptic Curve group 𝔾1 - Short Weierstrass with Projective Coordinates - Clang no Assembly":
+task bench_ec_g1_clang_noasm, "Run benchmark on Elliptic Curve group 𝔾1 - Clang no Assembly":
+  runBench("bench_ec_g1", "clang", useAsm = false)
+
+# Elliptic curve G1 - batch operations
+# ------------------------------------------
+
+task bench_ec_g1_batch, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops) - Default compiler":
+  runBench("bench_ec_g1_batch")
+
+task bench_ec_g1_batch_gcc, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops) - GCC":
+  runBench("bench_ec_g1_batch", "gcc")
+
+task bench_ec_g1_batch_clang, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops) - Clang":
+  runBench("bench_ec_g1_batch", "clang")
+
+task bench_ec_g1_batch_gcc_noasm, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops) - GCC no Assembly":
+  runBench("bench_ec_g1_batch", "gcc", useAsm = false)
+
+task bench_ec_g1_batch_clang_noasm, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops) - Clang no Assembly":
   runBench("bench_ec_g1", "clang", useAsm = false)
 
 # Elliptic curve G2
 # ------------------------------------------
 
-task bench_ec_g2, "Run benchmark on Elliptic Curve group 𝔾2 - Short Weierstrass with Projective Coordinates - Default compiler":
+task bench_ec_g2, "Run benchmark on Elliptic Curve group 𝔾2 - Default compiler":
   runBench("bench_ec_g2")
 
-task bench_ec_g2_gcc, "Run benchmark on Elliptic Curve group 𝔾2 - Short Weierstrass with Projective Coordinates - GCC":
+task bench_ec_g2_gcc, "Run benchmark on Elliptic Curve group 𝔾2 - GCC":
   runBench("bench_ec_g2", "gcc")
 
-task bench_ec_g2_clang, "Run benchmark on Elliptic Curve group 𝔾2 - Short Weierstrass with Projective Coordinates - Clang":
+task bench_ec_g2_clang, "Run benchmark on Elliptic Curve group 𝔾2 - Clang":
   runBench("bench_ec_g2", "clang")
 
-task bench_ec_g2_gcc_noasm, "Run benchmark on Elliptic Curve group 𝔾2 - Short Weierstrass with Projective Coordinates - GCC no Assembly":
+task bench_ec_g2_gcc_noasm, "Run benchmark on Elliptic Curve group 𝔾2 - GCC no Assembly":
   runBench("bench_ec_g2", "gcc", useAsm = false)
 
-task bench_ec_g2_clang_noasm, "Run benchmark on Elliptic Curve group 𝔾2 - Short Weierstrass with Projective Coordinates - Clang no Assembly":
+task bench_ec_g2_clang_noasm, "Run benchmark on Elliptic Curve group 𝔾2 - Clang no Assembly":
   runBench("bench_ec_g2", "clang", useAsm = false)
 
 # Pairings

--- a/constantine/math/elliptic/README.md
+++ b/constantine/math/elliptic/README.md
@@ -62,7 +62,7 @@ Ry = λ(Px - Rx) - Py
 ```
 but in the case of addition
 ```
-λ = (Qy - Py) / (Px - Qx)
+λ = (Qy - Py) / (Qx - Px)
 ```
 which is undefined for P == Q or P == -Q (as `-(x, y) = (x, -y)`)
 

--- a/constantine/math/elliptic/ec_shortweierstrass_affine.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_affine.nim
@@ -14,6 +14,9 @@ import
   ../io/[io_fields, io_extfields],
   ../constants/zoo_constants
 
+# No exceptions allowed
+{.push raises: [].}
+
 # ############################################################
 #
 #             Elliptic Curve in Short Weierstrass form

--- a/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
@@ -1,0 +1,301 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../../platforms/[abstractions, allocs],
+  ../arithmetic,
+  ../extension_fields,
+  ./ec_shortweierstrass_affine,
+  ./ec_shortweierstrass_jacobian,
+  ./ec_shortweierstrass_projective
+
+# No exceptions allowed
+{.push raises: [].}
+
+# ############################################################
+#
+#             Elliptic Curve in Short Weierstrass form
+#                     Batch addition
+#
+# ############################################################
+
+# Affine primitives
+# ------------------------------------------------------------
+#
+# The equation for elliptic curve addition is in affine (x, y) coordinates:
+# 
+# P + Q = R
+# (Px, Py) + (Qx, Qy) = (Rx, Ry)
+# 
+# with
+#   Rx = λ² - Px - Qx
+#   Ry = λ(Px - Rx) - Py
+# 
+# in the case of addition
+#   λ = (Qy - Py) / (Qx - Px)
+# 
+# which is undefined for P == Q or P == -Q as -(x, y) = (x, -y)
+# 
+# if P = Q, the doubling formula uses the slope of the tangent at the limit
+#   λ = (3 Px² + a) / (2 Px)
+#
+# if P = -Q, the sum is the point at infinity
+#
+# ~~~~
+#
+# Those formulas require
+#   addition: 2M + 1S + 1I
+#   doubling: 2M + 2S + 1I
+#
+# Inversion is very expensive:
+#   119.5x multiplications (with ADX) for BN254
+#   98.4x  multiplications (with ADX) for BLS12-381
+#
+# However, n inversions can use Montgomery's batch inversion
+# at the cost of 3(n-1)M + 1I
+#
+# Hence batch addition can have an asymptotic cost of
+#   5M + 1S
+# Compared to
+#   Jacobian addition:         12M + 4S
+#   Jacobian mixed addition:    7M + 4S
+#   Projective addition:       12M      (for curves in the form y² = x³ + b)
+#   Projective mixed addition: 11M      (for curves in the form y² = x³ + b)
+
+func lambdaAdd[F; G: static Subgroup](lambda_num, lambda_den: var F, P, Q: ECP_ShortW_Aff[F, G]) =
+  ## Compute the slope of the line (PQ)
+  lambda_num.diff(Q.y, P.y)
+  lambda_den.diff(Q.x, P.x)
+
+func lambdaDouble[F; G: static Subgroup](lambda_num, lambda_den: var F, P: ECP_ShortW_Aff[F, G]) =
+  ## Compute the tangent at P
+  lambda_num.square(P.x)
+  lambda_num *= 3
+  when F.C.getCoefA() != 0:
+    t += F.C.getCoefA()
+
+  lambda_den.double(P.y)
+
+func affineAdd[F; G: static Subgroup](
+       r: var ECP_ShortW_Aff[F, G],
+       lambda: var F,
+       P, Q: ECP_ShortW_Aff[F, G]) =
+  
+  r.x.square(lambda)
+  r.x -= P.x
+  r.x -= Q.x
+
+  r.y.diff(P.x, r.x)
+  r.y *= lambda
+  r.y -= P.y
+
+{.push checks:off.}
+func accum_half_vartime[F; G: static Subgroup](
+       points: ptr UncheckedArray[ECP_ShortW_Aff[F, G]],
+       lambdas: ptr UncheckedArray[tuple[num, den: F]],
+       len: uint) {.noinline.} =
+  ## Affine accumulation of half the points into the other half
+  ## Warning ⚠️ : variable-time
+  ## 
+  ## Accumulate `len` points pairwise into `len/2` 
+  ## 
+  ## Input/output:
+  ## - points: `len/2` affine points to add (must be even)
+  ##           Partial sums are stored in [0, len/2)
+  ##           [len/2, len) data has been destroyed
+  ## 
+  ## Scratchspace:
+  ## - Lambdas
+  ## 
+  ## Output:
+  ## - r
+  ## 
+  ## Warning ⚠️ : cannot be inlined if used in loop due to the use of alloca
+
+  debug: doAssert len and 1 == 0, "There must be an even number of points"
+  
+  let N = len div 2
+
+  # Step 1: Compute numerators and denominators of λᵢ = λᵢ_num / λᵢ_den
+  for i in 0 ..< N:
+    let p = i
+    let q = i+N
+    let q_prev = i-1+N
+
+    # As we can't divide by 0 in normal cases, λᵢ_den != 0,
+    # so we use it to indicate special handling.
+    template markSpecialCase(): untyped {.dirty.} =
+      #  we use Qy as an accumulator, so we save Qy in λᵢ_num
+      lambdas[i].num = points[q].y
+      # Mark for special handling
+      lambdas[i].den.setZero()
+
+      # Step 2: Accumulate denominators in Qy, which is not used anymore.
+      if i == 0:
+        points[q].y.setOne()
+      else:
+        points[q].y = points[q_prev].y
+
+    # Special case 1: infinity points have affine coordinates (0, 0) by convention
+    #                 it doesn't match the y²=x³+ax+b equation so slope formula need special handling
+    if points[p].isInf().bool() or points[q].isInf().bool():
+      markSpecialCase()
+      continue
+
+    # Special case 2: λ = (Qy-Py)/(Qx-Px) which is undefined when Px == Qx
+    #                 This happens when P == Q or P == -Q
+    if bool(points[p].x == points[q].x):
+      if bool(points[p].y == points[q].y):
+        lambdaDouble(lambdas[i].num, lambdas[i].den, points[p])
+      else: # P = -Q, so P+Q = inf
+        markSpecialCase()
+        continue
+    else:
+      lambdaAdd(lambdas[i].num, lambdas[i].den, points[p], points[q])
+  
+    # Step 2: Accumulate denominators in Qy, which is not used anymore.
+    if i == 0:
+      points[q].y = lambdas[i].den
+    else:
+      points[q].y.prod(points[q_prev].y, lambdas[i].den)
+
+  # Step 3: batch invert
+  var accInv {.noInit.}: F
+  accInv.inv(points[len-1].y)
+
+  # Step 4: Compute the partial sums
+
+  template recallSpecialCase(i, p, q): untyped {.dirty.} =
+    # As Qy is used as an accumulator, we saved Qy in λᵢ_num
+    # For special caseshandling, restore it.
+    points[q].y = lambdas[i].num
+    if points[p].isInf().bool():
+      points[i] = points[q]
+    elif points[q].x.isZero().bool() and lambdas[i].num.isZero().bool():
+      discard "points[i] = points[p]" # i == p
+    else:
+      points[i].setInf()
+
+  for i in countdown(N-1, 1):
+    let p = i
+    let q = i+N
+    let q_prev = i-1+N
+
+    if lambdas[i].den.isZero().bool():
+      recallSpecialCase(i, p, q)
+      continue
+
+    # Compute lambda
+    points[q].y.prod(accInv, points[q_prev].y)
+    points[q].y *= lambdas[i].num
+    
+    # Compute EC addition 
+    var r{.noInit.}: ECP_ShortW_Aff[F, G]
+    r.affineAdd(lambda = points[q].y, points[p], points[q])    
+
+    # Store result
+    points[i] = r
+
+    # Next iteration
+    accInv *= lambdas[i].den
+
+  block: # Tail
+    let i = 0
+    let p = 0
+    let q = N
+
+    if lambdas[0].den.isZero().bool():
+      recallSpecialCase(i, p, q)
+    else:
+      # Compute lambda
+      points[q].y.prod(lambdas[0].num, accInv)
+  
+      # Compute EC addition 
+      var r{.noInit.}: ECP_ShortW_Aff[F, G]
+      r.affineAdd(lambda = points[q].y, points[p], points[q])    
+
+      # Store result
+      points[0] = r
+
+{.pop.}
+
+# Batch addition: jacobian
+# ------------------------------------------------------------
+
+{.push checks:off.}
+func accumSum_chunk_vartime[F; G: static Subgroup](
+       r: var (ECP_ShortW_Jac[F, G] or ECP_ShortW_Prj[F, G]),
+       points: ptr UncheckedArray[ECP_ShortW_Aff[F, G]],
+       lambdas: ptr UncheckedArray[tuple[num, den: F]],
+       len: uint) =
+  ## Accumulate `points` into r.
+  ## `r` is NOT overwritten
+  ## r += ∑ points
+  
+  const ChunkThreshold = 16
+  var n = len
+
+  while n >= ChunkThreshold:
+    if (n and 1) == 1: # odd number of points
+      ## Accumulate the last
+      r += points[n-1]
+      n -= 1
+    
+    # Compute [0, n/2) += [n/2, n)
+    accum_half_vartime(points, lambdas, n)
+
+    # Next chunk
+    n = n div 2
+
+  # Tail
+  for i in 0'u ..< n:
+    r += points[i]
+{.pop.}
+
+{.push checks:off.}
+func sum_batch_vartime*[F; G: static Subgroup](
+       r: var (ECP_ShortW_Jac[F, G] or ECP_ShortW_Prj[F, G]),
+       points: openArray[ECP_ShortW_Aff[F, G]]) =
+  ## Batch addition of `points` into `r`
+  ## `r` is overwritten
+  
+  # We chunk the addition to limit memory usage
+  # especially as we allocate on the stack.
+
+  # From experience in high-performance computing,
+  # here are the constraints we want to optimize for
+  #   1. MSVC limits stack to 1MB by default, we want to use a fraction of that.
+  #   2. We want to use a large fraction of L2 cache, but not more.
+  #   3. We want to use a large fraction of the memory addressable by the TLB.
+  #   4. We optimize for hyperthreading with 2 sibling threads (Xeon Phi hyperthreads have 4 siblings).
+  #      Meaning we want to use less than half the L2 cache so that if run on siblings threads (same physical core),
+  #      the chunks don't evict each other.
+  #
+  # Hardware:
+  # - a Raspberry Pi 4 (2019, Cortex A72) has 1MB L2 cache size
+  # - Intel Ice Lake (2019, Core 11XXX) and AMD Zen 2 (2019, Ryzen 3XXX) have 512kB L2 cache size
+  #
+  # After one chunk is processed we are well within all 64-bit CPU L2 cache bounds
+  # as we halve after each chunk.
+
+  r.setInf()
+
+  const maxChunkSize = 262144 # 2¹⁸ = 262144
+  const maxStride = maxChunkSize div sizeof(ECP_ShortW_Aff[F, G])
+  
+  let n = min(maxStride, points.len)
+  let accumulators = alloca(ECP_ShortW_Aff[F, G], n)
+  let lambdas = alloca(tuple[num, den: F], n)
+
+  for i in countup(0, points.len-1, maxStride):
+    let n = min(maxStride, points.len - i)
+    let size = n * sizeof(ECP_ShortW_Aff[F, G])
+    copyMem(accumulators[0].addr, points[i].unsafeAddr, size)
+    r.accumSum_chunk_vartime(accumulators, lambdas, uint n)
+
+{.pop.} 

--- a/constantine/math/elliptic/ec_shortweierstrass_jacobian.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_jacobian.nim
@@ -15,6 +15,9 @@ import
 
 export Subgroup
 
+# No exceptions allowed
+{.push raises: [].}
+
 # ############################################################
 #
 #             Elliptic Curve in Short Weierstrass form

--- a/constantine/math/elliptic/ec_shortweierstrass_projective.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_projective.nim
@@ -480,9 +480,6 @@ func batchAffine*[N: static int, F, G](
   accInv.inv(affs[N-1].x)
 
   for i in countdown(N-1, 1):
-    # Skip zero z-coordinates (infinity points)
-    var z = affs[i].x
-
     # Extract 1/Pᵢ
     var invi {.noInit.}: F
     invi.prod(accInv, affs[i-1].x, skipFinalSub = true)

--- a/constantine/math/elliptic/ec_shortweierstrass_projective.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_projective.nim
@@ -471,7 +471,10 @@ func batchAffine*[N: static int, F, G](
     zeroes[i] = z.isZero()
     z.csetOne(zeroes[i])
 
-    affs[i].x.prod(affs[i-1].x, z)
+    if i != N-1:
+      affs[i].x.prod(affs[i-1].x, z, skipFinalSub = true)
+    else:
+      affs[i].x.prod(affs[i-1].x, z, skipFinalSub = false)
   
   var accInv {.noInit.}: F
   accInv.inv(affs[N-1].x)
@@ -482,7 +485,7 @@ func batchAffine*[N: static int, F, G](
 
     # Extract 1/Pᵢ
     var invi {.noInit.}: F
-    invi.prod(accInv, affs[i-1].x)
+    invi.prod(accInv, affs[i-1].x, skipFinalSub = true)
     invi.csetZero(zeroes[i])
 
     # Now convert Pᵢ to affine
@@ -492,7 +495,7 @@ func batchAffine*[N: static int, F, G](
     # next iteration
     invi = projs[i].z
     invi.csetOne(zeroes[i])
-    accInv *= invi
+    accInv.prod(accInv, invi, skipFinalSub = true)
   
   block: # tail
     accInv.csetZero(zeroes[0])

--- a/constantine/math/elliptic/ec_twistededwards_projective.nim
+++ b/constantine/math/elliptic/ec_twistededwards_projective.nim
@@ -276,6 +276,10 @@ func double*[Field](
   E -= D           # C stores E-D
   r.y *= E
 
+func `+=`*(P: var ECP_TwEdwards_Prj, Q: ECP_TwEdwards_Prj) {.inline.} =
+  ## In-place point addition
+  P.sum(P, Q)
+
 func double*(P: var ECP_TwEdwards_Prj) {.inline.} =
   ## In-place EC doubling
   P.double(P)

--- a/constantine/math/extension_fields/towers.nim
+++ b/constantine/math/extension_fields/towers.nim
@@ -2156,5 +2156,29 @@ func inv*(a: var CubicExt) =
   ## to affine for elliptic curve
   a.invImpl(a)
 
+# Convenience functions
+# ----------------------------------------------------------------------
+
+template square*(a: var ExtensionField, skipFinalSub: static bool) =
+  # Square alias,
+  # this allows using the same code for
+  # the base field and its extensions while benefitting from skipping
+  # the final substraction on Fp
+  a.square()
+
+template square*(r: var ExtensionField, a: ExtensionField, skipFinalSub: static bool) =
+  # Square alias,
+  # this allows using the same code for
+  # the base field and its extensions while benefitting from skipping
+  # the final substraction on Fp
+  r.square(a)
+
+template prod*(r: var ExtensionField, a, b: ExtensionField, skipFinalSub: static bool) =
+  # Prod alias,
+  # this allows using the same code for
+  # the base field and its extensions while benefitting from skipping
+  # the final substraction on Fp
+  r.prod(a, b)
+
 {.pop.} # inline
 {.pop.} # raises no exceptions

--- a/constantine/platforms/allocs.nim
+++ b/constantine/platforms/allocs.nim
@@ -1,0 +1,32 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#                        Allocators
+#
+# ############################################################
+
+# Due to the following constraints:
+# - No dynamic allocation in single-threaded codepaths (for compatibility with embedded devices like TPM or secure hardware)
+# - Avoiding cryptographic material in third-party libraries (like a memory allocator)
+# - Giving full control of the library user on allocation strategy
+# - Performance, especially for long-running processes (fragmentation, multithreaded allocation...)
+#
+# stack allocation is strongly preferred where necessary.
+
+when defined(windows):
+  proc alloca(size: int): pointer {.header: "<malloc.h>".}
+else:
+  proc alloca(size: int): pointer {.header: "<alloca.h>".}
+
+template alloca*(T: typedesc): ptr T =
+  cast[ptr T](alloca(sizeof(T)))
+
+template alloca*(T: typedesc, len: Natural): ptr UncheckedArray[T] =
+  cast[ptr UncheckedArray[T]](alloca(sizeof(T) * len))

--- a/helpers/pararun.nim
+++ b/helpers/pararun.nim
@@ -13,7 +13,7 @@ import
 
 # Pararun is a parallel shell command runner
 # ------------------------------------------
-# Usage: pararun <file-with-1-command-per-line> <numWorkers
+# Usage: pararun <file-with-1-command-per-line> <numWorkers>
 
 # AsyncSemaphore
 # ----------------------------------------------------------------

--- a/tests/math/t_ec_shortw_jac_g1_batch_add.nim
+++ b/tests/math/t_ec_shortw_jac_g1_batch_add.nim
@@ -1,0 +1,30 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../constantine/math/config/curves,
+  ../../constantine/math/elliptic/ec_shortweierstrass_jacobian,
+  ../../constantine/math/arithmetic,
+  # Test utilities
+  ./t_ec_template
+
+const
+  numPoints = [1, 2, 8, 16, 128, 1024, 2048, 16384, 32768] # 262144, 1048576]
+
+run_EC_batch_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BN254_Snarks], G1],
+    numPoints = numPoints,
+    moduleName = "test_ec_shortweierstrass_jacobian_batch_add_" & $BN254_Snarks
+  )
+
+run_EC_batch_add_impl(
+    ec = ECP_ShortW_Jac[Fp[BLS12_381], G1],
+    numPoints = numPoints,
+    moduleName = "test_ec_shortweierstrass_jacobian_batch_add_" & $BLS12_381
+  )

--- a/tests/math/t_ec_shortw_prj_g1_batch_add.nim
+++ b/tests/math/t_ec_shortw_prj_g1_batch_add.nim
@@ -1,0 +1,30 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  ../../constantine/math/config/curves,
+  ../../constantine/math/elliptic/ec_shortweierstrass_projective,
+  ../../constantine/math/arithmetic,
+  # Test utilities
+  ./t_ec_template
+
+const
+  numPoints = [1, 2, 8, 16, 128, 1024, 2048, 16384, 32768] # 262144, 1048576]
+
+run_EC_batch_add_impl(
+    ec = ECP_ShortW_Prj[Fp[BN254_Snarks], G1],
+    numPoints = numPoints,
+    moduleName = "test_ec_shortweierstrass_projective_batch_add_" & $BN254_Snarks
+  )
+
+run_EC_batch_add_impl(
+    ec = ECP_ShortW_Prj[Fp[BLS12_381], G1],
+    numPoints = numPoints,
+    moduleName = "test_ec_shortweierstrass_projective_batch_add_" & $BLS12_381
+  )

--- a/tests/math/t_ec_template.nim
+++ b/tests/math/t_ec_template.nim
@@ -23,6 +23,7 @@ import
     ec_shortweierstrass_affine,
     ec_shortweierstrass_jacobian,
     ec_shortweierstrass_projective,
+    ec_shortweierstrass_batch_ops,
     ec_twistededwards_affine,
     ec_twistededwards_projective,
     ec_scalar_mul],
@@ -41,7 +42,7 @@ type
     Long01Sequence
 
 func random_point*(rng: var RngState, EC: typedesc, randZ: bool, gen: RandomGen): EC {.noInit.} =
-  if not randZ:
+  when EC is ECP_ShortW_Aff:
     if gen == Uniform:
       result = rng.random_unsafe(EC)
     elif gen == HighHammingWeight:
@@ -49,12 +50,20 @@ func random_point*(rng: var RngState, EC: typedesc, randZ: bool, gen: RandomGen)
     else:
       result = rng.random_long01Seq(EC)
   else:
-    if gen == Uniform:
-      result = rng.random_unsafe_with_randZ(EC)
-    elif gen == HighHammingWeight:
-      result = rng.random_highHammingWeight_with_randZ(EC)
+    if not randZ:
+      if gen == Uniform:
+        result = rng.random_unsafe(EC)
+      elif gen == HighHammingWeight:
+        result = rng.random_highHammingWeight(EC)
+      else:
+        result = rng.random_long01Seq(EC)
     else:
-      result = rng.random_long01Seq_with_randZ(EC)
+      if gen == Uniform:
+        result = rng.random_unsafe_with_randZ(EC)
+      elif gen == HighHammingWeight:
+        result = rng.random_highHammingWeight_with_randZ(EC)
+      else:
+        result = rng.random_long01Seq_with_randZ(EC)
 
 template pairingGroup(EC: typedesc): string =
   when EC is (ECP_ShortW_Aff or ECP_ShortW_Prj or ECP_ShortW_Jac):
@@ -438,7 +447,7 @@ proc run_EC_mixed_add_impl*(
 
   suite testSuiteDesc & " - " & $ec & " - [" & $WordBitwidth & "-bit mode]":
     test "EC " & G1_or_G2 & " mixed addition is consistent with general addition":
-      proc test(EC: typedesc, bits: static int, randZ: bool, gen: RandomGen) =
+      proc test(EC: typedesc, randZ: bool, gen: RandomGen) =
         for _ in 0 ..< Iters:
           let a = rng.random_point(EC, randZ, gen)
           let b = rng.random_point(EC, randZ, gen)
@@ -452,12 +461,12 @@ proc run_EC_mixed_add_impl*(
 
           check: bool(r_generic == r_mixed)
 
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Long01Sequence)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Long01Sequence)
+      test(ec, randZ = false, gen = Uniform)
+      test(ec, randZ = true, gen = Uniform)
+      test(ec, randZ = false, gen = HighHammingWeight)
+      test(ec, randZ = true, gen = HighHammingWeight)
+      test(ec, randZ = false, gen = Long01Sequence)
+      test(ec, randZ = true, gen = Long01Sequence)
 
 proc run_EC_subgroups_cofactors_impl*(
        ec: typedesc,
@@ -480,7 +489,7 @@ proc run_EC_subgroups_cofactors_impl*(
 
   suite testSuiteDesc & " - " & $ec & " - [" & $WordBitwidth & "-bit mode]":
     test "Effective cofactor matches accelerated cofactor clearing" & " - " & $ec & " - [" & $WordBitwidth & "-bit mode]":
-      proc test(EC: typedesc, bits: static int, randZ: bool, gen: RandomGen) =
+      proc test(EC: typedesc, randZ: bool, gen: RandomGen) =
         for _ in 0 ..< ItersMul:
           let P = rng.random_point(EC, randZ, gen)
           var cPeff = P
@@ -491,17 +500,17 @@ proc run_EC_subgroups_cofactors_impl*(
 
           check: bool(cPeff == cPfast)
 
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Long01Sequence)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Long01Sequence)
+      test(ec, randZ = false, gen = Uniform)
+      test(ec, randZ = true, gen = Uniform)
+      test(ec, randZ = false, gen = HighHammingWeight)
+      test(ec, randZ = true, gen = HighHammingWeight)
+      test(ec, randZ = false, gen = Long01Sequence)
+      test(ec, randZ = true, gen = Long01Sequence)
 
     test "Subgroup checks and cofactor clearing consistency":
       var inSubgroup = 0
       var offSubgroup = 0
-      proc test(EC: typedesc, bits: static int, randZ: bool, gen: RandomGen) =
+      proc test(EC: typedesc, randZ: bool, gen: RandomGen) =
         stdout.write "    "
         for _ in 0 ..< ItersMul:
           let P = rng.random_point(EC, randZ, gen)
@@ -526,12 +535,12 @@ proc run_EC_subgroups_cofactors_impl*(
         
         stdout.write '\n'
 
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Uniform)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = HighHammingWeight)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = false, gen = Long01Sequence)
-      test(ec, bits = ec.F.C.getCurveOrderBitwidth(), randZ = true, gen = Long01Sequence)
+      test(ec, randZ = false, gen = Uniform)
+      test(ec, randZ = true, gen = Uniform)
+      test(ec, randZ = false, gen = HighHammingWeight)
+      test(ec, randZ = true, gen = HighHammingWeight)
+      test(ec, randZ = false, gen = Long01Sequence)
+      test(ec, randZ = true, gen = Long01Sequence)
     
       echo "    [SUCCESS] Test finished with ", inSubgroup, " points in ", G1_or_G2, " subgroup and ",
               offSubgroup, " points on curve but not in subgroup (before cofactor clearing)"
@@ -700,3 +709,81 @@ proc run_EC_conversion_failures*(
 
       test_bn254_snarks_g1(ECP_ShortW_Prj[Fp[BN254_Snarks], G1])
       test_bn254_snarks_g1(ECP_ShortW_Jac[Fp[BN254_Snarks], G1])
+
+proc run_EC_batch_add_impl*[N: static int](
+       ec: typedesc,
+       numPoints: array[N, int],
+       moduleName: string
+     ) =
+
+  # Random seed for reproducibility
+  var rng: RngState
+  let seed = 1666905586 # uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+  rng.seed(seed)
+  echo "\n------------------------------------------------------\n"
+  echo moduleName, " xoshiro512** seed: ", seed
+
+  when ec.G == G1:
+    const G1_or_G2 = "G1"
+  else:
+    const G1_or_G2 = "G2"
+
+  const testSuiteDesc = "Elliptic curve batch addition for Short Weierstrass form"
+
+  suite testSuiteDesc & " - " & $ec & " - [" & $WordBitwidth & "-bit mode]":
+    for n in numPoints:
+      test $ec & " batch addition (N=" & $n & ")":
+        proc test(EC: typedesc, gen: RandomGen) =
+          var points = newSeq[ECP_ShortW_Aff[EC.F, EC.G]](n)
+          
+          for i in 0 ..< n:
+            points[i] = rng.random_point(ECP_ShortW_Aff[EC.F, EC.G], randZ = false, gen)
+
+          var r_batch{.noinit.}, r_ref{.noInit.}: EC
+
+          r_ref.setInf()
+          for i in 0 ..< n:
+            r_ref += points[i]
+
+          r_batch.sum_batch_vartime(points)
+
+          check: bool(r_batch == r_ref)
+
+
+        test(ec, gen = Uniform)
+        test(ec, gen = HighHammingWeight)
+        test(ec, gen = Long01Sequence)
+
+      test "EC " & G1_or_G2 & " batch addition (N=" & $n & ") - special cases":
+        proc test(EC: typedesc, gen: RandomGen) =
+          var points = newSeq[ECP_ShortW_Aff[EC.F, EC.G]](n)
+
+          let halfN = n div 2
+          
+          for i in 0 ..< halfN:
+            points[i] = rng.random_point(ECP_ShortW_Aff[EC.F, EC.G], randZ = false, gen)
+          
+          for i in halfN ..< n:
+            # The special cases test relies on internal knowledge that we sum(points[i], points[i+n/2]
+            # It should be changed if scheduling change, for example if we sum(points[2*i], points[2*i+1])
+            let c = rng.random_unsafe(3)
+            if c == 0:
+              points[i] = rng.random_point(ECP_ShortW_Aff[EC.F, EC.G], randZ = false, gen)
+            elif c == 1:
+              points[i] = points[i-halfN]
+            else:
+              points[i].neg(points[i-halfN])
+
+          var r_batch{.noinit.}, r_ref{.noInit.}: EC
+
+          r_ref.setInf()
+          for i in 0 ..< n:
+            r_ref += points[i]
+
+          r_batch.sum_batch_vartime(points)
+
+          check: bool(r_batch == r_ref)
+
+        test(ec, gen = Uniform)
+        test(ec, gen = HighHammingWeight)
+        test(ec, gen = Long01Sequence)


### PR DESCRIPTION
This PR follows discussion at Devcon VI with @asn-d6 regarding accelerating validator pubkeys aggregation for large-scale Secret Single Leader Election.

It implements:
- [x] [feat] Batched additions, about 1.8x faster than naive additions starting from 1000+ validators
- [x] [bug] Jacobian mixed addition now handles point doubling
- [x] [bug] Jacobian addition had an aliasing issue if rhs was the infinity point
- [x] [ci] Run tests with -d:release optimizations

Perf 1M points in 180ms on my i9-11980HK (top laptop CPU from 2021)
![image](https://user-images.githubusercontent.com/22738317/198835749-e3495b85-3283-40a3-854a-7a64e2c9e7a7.png)

BLST: https://github.com/mratsim/nim-blscurve/pull/1

![image](https://user-images.githubusercontent.com/22738317/198835912-54ddf09a-ffd3-43d8-9d4d-4b8f7776062f.png)

Constantine has 33% speedup over BLST for 1000 point additions (then linear increase)