### PR TITLE
panics:on

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -332,6 +332,7 @@ template setupCommand(): untyped {.dirty.} =
     # Not available in MinGW https://github.com/libressl-portable/portable/issues/54
     flags &= " --passC:-fstack-protector-strong"
   let command = "nim " & lang & cc & " -d:release " & flags &
+    " --panics:on " & # Defects are not catchable
     " --verbosity:0 --outdir:build/testsuite -r --hints:off --warnings:off " &
     " --nimcache:nimcache/" & path & " " &
     path
@@ -363,6 +364,7 @@ template setupBench(): untyped {.dirty.} =
   if not useAsm:
     cc &= " -d:CttASM=false"
   let command = "nim " & lang & cc &
+       " --panics:on " & # Defects are not catchable
        " -d:danger --verbosity:0 -o:build/bench/" & benchName & "_" & compiler & "_" & (if useAsm: "useASM" else: "noASM") &
        " --nimcache:nimcache/benches/" & benchName & "_" & compiler & "_" & (if useAsm: "useASM" else: "noASM") &
        runFlag & "--hints:off --warnings:off benchmarks/" & benchName & ".nim"
@@ -451,6 +453,7 @@ proc genDynamicBindings(bindingsName, prefixNimMain: string) =
     #             - heap-allocated strings for hex-string or decimal strings
     echo "Compiling dynamic library: bindings/generated/" & libName
     exec "nim c -f " & flags & " --noMain -d:danger --app:lib --gc:arc " &
+         " --panics:on " & # Defects are not catchable
          " --verbosity:0 --hints:off --warnings:off " &
          " --nimMainPrefix:" & prefixNimMain &
          " --out:" & libName & " --outdir:bindings/generated " &
@@ -481,6 +484,7 @@ proc genStaticBindings(bindingsName, prefixNimMain: string) =
     #             - heap-allocated strings for hex-string or decimal strings
     echo "Compiling static library:  bindings/generated/" & libName
     exec "nim c -f " & flags & " --noMain -d:danger --app:staticLib --gc:arc " &
+         " --panics:on " & # Defects are not catchable
          " --verbosity:0 --hints:off --warnings:off " &
          " --nimMainPrefix:" & prefixNimMain &
          " --out:" & libName & " --outdir:bindings/generated " &

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -114,8 +114,7 @@ func eth_evm_ecadd*(
 
   # Auto-pad with zero
   var padded: array[128, byte]
-  let lastIdx = min(inputs.len, 128) - 1
-  padded[0 .. lastIdx] = inputs.toOpenArray(0, lastIdx)
+  padded.copy(0, inputs, 0, min(inputs.len, 128))
 
   var P{.noInit.}, Q{.noInit.}, R{.noInit.}: ECP_ShortW_Prj[Fp[BN254_Snarks], G1]
 
@@ -171,8 +170,7 @@ func eth_evm_ecmul*(
 
   # Auto-pad with zero
   var padded: array[128, byte]
-  let lastIdx = min(inputs.len, 128) - 1
-  padded[0 .. lastIdx] = inputs.toOpenArray(0, lastIdx)
+  padded.copy(0, inputs, 0, min(inputs.len, 128))
 
   var P{.noInit.}: ECP_ShortW_Prj[Fp[BN254_Snarks], G1]
 


### PR DESCRIPTION
This turns on `panics:on`

1. The defects (index errors, signed integer overflow, div by zero) cannot be recovered from.
2. The library is tested and will be fuzzed and hopefully formally verified to prove those cannot happen
3. The codegen is cleaner (no error check after each function) because `raises:[]` is not enough after `raises:[]` still allowed raising defects.

See https://nim-lang.org/araq/gotobased_exceptions.html

> The development version of Nim now offers a new exception handling implementation called "goto based exceptions". It can be enabled via the new command line switch --exceptions:goto. This mode is also activated by --gc:arc for the C target.
>
> This mode implements exceptions in a deterministic way: Raising an exception is implemented by setting an internal threadlocal error flag that is queried after every function call that can raise. Neither C's setjmp mechanism is used nor are C++'s exception handling tables. The error path is intertwined with the success path with the resulting instruction cache benefits and drawbacks. Exception handling is fast and deterministic, there are few reasons to avoid it.
> 
> To improve the precision of the compiler's abilities to reason about which call "can raise", make wise usage of the .raises: [] annotation.