### PR TITLE
[Threadpool] Remove reserve threads

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -243,6 +243,8 @@ const testDescNvidia: seq[string] = @[
 const testDescThreadpool: seq[string] = @[
   "constantine/platforms/threadpool/examples/e01_simple_tasks.nim",
   "constantine/platforms/threadpool/examples/e02_parallel_pi.nim",
+  "constantine/platforms/threadpool/examples/e03_parallel_for.nim",
+  "constantine/platforms/threadpool/examples/e04_parallel_reduce.nim",
   # "constantine/platforms/threadpool/benchmarks/bouncing_producer_consumer/threadpool_bpc.nim", # Need timing not implemented on Windows
   "constantine/platforms/threadpool/benchmarks/dfs/threadpool_dfs.nim",
   "constantine/platforms/threadpool/benchmarks/fibonacci/threadpool_fib.nim",

--- a/constantine/platforms/primitives.nim
+++ b/constantine/platforms/primitives.nim
@@ -34,6 +34,10 @@ export
   allocs,
   compiler_optim_hints
 
+# Note:
+# - cpuinfo_x86 initialize globals with following CPU features detection.
+#   This will impact benchmarks that do not need it, such as the threadpool.
+
 when X86 and GCC_Compatible:
   import isa/[cpuinfo_x86, macro_assembler_x86]
   export cpuinfo_x86, macro_assembler_x86
@@ -69,7 +73,7 @@ func ceilDiv_vartime*(a, b: auto): auto {.inline.} =
   ## ceil division, to be used only on length or at compile-time
   ## ceil(a / b)
   # "LengthInDigits: static int" doesn't match "int"
-  # if "SomeInteger" is used instead of "autoi"
+  # if "SomeInteger" is used instead of "auto"
   (a + b - 1) div b
 
 # ############################################################

--- a/constantine/platforms/threadpool/README.md
+++ b/constantine/platforms/threadpool/README.md
@@ -16,13 +16,11 @@ This threadpool will desirable properties are:
   and not dealing with threadpool contention, latencies and overheads.
 
 Compared to [Weave](https://github.com/mratsim/weave), here are the tradeoffs:
-- Constantine's threadpool only provide spawn/sync (task parallelism).\
-  There is no (extremely) optimized parallel for (data parallelism)\
-  or precise in/out dependencies (events / dataflow parallelism).
+- Constantine's threadpool provides spawn/sync (task parallelism)
+  and optimized parallelFor for (data parallelism).\
+  It however does not provide precise in/out dependencies (events / dataflow parallelism).
 - Constantine's threadpool has been significantly optimized to provide
-  overhead lower than Weave's default (and as low as Weave "lazy" + "alloca" allocation scheme)
-- Constantine's threadpool provides the same adaptative scheduling strategy as Weave
-  with additional enhancement (leapfrogging)
+  overhead lower than Weave's default (and as low as Weave "lazy" + "alloca" allocation scheme).
 
 Compared to [nim-taskpools](https://github.com/status-im), here are the tradeoffs:
 - Constantine does not use std/tasks:
@@ -36,3 +34,5 @@ Compared to [nim-taskpools](https://github.com/status-im), here are the tradeoff
 - Contention improvement, Constantine is entirely lock-free while Nim-taskpools need a lock+condition variable for putting threads to sleep
 - Powersaving improvement, threads sleep when awaiting for a task and there is no work available.
 - Scheduling improvement, Constantine's threadpool incorporate Weave's adaptative scheduling policy with additional enhancement (leapfrogging)
+
+See also [design.md](./docs/design.md)

--- a/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
+++ b/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
@@ -204,7 +204,7 @@ func readyWith*[T](task: ptr Task, childResult: T) {.inline.} =
   cast[ptr (ptr Task, T)](task.env.addr)[1] = childResult
   task.completed.store(true, moRelease)
 
-proc sync*[T](fv: sink Flowvar[T]): T {.inline, gcsafe.} =
+proc sync*[T](fv: sink Flowvar[T]): T {.noInit, inline, gcsafe.} =
   ## Blocks the current thread until the flowvar is available
   ## and returned.
   ## The thread is not idle and will complete pending tasks.

--- a/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
+++ b/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
@@ -9,7 +9,7 @@
 import
   std/atomics,
   ../instrumentation,
-  ../../allocs, ../../primitives,
+  ../../allocs,
   ./backoff
 
 # Tasks have an efficient design so that a single heap allocation
@@ -27,14 +27,10 @@ import
 
 type
   Task* = object
-    # Intrusive metadata
+    # Synchronization
     # ------------------
     parent*: ptr Task        # When a task is awaiting, a thread can quickly prioritize the direct child of a task
-
     thiefID*: Atomic[int32]  # ID of the worker that stole and run the task. For leapfrogging.
-
-    # Result sync
-    # ------------------
     hasFuture*: bool         # Ownership: if a task has a future, the future deallocates it. Otherwise the worker thread does.
     completed*: Atomic[bool]
     waiter*: Atomic[ptr EventNotifier]
@@ -42,25 +38,20 @@ type
     # Data parallelism
     # ------------------
     isFirstIter*: bool       # Awaitable for-loops return true for first iter. Loops are split before first iter.
+    envSize*: int32          # This is used for splittable loop
     loopStart*: int
     loopStop*: int
     loopStride*: int
     loopStepsLeft*: int
     reductionDAG*: ptr ReductionDagNode # For parallel loop reduction, merge with other range result
 
-    # Dataflow parallelism
-    # --------------------
-    dependsOnEvent: bool     # We cannot leapfrog a task triggered by an event
-
     # Execution
     # ------------------
     fn*: proc (env: pointer) {.nimcall, gcsafe, raises: [].}
-    # destroy*: proc (env: pointer) {.nimcall, gcsafe.} # Constantine only deals with plain old data
-    envSize*: int32
+    # destroy*: proc (env: pointer) {.nimcall, gcsafe.} # Constantine only deals with plain old env
     env*{.align:sizeof(int).}: UncheckedArray[byte]
 
   Flowvar*[T] = object
-    ## A Flowvar is a placeholder for a future result that may be computed in parallel
     task: ptr Task
 
   ReductionDagNode* = object
@@ -82,7 +73,8 @@ const SentinelThief* = 0xFACADE'i32
 proc newSpawn*(
        T: typedesc[Task],
        parent: ptr Task,
-       fn: proc (env: pointer) {.nimcall, gcsafe, raises: [].}): ptr Task =
+       fn: proc (env: pointer) {.nimcall, gcsafe, raises: [].}
+     ): ptr Task {.inline.} =
 
   const size = sizeof(T)
 
@@ -93,22 +85,12 @@ proc newSpawn*(
   result.completed.store(false, moRelaxed)
   result.waiter.store(nil, moRelaxed)
   result.fn = fn
-  result.envSize = 0
-
-  result.isFirstIter = false
-  result.loopStart = 0
-  result.loopStop = 0
-  result.loopStride = 0
-  result.loopStepsLeft = 0
-  result.reductionDAG = nil
-
-  result.dependsOnEvent = false
 
 proc newSpawn*(
        T: typedesc[Task],
        parent: ptr Task,
        fn: proc (env: pointer) {.nimcall, gcsafe, raises: [].},
-       env: auto): ptr Task =
+       env: auto): ptr Task {.inline.} =
 
   const size = sizeof(T) + # size without Unchecked
                sizeof(env)
@@ -120,24 +102,20 @@ proc newSpawn*(
   result.completed.store(false, moRelaxed)
   result.waiter.store(nil, moRelaxed)
   result.fn = fn
-  result.envSize = int32 sizeof(env)
   cast[ptr[type env]](result.env)[] = env
 
-  result.isFirstIter = false
-  result.loopStart = 0
-  result.loopStop = 0
-  result.loopStride = 0
-  result.loopStepsLeft = 0
-  result.reductionDAG = nil
-
-  result.dependsOnEvent = false
+func ceilDiv_vartime*(a, b: auto): auto {.inline.} =
+  ## ceil division, to be used only on length or at compile-time
+  ## ceil(a / b)
+  (a + b - 1) div b
 
 proc newLoop*(
        T: typedesc[Task],
        parent: ptr Task,
        start, stop, stride: int,
        isFirstIter: bool,
-       fn: proc (env: pointer) {.nimcall, gcsafe, raises: [].}): ptr Task =
+       fn: proc (env: pointer) {.nimcall, gcsafe, raises: [].}
+      ): ptr Task =
   const size = sizeof(T)
   preCondition: start < stop
 
@@ -188,8 +166,6 @@ proc newLoop*(
   result.loopStepsLeft = ceilDiv_vartime(stop-start, stride)
   result.reductionDAG = nil
 
-  result.dependsOnEvent = false
-
 # Flowvars
 # -------------------------------------------------------------------------
 
@@ -230,14 +206,11 @@ func readyWith*[T](task: ptr Task, childResult: T) {.inline.} =
   cast[ptr (ptr Task, T)](task.env.addr)[1] = childResult
   task.completed.store(true, moRelease)
 
-proc sync*[T](fv: sink Flowvar[T]): T {.noInit, inline, gcsafe.} =
+proc sync*[T](fv: sink Flowvar[T]): T {.inline, gcsafe.} =
   ## Blocks the current thread until the flowvar is available
   ## and returned.
   ## The thread is not idle and will complete pending tasks.
   mixin completeFuture
-  if fv.task.isNil:
-    zeroMem(result.addr, sizeof(T))
-    return
   completeFuture(fv, result)
   cleanup(fv)
 

--- a/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
+++ b/constantine/platforms/threadpool/crossthread/tasks_flowvars.nim
@@ -135,8 +135,6 @@ proc newLoop*(
   result.loopStepsLeft = ceilDiv_vartime(stop-start, stride)
   result.reductionDAG = nil
 
-  result.dependsOnEvent = false
-
 proc newLoop*(
        T: typedesc[Task],
        parent: ptr Task,


### PR DESCRIPTION
This removes a significant threadpool perf pessimization introduced in #222

- reserve threads are removed.
- some perf was also lost because:
  - `primitives.nim` was imported and it needed globals for CPU features detection. Unsure how this exactly slowed a benchmark down though.
  - creating a task is inlined for spawn (but not for loops as those requires more initialization)
  - the conditional branch in `sync` was a debugging aid and is not needed

An additional slight optimization is avoiding syscalls in `wake` when we have sleepy workers that are not yet asleep. The change in epoch is sufficient to avoid their sleep.

Finally, the stealHalf and adaptative theft policy code has been removed as it was never finished.