### PR TITLE
Fix fuzz 1 failure: incorrect reduction of BigInt

### DIFF
--- a/constantine/math/arithmetic/limbs_montgomery.nim
+++ b/constantine/math/arithmetic/limbs_montgomery.nim
@@ -609,7 +609,13 @@ func getMont*(r: var Limbs, a, M, r2modM: Limbs,
   ## Important: `r` is overwritten
   ## The result `r` buffer size MUST be at least the size of `M` buffer
   # Reference: https://eprint.iacr.org/2017/1057.pdf
-  mulMont(r, a, r2ModM, M, m0ninv, spareBits)
+
+  # For conversion to a field element (in the Montgomery domain), we do not use the "no-carry" optimization:
+  #    While Montgomery Reduction can map inputs [0, 4p²) -> [0, p)
+  #    that range is not valid with the no-carry optimization,
+  #    hence an unreduced input that uses 256-bit while prime is 254-bit
+  #    can have an incorrect representation.
+  mulMont_FIPS(r, a, r2ModM, M, m0ninv, skipFinalSub = false)
 
 # Montgomery Modular Exponentiation
 # ------------------------------------------

--- a/constantine/math_arbitrary_precision/arithmetic/bigints_views.nim
+++ b/constantine/math_arbitrary_precision/arithmetic/bigints_views.nim
@@ -70,7 +70,6 @@ func powOddMod_vartime*(
     # if we use redc2xMont (a/R) and montgomery multiplication by R³
     # For now, we call explicit reduction as it can handle all sizes.
     # TODO: explicit reduction uses constant-time division which is **very** expensive
-    # TODO: fix https://github.com/mratsim/constantine/issues/241
     if a.len != M.len:
       let t = allocStackArray(SecretWord, L)
       t.LimbsViewMut.reduce(a.view(), aBits, M.view(), mBits)

--- a/tests/math_fields/t_io_fields.nim
+++ b/tests/math_fields/t_io_fields.nim
@@ -156,4 +156,14 @@ proc main() =
 
         check: p == hex
 
+    test "Fuzz #1 - incorrect reduction of BigInt":
+      block:
+        var a{.noInit.}: Fp[BN254_Snarks]
+        a.fromBig(BigInt[254].fromHex("0xdd1119d0c5b065898a0848e21c209153f4622f06cb763e7ef00eef28b94780f8"))
+
+        var b{.noInit.}: Fp[BN254_Snarks]
+        b.fromBig(BigInt[254].fromHex("0x1b7fe00540e9e4e2a8c73208161b2fdd965c84c129af1449ff8cbecd57538bdc"))
+
+        doAssert bool(a == b)
+
 main()


### PR DESCRIPTION
From the Ethereum Foundation sponsored fuzzing by @guidovranken (linked to #54),
``fromBig`` can lead to incorrectly reduced field elements.

This is because classic Montgomery reduction can reduce inputs from the range [0, 4p²) -> [0, p)  but this is not the case with the no-carry optimization from Gnark (https://hackmd.io/@gnark/modular_multiplication and https://eprint.iacr.org/2022/1400.pdf section 2)

In practice ``getMont`` and ``fromBig`` are internal-only procedures that only deserialized well-formed inputs that have been pre-checked in protocols:
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/ethereum_bls_signatures.nim#L284-L293
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/ethereum_bls_signatures.nim#L339-L354
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/ethereum_evm_precompiles.nim#L38-L54

and for large inputs, we use redc2xMont + multMont:
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/hash_to_curve/h2c_hash_to_field.nim#L222-L235
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/ethereum_eip2333_bls12381_key_derivation.nim#L56-L71

or full reduction:
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/math_arbitrary_precision/arithmetic/bigints_views.nim#L69-L79

However there is one protocol case where ``getMont`` is used, in ECMUL (EIP-198):
- https://github.com/mratsim/constantine/blob/151f284da6caad1545a38f871c421c5bb2da8f6a/constantine/ethereum_evm_precompiles.nim#L189-L209

## Perf

The impact on BN254 is a slowdown from 10ns to 17ns (with Clang, worse with GCC)

The impact on BLS12-381 is a slowdown from 23ns to 39ns (with Clang, worse with GCC)

Most of the slowdown is due to classic Montgomery reduction not having an assembly implementation.

However, that conversion is not in the hot path of any protocol, most protocols that need to deal with a large amount of deserialization allow caching, for example in case of Ethereum validator public keys. And 99% of the time is spend in computing the square root of compressed keys/signatures.