### PR TITLE
Fuzz Fix - Hash-To-Curve - Isogeny EC add non-fully-reduced input

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -483,7 +483,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # Hashing to elliptic curves
   # ----------------------------------------------------------
   ("tests/t_hash_to_field.nim", false),
-  # ("tests/t_hash_to_curve_random.nim", false),
+  ("tests/t_hash_to_curve_random.nim", false),
   ("tests/t_hash_to_curve.nim", false),
 
   # Protocols

--- a/constantine/hash_to_curve/hash_to_curve.nim
+++ b/constantine/hash_to_curve/hash_to_curve.nim
@@ -133,12 +133,12 @@ func mapToCurve_svdw_fusedAdd[F; G: static Subgroup](
   ## finite or extension field F
   ## to an elliptic curve E
   ## and add them
-  var P0{.noInit.}, P1{.noInit.}: ECP_ShortW_Aff[F, G]
-  P0.mapToCurve_svdw(u0)
-  P1.mapToCurve_svdw(u1)
+  var Q0{.noInit.}, Q1{.noInit.}: ECP_ShortW_Aff[F, G]
+  Q0.mapToCurve_svdw(u0)
+  Q1.mapToCurve_svdw(u1)
 
-  r.fromAffine(P0)
-  r += P1
+  r.fromAffine(Q0)
+  r += Q1
 
 func mapToCurve_sswu_fusedAdd[F; G: static Subgroup](
        r: var ECP_ShortW_Jac[F, G],
@@ -164,25 +164,24 @@ func mapToCurve_sswu_fusedAdd[F; G: static Subgroup](
     # https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-6.6.3
     # Simplified Shallue-van de Woestijne-Ulas method for AB == 0
 
-    var P0{.noInit.}, P1{.noInit.}: ECP_ShortW_Jac[F, G]
+    var Q0{.noInit.}, Q1{.noInit.}: ECP_ShortW_Jac[F, G]
 
     # 1. Map to E' isogenous to E
     when F is Fp and F.C.has_P_3mod4_primeModulus():
       # 1. Map to E'1 isogenous to E1
-      P0.mapToIsoCurve_sswuG1_opt3mod4(u0)
-      P1.mapToIsoCurve_sswuG1_opt3mod4(u1)
-      P0.sum(P0, P1, h2CConst(F.C, sswu, G1, Aprime_E1))
+      Q0.mapToIsoCurve_sswuG1_opt3mod4(u0)
+      Q1.mapToIsoCurve_sswuG1_opt3mod4(u1)
+      Q0.sum(Q0, Q1, h2CConst(F.C, sswu, G1, Aprime_E1))
     elif F is Fp2 and F.C.has_Psquare_9mod16_primePower():
-      # p ≡ 3 (mod 4) => p² ≡ 9 (mod 16)
       # 1. Map to E'2 isogenous to E2
-      P0.mapToIsoCurve_sswuG2_opt9mod16(u0)
-      P1.mapToIsoCurve_sswuG2_opt9mod16(u1)
-      P0.sum(P0, P1, h2CConst(F.C, sswu, G2, Aprime_E2))
+      Q0.mapToIsoCurve_sswuG2_opt9mod16(u0)
+      Q1.mapToIsoCurve_sswuG2_opt9mod16(u1)
+      Q0.sum(Q0, Q1, h2CConst(F.C, sswu, G2, Aprime_E2))
     else:
       {.error: "Not implemented".}
 
     # 2. Map from E'2 to E2
-    r.h2c_isogeny_map(P0)
+    r.h2c_isogeny_map(Q0)
   else:
     {.error: "Not implemented".}
 

--- a/constantine/math/elliptic/ec_shortweierstrass_jacobian.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_jacobian.nim
@@ -295,8 +295,7 @@ template sumImpl[F; G: static Subgroup](
       a.square(HHH_or_Mpre, skipFinalSub = true)
       a *= HHH_or_Mpre              # a = 3X₁²
       b.square(Z1Z1)
-      # b.mulCheckSparse(CoefA)     # TODO: broken static compile-time type inference
-      b *= CoefA                    # b = αZZ, with α the "a" coefficient of the curve
+      b.mulCheckSparse(CoefA)       # b = αZZ, with α the "a" coefficient of the curve
 
       a += b
       a.div2()
@@ -516,8 +515,7 @@ func madd*[F; G: static Subgroup](
       a.square(HHH_or_Mpre, skipFinalSub = true)
       a *= HHH_or_Mpre              # a = 3X₁²
       b.square(Z1Z1)
-      # b.mulCheckSparse(CoefA)     # TODO: broken static compile-time type inference
-      b *= CoefA                    # b = αZZ, with α the "a" coefficient of the curve
+      b.mulCheckSparse(CoefA)       # b = αZZ, with α the "a" coefficient of the curve
 
       a += b
       a.div2()

--- a/constantine/math/extension_fields/towers.nim
+++ b/constantine/math/extension_fields/towers.nim
@@ -1440,11 +1440,11 @@ func mul_sparse_by_x0*(a: var QuadraticExt, sparseB: QuadraticExt) =
   a.mul_sparse_by_x0(a, sparseB)
 
 template mulCheckSparse*(a: var QuadraticExt, b: QuadraticExt) =
-  when b.isOne().bool:
+  when isOne(b).bool:
     discard
-  elif b.isMinusOne().bool:
+  elif isMinusOne(b).bool:
     a.neg()
-  elif b.c0.isZero().bool and b.c1.isOne().bool:
+  elif isZero(c0(b)).bool and isOne(c1(b)).bool:
     var t {.noInit.}: type(a.c0)
     when fromComplexExtension(b):
       t.neg(a.c1)
@@ -1454,7 +1454,7 @@ template mulCheckSparse*(a: var QuadraticExt, b: QuadraticExt) =
       t.prod(a.c1, NonResidue)
       a.c1 = a.c0
       a.c0 = t
-  elif b.c0.isZero().bool and b.c1.isMinusOne().bool:
+  elif isZero(c0(b)).bool and isMinusOne(c1(b)).bool:
     var t {.noInit.}: type(a.c0)
     when fromComplexExtension(b):
       t = a.c1
@@ -1464,9 +1464,9 @@ template mulCheckSparse*(a: var QuadraticExt, b: QuadraticExt) =
       t.prod(a.c1, NonResidue)
       a.c1.neg(a.c0)
       a.c0.neg(t)
-  elif b.c0.isZero().bool:
+  elif isZero(c0(b)).bool:
     a.mul_sparse_by_0y(b)
-  elif b.c1.isZero().bool:
+  elif isZero(c1(b)).bool:
     a.mul_sparse_by_x0(b)
   else:
     a *= b

--- a/tests/t_hash_to_curve_random.nim
+++ b/tests/t_hash_to_curve_random.nim
@@ -16,6 +16,7 @@ import
   ../constantine/hash_to_curve/hash_to_curve,
   ../constantine/hashes,
   ../constantine/math/constants/zoo_subgroups,
+  ../constantine/math/io/io_ec,
   # Test utilities
   ../helpers/prng_unsafe
 
@@ -55,3 +56,35 @@ suite "Hash-to-curve produces points on curve and in correct subgroup":
   test "BN254_Snarks G2":
     for i in 0 ..< Iters:
       testH2C_consistency(ECP_ShortW_Aff[Fp2[BN254_Snarks], G2])
+
+proc testH2C_guidovranken_fuzz_failure_2() =
+  # From Guido Vranken differential fuzzing
+  # Summing elliptic curve on an isogeny was mistakenly not fully reducing HHH_or_Mpre
+  let msg = [
+      uint8 0xa7, 0x1b, 0x0a, 0x38, 0xd4, 0x09, 0x2b, 0x3b,
+            0xdc, 0x9e, 0x75, 0x0a, 0x27, 0x0a, 0xd5, 0xdd,
+            0x16, 0x6f, 0x32, 0x5c, 0x16, 0xf5, 0x6d, 0x2f,
+            0x87, 0xbb, 0x6b, 0xf5, 0xd2]
+  let dst = [
+      uint8 0x5a, 0x59, 0xae, 0x59, 0x04, 0x8a, 0x29, 0x0f,
+            0x9a, 0xc1, 0x80, 0x26, 0xba, 0x6d, 0xd8, 0x7f,
+            0x54, 0xf0, 0x5a, 0x01, 0x49, 0xad, 0x2b, 0x95,
+            0xfe]
+  let aug = [
+      uint8 0x70, 0x20, 0xde, 0x7c, 0x51, 0x88, 0x88, 0x54,
+            0xf1, 0xaf, 0xa5, 0x06, 0x78, 0x80, 0xde, 0xf0,
+            0x0d, 0xdf]
+
+  var r{.noInit}: ECP_ShortW_Jac[Fp[BLS12_381], G1]
+  sha256.hashToCurve(128, r, aug, msg, dst)
+
+  let expected = ECP_ShortW_Jac[Fp[BLS12_381], G1].fromHex(
+    x = "0x48f2bbee30aa236feaa7fb924d8a3de3090ff160f9972a8afda302bd248248527dcc59ce195cd5f5a1488417cfc64cc",
+    y = "0xe91b0a3cdea4981741791c8e9b4287d2f693c6626d8e4408ecaaa473e6ff2f691f5f23f8b7b46bdf3560e7cca67e5bc"
+  )
+
+  doAssert bool(r == expected)
+
+suite "Hash-to-curve anti-regression":
+  test "BLS12-381 G1 - Fuzzing Failure 2":
+    testH2C_guidovranken_fuzz_failure_2()


### PR DESCRIPTION
Skipping the final substraction in this codepath (only taken for EC add on isogeny in SSWU hash-to-curve): https://github.com/mratsim/constantine/blob/d0f4ad8cdaf5fbbec98889bfcfb3a04082ff6f94/constantine/math/elliptic/ec_shortweierstrass_jacobian.nim#L292
is incorrect as `HHH_or_Mpre` is later used in field addition/substraction and so need fully reduced Montgomery representation.

Furthermore we fix a similar bug when the curve has a coefficient a=-3 (we have no such curve fully implemented though P256 and other NIST curves all have a=-3).

Lastly we accelerate BLS12-381 hashToG2 by enabling `mulCheckSparse`

We also change the notation of intermediate point from P to Q to be in line with the spec documentation
![image](https://user-images.githubusercontent.com/22738317/165356889-06da7a2e-38c6-41ab-8c17-6db1fa4d3982.png)
