### PR TITLE
fix: support for ECP_TwEdwards in toHex()

### DIFF
--- a/constantine/math/elliptic/ec_twistededwards_projective.nim
+++ b/constantine/math/elliptic/ec_twistededwards_projective.nim
@@ -294,7 +294,7 @@ func diff*(r: var ECP_TwEdwards_Prj,
   r.sum(P, nQ)
 
 func affine*[F](
-       aff: var ECP_TwEdwards_Prj[F],
+       aff: var ECP_TwEdwards_Aff[F],
        proj: ECP_TwEdwards_Prj[F]) =
   var invZ {.noInit.}: F
   invZ.inv(proj.z)
@@ -303,7 +303,7 @@ func affine*[F](
   aff.y.prod(proj.y, invZ)
 
 func projective*[F](
-       proj: var ECP_TwEdwards_Prj[F],
+       proj: var ECP_TwEdwards_Aff[F],
        aff: ECP_TwEdwards_Prj[F]) {.inline.} =
   proj.x = aff.x
   proj.y = aff.y

--- a/constantine/math/io/io_ec.nim
+++ b/constantine/math/io/io_ec.nim
@@ -15,7 +15,9 @@ import
     ec_shortweierstrass_affine,
     ec_shortweierstrass_projective,
     ec_shortweierstrass_jacobian,
-    ec_shortweierstrass_jacobian_extended
+    ec_shortweierstrass_jacobian_extended,
+    ec_twistededwards_projective,
+    ec_twistededwards_affine
   ]
 
 # No exceptions allowed
@@ -42,6 +44,32 @@ func toHex*[EC: ECP_ShortW_Prj or ECP_ShortW_Jac or ECP_ShortW_Aff or ECP_ShortW
 
   var aff {.noInit.}: ECP_ShortW_Aff[EC.F, EC.G]
   when EC isnot ECP_ShortW_Aff:
+    aff.affine(P)
+  else:
+    aff = P
+
+  const sp = spaces(indent)
+
+  result = sp & $EC & "(\n" & sp & "  x: "
+  result.appendHex(aff.x)
+  result &= ",\n" & sp & "  y: "
+  result.appendHex(aff.y)
+  result &= "\n" & sp & ")"
+
+func toHex*[EC: ECP_TwEdwards_Aff or ECP_TwEdwards_Prj](P: EC, indent: static int = 0): string =
+  ## Stringify an elliptic curve point to Hex for Twisted Edwards Curve
+  ## Note. Leading zeros are not removed.
+  ## Result is prefixed with 0x
+  ##
+  ## Output will be padded with 0s to maintain constant-time.
+  ##
+  ## CT:
+  ##   - no leaks
+  ##
+  ## This proc output may change format in the future
+
+  var aff {.noInit.}: ECP_TwEdwards_Aff[EC.F]
+  when EC isnot ECP_TwEdwards_Aff:
     aff.affine(P)
   else:
     aff = P


### PR DESCRIPTION
Fixes #260 

For affine points, Projective types were getting used (fixed in this PR)
https://github.com/mratsim/constantine/blob/ad04e6ea573e7d5de3e03edc60f40114f1fe5050/constantine/math/elliptic/ec_twistededwards_projective.nim#L297

No support was there for TwistedEdwards curve in `toHex()` ( fixed in this PR )
https://github.com/mratsim/constantine/blob/ad04e6ea573e7d5de3e03edc60f40114f1fe5050/constantine/math/io/io_ec.nim#L31