### PR TITLE
`MapToScalarField()` added for Banderwagon points

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -497,6 +497,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/t_ethereum_bls_signatures.nim", false),
   ("tests/t_ethereum_eip2333_bls12381_key_derivation.nim", false),
   ("tests/t_ethereum_eip4844_deneb_kzg.nim", false),
+  ("tests/t_ethereum_verkle_primitives.nim", false)
 ]
 
 const testDescNvidia: seq[string] = @[

--- a/constantine/ethereum_verkle_primitives.nim
+++ b/constantine/ethereum_verkle_primitives.nim
@@ -52,10 +52,24 @@ func mapToScalarField*(res: var Fr[Banderwagon], p: ECP_TwEdwards_Prj[Fp[Banderw
 
   return check1 and check2
 
+## ############################################################
+##
+##                      Batch Operations
+##
+## ############################################################
 func batchMapToScalarField*[N: static int](
       res: var array[N, Fr[Banderwagon]], 
       points: array[N, ECP_TwEdwards_Prj[Fp[Banderwagon]]]): bool {.discardable.} =
-
+  ## This function performs the `mapToScalarField` operation
+  ## on a batch of points
+  ## 
+  ## The batch inversion used in this using
+  ## the montogomenry trick, makes is faster than
+  ## just iterating of over the array of points and 
+  ## converting the curve points to field elements
+  ## 
+  ## Spec : https://hackmd.io/wliPP_RMT4emsucVuCqfHA?view#MapToFieldElement
+  
   var ys: array[N, Fp[Banderwagon]]
 
   for i in 0 ..< N:

--- a/constantine/ethereum_verkle_primitives.nim
+++ b/constantine/ethereum_verkle_primitives.nim
@@ -20,13 +20,14 @@ import
   ./curves_primitives
   
 
-func mapToBaseField*(p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): Fp[Banderwagon] =
+func mapToBaseField*(dst: var Fp[Banderwagon],p: ECP_TwEdwards_Prj[Fp[Banderwagon]]) =
   var invY: Fp[Banderwagon]
   invY.inv(p.y)
-  result.prod(p.x, invY)
+  dst.prod(p.x, invY)
 
-func MapToScalarField*(res: var Fr[Banderwagon], p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): bool {.discardable.} =
-  var baseField: Fp[Banderwagon] = p.mapToBaseField()
+func mapToScalarField*(res: var Fr[Banderwagon], p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): bool {.discardable.} =
+  var baseField: Fp[Banderwagon]
+  baseField.mapToBaseField(p)
   var baseFieldBytes: array[32, byte]
 
   let check1 = baseFieldBytes.marshalBE(baseField)

--- a/constantine/ethereum_verkle_primitives.nim
+++ b/constantine/ethereum_verkle_primitives.nim
@@ -1,0 +1,35 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## ############################################################
+##
+##              Verkle Trie primitives for Ethereum
+##
+## ############################################################
+
+import
+  ./math/config/[type_ff, curves],
+  ./math/arithmetic,
+  ./math/elliptic/ec_twistededwards_projective,
+  ./math/io/[io_bigints, io_fields],
+  ./curves_primitives
+  
+
+func mapToBaseField*(p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): Fp[Banderwagon] =
+  var invY: Fp[Banderwagon]
+  invY.inv(p.y)
+  result.prod(p.x, invY)
+
+func MapToScalarField*(res: var Fr[Banderwagon], p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): bool {.discardable.} =
+  var baseField: Fp[Banderwagon] = p.mapToBaseField()
+  var baseFieldBytes: array[32, byte]
+
+  let check1 = baseFieldBytes.marshalBE(baseField)
+  let check2 = res.unmarshalBE(baseFieldBytes)
+
+  return check1 and check2

--- a/constantine/ethereum_verkle_primitives.nim
+++ b/constantine/ethereum_verkle_primitives.nim
@@ -21,16 +21,30 @@ import
   
 
 func mapToBaseField*(dst: var Fp[Banderwagon],p: ECP_TwEdwards_Prj[Fp[Banderwagon]]) =
+  ## The mapping chosen for the Banderwagon Curve is x/y
+  ## 
+  ## This function takes a Banderwagon element & then
+  ## computes the x/y value and returns as an Fp element
+  ## 
+  ## Spec : https://hackmd.io/@6iQDuIePQjyYBqDChYw_jg/BJBNcv9fq#Map-To-Field
+  
   var invY: Fp[Banderwagon]
-  invY.inv(p.y)
-  dst.prod(p.x, invY)
+  invY.inv(p.y)             # invY = 1/Y
+  dst.prod(p.x, invY)       # dst = (X) * (1/Y)
 
 func mapToScalarField*(res: var Fr[Banderwagon], p: ECP_TwEdwards_Prj[Fp[Banderwagon]]): bool {.discardable.} =
-  var baseField: Fp[Banderwagon]
-  baseField.mapToBaseField(p)
-  var baseFieldBytes: array[32, byte]
+  ## This function takes the x/y value from the above function as Fp element 
+  ## and convert that to bytes in Big Endian, 
+  ## and then load that to a Fr element
+  ## 
+  ## Spec : https://hackmd.io/wliPP_RMT4emsucVuCqfHA?view#MapToFieldElement
 
-  let check1 = baseFieldBytes.marshalBE(baseField)
-  let check2 = res.unmarshalBE(baseFieldBytes)
+  var baseField: Fp[Banderwagon]
+  var baseFieldBytes: array[32, byte]
+  
+  baseField.mapToBaseField(p)   # compute the defined mapping
+
+  let check1 = baseFieldBytes.marshalBE(baseField)  # Fp -> bytes
+  let check2 = res.unmarshalBE(baseFieldBytes)      # bytes -> Fr
 
   return check1 and check2

--- a/constantine/math/elliptic/ec_twistededwards_batch_ops.nim
+++ b/constantine/math/elliptic/ec_twistededwards_batch_ops.nim
@@ -88,11 +88,13 @@ func batchAffine*[M, N: static int, F](
   batchAffine(affs[0].asUnchecked(), projs[0].asUnchecked(), M*N)
 
 func batchInvert_vartime*[N: static int, F](elements: var array[N, F]) =
-  # TODO: optimize
+  ##  Montgomery's batch inversion
+  ##  This function person the inversion in-place
   var res: array[N, F]
   var zeros: array[N, bool]
+
   var accumulator: F
-  accumulator.setOne()
+  accumulator.setOne()    # sets the accumulator to 1
 
   for i in 0 ..< N: 
     if elements[i].isZero().bool():
@@ -102,7 +104,7 @@ func batchInvert_vartime*[N: static int, F](elements: var array[N, F]) =
     res[i] = accumulator
     accumulator *= elements[i]
 
-  accumulator.inv_vartime()
+  accumulator.inv_vartime()   # inversion of the accumulator
 
   for i in countdown(N-1, 0):
     if zeros[i] == true:

--- a/constantine/math/elliptic/ec_twistededwards_batch_ops.nim
+++ b/constantine/math/elliptic/ec_twistededwards_batch_ops.nim
@@ -1,0 +1,113 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../../platforms/abstractions,
+  ../arithmetic,
+  ./ec_twistededwards_affine,
+  ./ec_twistededwards_projective
+
+# No exceptions allowed, or array bound checks or integer overflow
+{.push raises: [], checks:off.}
+
+# ############################################################
+#
+#             Elliptic Curve in Twisted Edwards form
+#                     Batch conversion
+#
+# ############################################################
+
+func batchAffine*[F](
+       affs: ptr UncheckedArray[ECP_TwEdwards_Aff[F]],
+       projs: ptr UncheckedArray[ECP_TwEdwards_Prj[F]],
+       N: int) {.noInline, tags:[Alloca].} =
+  # Algorithm: Montgomery's batch inversion
+  # - Speeding the Pollard and Elliptic Curve Methods of Factorization
+  #   Section 10.3.1
+  #   Peter L. Montgomery
+  #   https://www.ams.org/journals/mcom/1987-48-177/S0025-5718-1987-0866113-7/S0025-5718-1987-0866113-7.pdf
+  # - Modern Computer Arithmetic
+  #   Section 2.5.1 Several inversions at once
+  #   Richard P. Brent and Paul Zimmermann
+  #   https://members.loria.fr/PZimmermann/mca/mca-cup-0.5.9.pdf
+
+  # To avoid temporaries, we store partial accumulations
+  # in affs[i].x
+  let zeroes = allocStackArray(SecretBool, N)
+  affs[0].x = projs[0].z
+  zeroes[0] = affs[0].x.isZero()
+  affs[0].x.csetOne(zeroes[0])
+
+  for i in 1 ..< N:
+    # Skip zero z-coordinates (infinity points)
+    var z = projs[i].z
+    zeroes[i] = z.isZero()
+    z.csetOne(zeroes[i])
+
+    if i != N-1:
+      affs[i].x.prod(affs[i-1].x, z, skipFinalSub = true)
+    else:
+      affs[i].x.prod(affs[i-1].x, z, skipFinalSub = false)
+
+  var accInv {.noInit.}: F
+  accInv.inv(affs[N-1].x)
+
+  for i in countdown(N-1, 1):
+    # Extract 1/Pᵢ
+    var invi {.noInit.}: F
+    invi.prod(accInv, affs[i-1].x, skipFinalSub = true)
+    invi.csetZero(zeroes[i])
+
+    # Now convert Pᵢ to affine
+    affs[i].x.prod(projs[i].x, invi)
+    affs[i].y.prod(projs[i].y, invi)
+
+    # next iteration
+    invi = projs[i].z
+    invi.csetOne(zeroes[i])
+    accInv.prod(accInv, invi, skipFinalSub = true)
+
+  block: # tail
+    accInv.csetZero(zeroes[0])
+    affs[0].x.prod(projs[0].x, accInv)
+    affs[0].y.prod(projs[0].y, accInv)
+
+func batchAffine*[N: static int, F](
+       affs: var array[N, ECP_TwEdwards_Aff[F]],
+       projs: array[N, ECP_TwEdwards_Prj[F]]) {.inline.} =
+  batchAffine(affs.asUnchecked(), projs.asUnchecked(), N)
+
+func batchAffine*[M, N: static int, F](
+       affs: var array[M, array[N, ECP_TwEdwards_Aff[F]]],
+       projs: array[M, array[N, ECP_TwEdwards_Prj[F]]]) {.inline.} =
+  batchAffine(affs[0].asUnchecked(), projs[0].asUnchecked(), M*N)
+
+func batchInvert_vartime*[N: static int, F](elements: var array[N, F]) =
+  # TODO: optimize
+  var res: array[N, F]
+  var zeros: array[N, bool]
+  var accumulator: F
+  accumulator.setOne()
+
+  for i in 0 ..< N: 
+    if elements[i].isZero().bool():
+      zeros[i] = true
+      continue
+
+    res[i] = accumulator
+    accumulator *= elements[i]
+
+  accumulator.inv_vartime()
+
+  for i in countdown(N-1, 0):
+    if zeros[i] == true:
+      continue
+    res[i] *= accumulator
+    accumulator *= elements[i]
+
+  elements = res

--- a/tests/t_banderwagon.nim
+++ b/tests/t_banderwagon.nim
@@ -224,8 +224,8 @@ suite "Banderwagon Elements Mapping":
       B.double()
 
       var expected_a, expected_b: Fr[Banderwagon]
-      expected_a.MapToScalarField(A)
-      expected_b.MapToScalarField(B)
+      expected_a.mapToScalarField(A)
+      expected_b.mapToScalarField(B)
 
       doAssert expected_a.toHex() == expected_scalar_field_elements[0], "Mapping to Scalar Field Incorrect"
       doAssert expected_b.toHex() == expected_scalar_field_elements[1], "Mapping to Scalar Field Incorrect"

--- a/tests/t_banderwagon.nim
+++ b/tests/t_banderwagon.nim
@@ -20,7 +20,8 @@ import
     codecs
   ],
   ../constantine/math/arithmetic,
-  ../constantine/math/constants/zoo_generators
+  ../constantine/math/constants/zoo_generators,
+  ../constantine/ethereum_verkle_primitives
 
 type
   EC* = ECP_TwEdwards_Prj[Fp[Banderwagon]]
@@ -69,6 +70,11 @@ const bad_bit_string: array[16, string] = [
   "0x6671109a7a15f4852ead3298318595a36010930fddbd3c8f667c6390e7ac3c66",
   "0x120faa1df94d5d831bbb69fc44816e25afd27288a333299ac3c94518fd0e016f",
 ]
+
+const expected_scalar_field_elements: array[2, string] = [
+  "0x0e0c604381ef3cd11bdc84e8faa59b542fbbc92f800ed5767f21e5dbc59840ce",
+  "0x0a21f7dfa8ddaf6ef6f2044f13feec50cbb963996112fa1de4e3f52dbf6b7b6d"
+] # test data generated from go-ipa implementation
 
 # ############################################################
 #
@@ -207,3 +213,21 @@ suite "Banderwagon Points Tests":
 
     testTwoTorsion()
 
+suite "Banderwagon Elements Mapping":
+  test "Testing Multi Map To Base Field":
+    proc testMultiMapToBaseField() =
+      var A, B, genPoint {.noInit.}: EC
+      genPoint.fromAffine(generator)
+
+      A.sum(genPoint, genPoint)
+      B.double(genPoint)
+      B.double()
+
+      var expected_a, expected_b: Fr[Banderwagon]
+      expected_a.MapToScalarField(A)
+      expected_b.MapToScalarField(B)
+
+      doAssert expected_a.toHex() == expected_scalar_field_elements[0], "Mapping to Scalar Field Incorrect"
+      doAssert expected_b.toHex() == expected_scalar_field_elements[1], "Mapping to Scalar Field Incorrect"
+
+    testMultiMapToBaseField()

--- a/tests/t_banderwagon.nim
+++ b/tests/t_banderwagon.nim
@@ -213,17 +213,28 @@ suite "Banderwagon Points Tests":
 
     testTwoTorsion()
 
+# ############################################################
+#
+#     Banderwagon Points Mapped to Scalar Field ( Fp -> Fr )
+#
+# ############################################################
 suite "Banderwagon Elements Mapping":
+
+  ## Tests if the mapping from Fp to Fr 
+  ## is working as expected or not
   test "Testing Multi Map To Base Field":
     proc testMultiMapToBaseField() =
       var A, B, genPoint {.noInit.}: EC
       genPoint.fromAffine(generator)
 
-      A.sum(genPoint, genPoint)
-      B.double(genPoint)
-      B.double()
+      A.sum(genPoint, genPoint) # A = g+g = 2g
+      B.double(genPoint)        # B = 2g
+      B.double()                # B = 2B = 4g
 
       var expected_a, expected_b: Fr[Banderwagon]
+
+      # conver the points A & B which are in Fp
+      # to the their mapped Fr points 
       expected_a.mapToScalarField(A)
       expected_b.mapToScalarField(B)
 

--- a/tests/t_ethereum_verkle_primitives.nim
+++ b/tests/t_ethereum_verkle_primitives.nim
@@ -6,6 +6,12 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+# ############################################################
+#
+#             Ethereum Verkle Primitves Tests
+#
+# ############################################################
+
 import
   std/unittest,
   ../constantine/math/config/[type_ff, curves],
@@ -296,16 +302,17 @@ suite "Batch Operations on Banderwagon":
         arr_fp[i] = one.x
         one.double()
 
-      arr_fp.batchInvert_vartime()
+      var arr_fp_inv: array[n, Fp[Banderwagon]]
+      doAssert arr_fp_inv.batchInvert(arr_fp) == true
 
       # Checking the correspondence with singular element inversion
       for i in 0 ..< n:
         var temp: Fp[Banderwagon]
         temp.inv(two.x)
-        doAssert (arr_fp[i] == temp).bool(), "Batch Inversion in consistent"
+        doAssert (arr_fp_inv[i] == temp).bool(), "Batch Inversion in consistent"
         two.double()
 
-    batchInvert(1000)
+    batchInvert(10)
 
   ## Tests to check if the Batch Map to Scalar Field
   ## is consistent with it's respective singular operation


### PR DESCRIPTION
Fixes #277 

Refere the issue #277 for the detailed specs

- [x] Write the `mapToBaseField()` function for computing $\frac{x}{y}$ and returning as an $F_p$ element
- [x] `MapToScalarField()` for  converting the $F_p$ element to $F_r$, in between it is done by first converting $F_p$ -> *Bytes* -> $F_r$
- [x] Tests for `mapToBaseField()` & `MapToScalarField()`
- [x] Commenting and linking specs documents in the code 
- [x] Adding the `BatchMapToField()`, this does the same operations but for a batch of *Banderwagon* points together
- [x] Tests for the Batch operations
- [x] Final checks, fixes and commenting the codebase