### PR TITLE
Allow installation / import through nimble

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -8,6 +8,8 @@ license       = "MIT or Apache License 2.0"
 # ----------------------------------------------------------------
 
 requires "nim >= 1.6.12"
+installDirs "constantine",
+            "metering"
 
 # Nimscript imports
 # ----------------------------------------------------------------

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -4,12 +4,12 @@ author        = "Mamy Ratsimbazafy"
 description   = "This library provides thoroughly tested and highly-optimized implementations of cryptography protocols."
 license       = "MIT or Apache License 2.0"
 
+installDirs = @["constantine", "metering"]
+
 # Dependencies
 # ----------------------------------------------------------------
 
 requires "nim >= 1.6.12"
-installDirs "constantine",
-            "metering"
 
 # Nimscript imports
 # ----------------------------------------------------------------


### PR DESCRIPTION
By default, nimble strips anything not named `constantine` but we need `metering` as well.

This adapt the nimble file to allow this.

Note: the current directory structure was chosen after careful consideration to market across devs looking for different capabilities in cryptographic backend. Metering is a particularly valuable niche to optimize EVM gas costs hence it SHOULD be "in-your-face" in the directory structure.

We might also want to consider installing the binding generators, but it's unsure if there is a command (maybe `nimble build`?) to build Constantine as a static or shared library. Though that might not be needed in the future with incremental compilation.

Lastly we might also consider installing the tests so they can be run on constantine install, it's especially important given unique codepaths for 32/64-bit, CPU ISAs and OS combination.

