### PR TITLE
Nvidia JIT fixes

### DIFF
--- a/constantine/platforms/code_generator/bindings/llvm_abi.nim
+++ b/constantine/platforms/code_generator/bindings/llvm_abi.nim
@@ -248,16 +248,20 @@ proc getGlobalPassRegistry(): PassRegistryRef {.importc: "LLVMGetGlobalPassRegis
 proc initializeCore(registry: PassRegistryRef) {.importc: "LLVMInitializeCore".}
 proc initializeTransformUtils(registry: PassRegistryRef) {.importc: "LLVMInitializeTransformUtils".}
 proc initializeScalarOpts(registry: PassRegistryRef) {.importc: "LLVMInitializeScalarOpts".}
-proc initializeObjCARCOpts(registry: PassRegistryRef) {.importc: "LLVMInitializeObjCARCOpts".}
 proc initializeVectorization(registry: PassRegistryRef) {.importc: "LLVMInitializeVectorization".}
 proc initializeInstCombine(registry: PassRegistryRef) {.importc: "LLVMInitializeInstCombine".}
-proc initializeAggressiveInstCombiner(registry: PassRegistryRef) {.importc: "LLVMInitializeAggressiveInstCombiner".}
 proc initializeIPO(registry: PassRegistryRef) {.importc: "LLVMInitializeIPO".}
-proc initializeInstrumentation(registry: PassRegistryRef) {.importc: "LLVMInitializeInstrumentation".}
 proc initializeAnalysis(registry: PassRegistryRef) {.importc: "LLVMInitializeAnalysis".}
 proc initializeIPA(registry: PassRegistryRef) {.importc: "LLVMInitializeIPA".}
 proc initializeCodeGen(registry: PassRegistryRef) {.importc: "LLVMInitializeCodeGen".}
 proc initializeTarget(registry: PassRegistryRef) {.importc: "LLVMInitializeTarget".}
+
+# Removed in LLVM 16
+# ------------------
+# proc initializeObjCARCOpts(registry: PassRegistryRef) {.importc: "LLVMInitializeObjCARCOpts".}
+# proc initializeAggressiveInstCombiner(registry: PassRegistryRef) {.importc: "LLVMInitializeAggressiveInstCombiner".}
+# proc initializeInstrumentation(registry: PassRegistryRef) {.importc: "LLVMInitializeInstrumentation".}
+
 {.pop.}
 
 # https://llvm.org/doxygen/group__LLVMCTarget.html

--- a/constantine/platforms/code_generator/ir.nim
+++ b/constantine/platforms/code_generator/ir.nim
@@ -10,7 +10,7 @@ import
   ../../math/config/[curves, precompute],
   ../../math/io/io_bigints,
   ../primitives, ../bithacks,
-  ../../serialization/[endians, codecs],
+  ../../serialization/[endians, codecs, io_limbs],
   ./llvm
 
 # ############################################################

--- a/constantine/platforms/code_generator/llvm.nim
+++ b/constantine/platforms/code_generator/llvm.nim
@@ -120,7 +120,7 @@ template emitToFile*(t: TargetMachineRef, m: ModuleRef,
     writeStackTrace()
     stderr.write("\"emitToFile\" for module '" & astToStr(module) & "' " & $instantiationInfo() & " exited with error: " & $cstring(errMsg) & '\n')
     errMsg.dispose()
-    quit 1 
+    quit 1
 
 template emitToString*(t: TargetMachineRef, m: ModuleRef, codegen: CodeGenFileType): string =
   ## Codegen to string
@@ -147,16 +147,19 @@ proc initializePasses* =
   registry.initializeCore()
   registry.initializeTransformUtils()
   registry.initializeScalarOpts()
-  registry.initializeObjCARCOpts()
   registry.initializeVectorization()
   registry.initializeInstCombine()
-  registry.initializeAggressiveInstCombiner()
   registry.initializeIPO()
-  registry.initializeInstrumentation()
   registry.initializeAnalysis()
   registry.initializeIPA()
   registry.initializeCodeGen()
   registry.initializeTarget()
+
+  # Removed in LLVM 16
+  # --------------------------------
+  # registry.initializeObjCARCOpts()
+  # registry.initializeAggressiveInstCombiner()
+  # registry.initializeInstrumentation()
 
 # Builder
 # ------------------------------------------------------------


### PR DESCRIPTION
This fixes the Nvidia JIT backend

- #239 moved an `unmarshal` proc to `constantine/serialization/io_limbs` that is needed for BigNums https://github.com/mratsim/constantine/blob/4ccd8aaab86f0c1955125a5ce6fe66915cb2cbf4/constantine/platforms/code_generator/ir.nim#L91-L95
- Warning about unused `ctx` in the Nvidia assembly code generator when regTy takes a branch that doesn't use `ctx`
- Warning about unnecesary conversion from a type to itself
- LLVM 16 deleted some optimization passes or moved them to another name
