### PR TITLE
Conversion of little endian hex strings to bigints

### DIFF
--- a/constantine/math/io/io_bigints.nim
+++ b/constantine/math/io/io_bigints.nim
@@ -131,13 +131,11 @@ func marshal*(
 #
 # ############################################################
 
-func fromHex*(a: var BigInt, s: string) =
+func fromHex*(a: var BigInt, s: string, order: static Endianness = bigEndian) =
   ## Convert a hex string to BigInt that can hold
   ## the specified number of bits
   ##
   ## For example `fromHex(BigInt[256], "0x123456")`
-  ##
-  ## Hex string is assumed big-endian
   ##
   ## Procedure is constant-time except for the presence (or absence) of the 0x prefix.
   ##
@@ -152,15 +150,16 @@ func fromHex*(a: var BigInt, s: string) =
   bytes.paddedFromHex(s, bigEndian)
 
   # 2. Convert canonical uint to Big Int
-  a.unmarshal(bytes, bigEndian)
+  a.unmarshal(bytes, order)
 
-func fromHex*(T: type BigInt, s: string): T {.noInit.} =
+func fromHex*(
+        T: type BigInt,
+        s: string,
+        order: static Endianness = bigEndian): T {.noInit.} =
   ## Convert a hex string to BigInt that can hold
   ## the specified number of bits
   ##
   ## For example `fromHex(BigInt[256], "0x123456")`
-  ##
-  ## Hex string is assumed big-endian
   ##
   ## Procedure is constant-time except for the presence (or absence) of the 0x prefix.
   ##
@@ -168,7 +167,7 @@ func fromHex*(T: type BigInt, s: string): T {.noInit.} =
   ## You MUST NOT use it for production.
   ##
   ## Can work at compile-time to declare curve moduli from their hex strings
-  result.fromHex(s)
+  result.fromHex(s, order)
 
 func appendHex*(dst: var string, big: BigInt, order: static Endianness = bigEndian) =
   ## Append the BigInt hex into an accumulator

--- a/tests/math_bigints/t_io_bigints.nim
+++ b/tests/math_bigints/t_io_bigints.nim
@@ -93,10 +93,18 @@ proc main() =
 
     test "Round trip on 3072-bit integer":
       const n = "0x75be9187192dccf08bedcb06c7fba60830840cb8a5c3a5895e63ffd78073f2f7e0ccc72ae2f91c2be9fe51e48373bf4426e6e1babb9bc5374747a0e24b982a27359cf403a6bb900800b6dd52b309788df7f599f3db6f5b5ba5fbe88b8d03ab32fbe8d75dbbad0178f70dc4dfbc39008e5c8a4975f08060f4af1718e1a8811b0b73daabf67bf971c1fa79d678e3e2bf878a844004d1ab5b11a2c3e4fa8abbbe15b75a4a15a4c0eecd128ad7b13571545a967cac88d1b1e88c3b09723849c54adede6b36dd21000f41bc404083bf01902d2d3591c2e51fe0cc26d691cbc9ba6ea3137bd977745cc8761c828f7d54899841701faeca7ff5fc975968693284c2dcaf68e9852a67b5782810834f2eed0ba8e69d18c2a9d8aa1d81528110f0156610febe5ee2db65add65006a9f91370828e356c7751fa50bb49f43b408cd2f4767a43bc57888afe01d2a85d457c68a3eb60de713b79c318b92cb1b2837cf78f9e6e5ec0091d2810a34a1c75400190f8582a8b42f436b799db088689f8187b6db8530d"
-      let x = BigInt[3072].fromHex(n)
-      let h = x.toHex(bigEndian)
 
-      check: n == h
+      block: # Big-Endian
+        let x = BigInt[3072].fromHex(n)
+        let h = x.toHex(bigEndian)
+
+        check: n == h
+
+      block: # Little-Endian
+        let x = BigInt[3072].fromHex(n, littleEndian)
+        let h = x.toHex(littleEndian)
+
+        check: n == h
 
   suite "IO Decimal - BigInt" & " [" & $WordBitWidth & "-bit words]":
     test "Checks elliptic curve constants":


### PR DESCRIPTION
Allows `BigInt.fromHex()` to work with both little-endian and big-endian hex strings.