### PR TITLE
Rework LTO, Intel Assembly syntax and default compile-options

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [build]
 # https://doc.rust-lang.org/rustc/linker-plugin-lto.html
 rustflags="-Clinker-plugin-lto -Clinker=clang -Clink-arg=-fuse-ld=lld"
+
+# Note, on MacOS, for Intel targets, LTO on the Nim code is not used
+# as Apple Clang does not support the Intel assembly syntax.
+# Unfortunately the AT&T syntax causes issues when LTO inlines constants into inline assembly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,17 +189,27 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install gmp
-          mkdir -p external/bin
-          cat << EOF > external/bin/clang
-          #!/bin/bash
-          exec $(brew --prefix llvm@15)/bin/clang "\$@"
-          EOF
-          cat << EOF > external/bin/clang++
-          #!/bin/bash
-          exec $(brew --prefix llvm@15)/bin/clang++ "\$@"
-          EOF
-          chmod 755 external/bin/{clang,clang++}
-          echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
+      # - name: Install Clang with Intel Assembly support (macOS)
+      #   if: runner.os == 'macOS'
+      #   # Apple Clang does not support Intel syntax due to missing
+      #   # commit: https://github.com/llvm/llvm-project/commit/ae98182cf7341181e4aa815c372a072dec82779f
+      #   # Revision: https://reviews.llvm.org/D113707
+
+      #   # We test without LTO on Mac
+      #   # Uncomment the following to use upstream clang/llvm
+      #   # and test with LTO on Macs
+      #   run: |
+      #     mkdir -p external/bin
+      #     cat << EOF > external/bin/clang
+      #     #!/bin/bash
+      #     exec $(brew --prefix llvm@15)/bin/clang "\$@"
+      #     EOF
+      #     cat << EOF > external/bin/clang++
+      #     #!/bin/bash
+      #     exec $(brew --prefix llvm@15)/bin/clang++ "\$@"
+      #     EOF
+      #     chmod 755 external/bin/{clang,clang++}
+      #     echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
 
       - name: Setup MSYS2 (Windows)
         if: runner.os == 'Windows'

--- a/benchmarks/bench_sha256.nim
+++ b/benchmarks/bench_sha256.nim
@@ -15,12 +15,12 @@ when defined(windows):
   else:
     const DLLSSLName* = "(libssl-1_1|ssleay32|libssl32).dll"
 else:
-  when defined(macosx):
+  when defined(macosx) or defined(macos) or defined(ios):
     const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
   else:
     const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
-  when defined(macosx):
+  when defined(macosx) or defined(macos) or defined(ios):
     const DLLSSLName* = "libssl" & versions & ".dylib"
   elif defined(genode):
     const DLLSSLName* = "libssl.lib.so"

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -114,7 +114,7 @@ func compilerFlags(): string =
 
 const Apple = defined(macos) or defined(macox) or defined(ios)
 
-proc releaseBuildOptions(useLTO = not Apple): string =
+proc releaseBuildOptions(useLTO = false): string =
 
   let compiler = if existsEnv"CC": " --cc:" & getEnv"CC"
                  else: ""

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -128,7 +128,7 @@ proc releaseBuildOptions(useLTO = false): string =
   let lto = if useLTO: " --passC:-flto=auto --passL:-flto=auto "
             else: ""
 
-  let lto_syntax = if useLTO: "  -d:UseAsmSyntaxIntel "
+  let lto_syntax = if useLTO: "  -d:UseAsmSyntaxIntel=true "
                    else: "  -d:UseAsmSyntaxIntel=false "
 
   compiler &
@@ -157,7 +157,7 @@ proc genDynamicLib(outdir, nimcache: string) =
 
     exec "nim c " &
          flags &
-         releaseBuildOptions(useLTO = true) &
+         releaseBuildOptions(useLTO = false) &
          " --noMain --app:lib " &
          &" --nimMainPrefix:ctt_init_ " & # Constantine is designed so that NimMain isn't needed, provided --mm:arc -d:useMalloc --panics:on -d:noSignalHandler
          &" --out:{libName} --outdir:{outdir} " &

--- a/constantine/csprngs/sysrand.nim
+++ b/constantine/csprngs/sysrand.nim
@@ -100,7 +100,7 @@ elif defined(linux):
     ## Fills the buffer with cryptographically secure random data
     return urandom(buffer.addr, sizeof(T))
 
-elif defined(ios) or defined(macosx):
+elif defined(ios) or defined(macosx) or defined(macos):
   # There are 4 APIs we can use
   # - The getentropy(2) system call (similar to OpenBSD)
   # - The random device (/dev/random)

--- a/constantine/math/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_modular_dbl_prec_x86.nim
@@ -30,6 +30,9 @@ static: doAssert UseASM_X86_64
 # Necessary for the compiler to find enough registers
 {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Double-precision field addition
 # ------------------------------------------------------------
 

--- a/constantine/math/arithmetic/assembly/limbs_asm_modular_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_modular_x86.nim
@@ -23,6 +23,9 @@ static: doAssert UseASM_X86_32
 # Necessary for the compiler to find enough registers
 {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 proc finalSubNoOverflowImpl*(
        ctx: var Assembler_x86,
        r: Operand or OperandArray,

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
@@ -27,6 +27,9 @@ static: doAssert UseASM_X86_64
 {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 {.localPassC:"-fno-sanitize=address".} # need 15 registers out of 16 (1 reserved for stack pointer, none available for Address Sanitizer)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Montgomery multiplication
 # ------------------------------------------------------------
 # Fallback when no ADX and BMI2 support (MULX, ADCX, ADOX)

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
@@ -29,6 +29,9 @@ static: doAssert UseASM_X86_64
 {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 {.localPassC:"-fno-sanitize=address".} # need 15 registers out of 16 (1 reserved for stack pointer, none available for Address Sanitizer)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Montgomery Multiplication
 # ------------------------------------------------------------
 

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_x86.nim
@@ -21,6 +21,9 @@ import
 static: doAssert UseASM_X86_64 # Need 8 registers just for mul
                                # and 32-bit only has 8 max.
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Multiplication
 # -----------------------------------------------------------------------------------------------
 

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_x86_adx_bmi2.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_x86_adx_bmi2.nim
@@ -25,6 +25,9 @@ static: doAssert UseASM_X86_64
 # Necessary for the compiler to find enough registers
 # {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Multiplication
 # ------------------------------------------------------------
 proc mulx_by_word(

--- a/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86.nim
@@ -25,6 +25,9 @@ static: doAssert UseASM_X86_32
 # Necessary for the compiler to find enough registers
 {.localPassC:"-fomit-frame-pointer".}  # (enabled at -O1)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Montgomery reduction
 # ------------------------------------------------------------
 

--- a/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
@@ -26,6 +26,9 @@ static: doAssert UseASM_X86_64
 # Necessary for the compiler to find enough registers
 {.localPassC:"-fomit-frame-pointer".} # (enabled at -O1)
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # No exceptions allowed
 {.push raises: [].}
 

--- a/constantine/math/arithmetic/assembly/limbs_asm_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_x86.nim
@@ -20,6 +20,9 @@ import
 
 static: doAssert UseASM_X86_32
 
+when UseAsmSyntaxIntel:
+  {.localpassC:"-masm=intel".}
+
 # Copy
 # ------------------------------------------------------------
 macro ccopy_gen[N: static int](a_PIR: var Limbs[N], b_MEM: Limbs[N], ctl: SecretBool): untyped =

--- a/constantine/math/extension_fields/assembly/fp2_asm_x86_adx_bmi2.nim
+++ b/constantine/math/extension_fields/assembly/fp2_asm_x86_adx_bmi2.nim
@@ -26,11 +26,6 @@ import
 
 static: doAssert UseASM_X86_64
 
-# MULX/ADCX/ADOX
-{.localPassC:"-madx -mbmi2".}
-# Necessary for the compiler to find enough registers
-{.localPassC:"-fomit-frame-pointer".} # (enabled at -O1)
-
 # No exceptions allowed
 {.push raises: [].}
 
@@ -112,8 +107,7 @@ func mul2x_fp2_complex_asm_adx*(
 
 func mul_fp2_complex_asm_adx*(
         r: var array[2, Fp],
-        a, b: array[2, Fp]
-      ) =
+        a, b: array[2, Fp]) =
   ## Complex multiplication on 𝔽p2
   var d {.noInit.}: array[2,doublePrec(Fp)]
   d.mul2x_fp2_complex_asm_adx(a, b)

--- a/constantine/platforms/config.nim
+++ b/constantine/platforms/config.nim
@@ -28,4 +28,20 @@ const UseASM_X86_64* = not(CTT_32) and UseASM_X86_32
 when UseASM_X86_64:
   static: doAssert bool(sizeof(pointer)*8 == 64), "Only 32-bit and 64-bit platforms are supported"
 
-const UseAsmSyntaxIntel* {.booldefine.} = true
+const UseAsmSyntaxIntel* {.booldefine.} = not(defined(macos) or defined(macosx) or defined(ios))
+  ## When using LTO with AT&T syntax
+  ## - GCC will give spurious "Warning: missing operand; zero assumed" with AT&T syntax
+  ## - Clang will wrongly combine memory offset and constant propagated address of constants
+  ##
+  ## Intel syntax does not have such limitation.
+  ## However
+  ## - Global "-masm=intel" composition with other libraries that use AT&T inline assembly
+  ## - It is not supported on Apple Clang due to missing
+  ##   commit: https://github.com/llvm/llvm-project/commit/ae98182cf7341181e4aa815c372a072dec82779f
+  ##   Revision: https://reviews.llvm.org/D113707
+  ##
+  ## As a workaround:
+  ## - Intel assembly is used on a per-file basis
+  ##   and does not affect other libraries that might be compiled together with Constantine.
+  ## - It is deactivated on MacOs / iOS.
+  ##   That means LTO will not work on MacOS unless upstream Clang is used instead of Apple fork.

--- a/constantine/platforms/isa/macro_assembler_x86.nim
+++ b/constantine/platforms/isa/macro_assembler_x86.nim
@@ -16,8 +16,6 @@ when UseAsmSyntaxIntel:
   # However when constant are propagated, 8(%[identifier]) can also expand to
   # 8BLS12_381_Modulus(%rip) i.e. the compiler tries to forward to the linker the relative address of a constant
   # and due to naive string mixin it fails.
-  {.passC:"-masm=intel".}
-
   import ./macro_assembler_x86_intel
   export macro_assembler_x86_intel
 else:

--- a/constantine/platforms/isa/macro_assembler_x86_intel.nim
+++ b/constantine/platforms/isa/macro_assembler_x86_intel.nim
@@ -41,6 +41,10 @@ type
     # Clobbered register
     ClobberedReg
 
+    # We can replace m and o by p constraint for optimization but this triggers impossible constraints in some cases
+    # See https://stackoverflow.com/questions/20965114/gcc-inline-assembly-using-modifier-p-and-constraint-p-over-m-in-linux-kern
+    # and https://lists.openwall.net/linux-kernel/2009/08/01/115
+
 when CTT_32:
   type
     Register* = enum
@@ -188,11 +192,11 @@ func genMemClobber(nimSymbol: NimNode, len: int, memIndirect: MemIndirectAccess)
 
   case memIndirect
   of memRead:
-    return "\"m\" (`*(const " & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
+    return "\"o\" (`*(const " & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
   of memWrite:
-    return "\"=m\" (`*(" & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
+    return "\"=o\" (`*(" & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
   of memReadWrite:
-    return "\"+m\" (`*(" & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
+    return "\"+o\" (`*(" & cBaseType & " (*)[" & $len & "]) " & symStr & "`)"
   else:
     doAssert false, "Indirect access kind not specified"
 

--- a/constantine/threadpool/primitives/timers.nim
+++ b/constantine/threadpool/primitives/timers.nim
@@ -66,7 +66,7 @@ when defined(linux):
     ## Returns the elapsed time in nano-seconds from ticks
     stop.int64 - start.int64
 
-elif defined(macosx):
+elif defined(macosx) or defined(macos) or defined(ios):
   type
     MachTimebaseInfoData {.pure, final, importc: "mach_timebase_info_data_t", header: "<mach/mach_time.h>".} = object
       numer, denom: int32

--- a/tests/t_hash_sha256_vs_openssl.nim
+++ b/tests/t_hash_sha256_vs_openssl.nim
@@ -13,12 +13,12 @@ when defined(windows):
   else:
     const DLLSSLName* = "(libssl-1_1|ssleay32|libssl32).dll"
 else:
-  when defined(macosx):
+  when defined(macosx) or defined(macos) or defined(ios):
     const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.47|.48|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
   else:
     const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
-  when defined(macosx):
+  when defined(macosx) or defined(macos) or defined(ios):
     const DLLSSLName* = "libssl" & versions & ".dylib"
   elif defined(genode):
     const DLLSSLName* = "libssl.lib.so"


### PR DESCRIPTION
This tries to address #303 #295 https://github.com/codex-storage/nim-codex/pull/625#discussion_r1397703104 following making Constantine compatible with LTO #231

- Intel assembly is used on a per-file basis to avoid interfering with other libraries like secp256k1
- On Apple MacOS/iOS it will need to be explicitly enabled, due to:
  - Clang not supporting Intel syntax:
    - This has not be upstreamed in Apple Clang: https://reviews.llvm.org/D113707
    - Opened issue to Apple: FB12137688
  - Intel Apple CPUs being outdated and not being used for high-performance cryptography and Intel syntax being irrelevant for ARM CPUs.