### PR TITLE
Rust: Add tentative caching API for ZAL

### DIFF
--- a/constantine-rust/constantine-sys/build.rs
+++ b/constantine-rust/constantine-sys/build.rs
@@ -23,7 +23,7 @@ fn main() {
         .expect("failed to execute process");
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
-    
+
     // On windows stable channel (msvc) expects constantine.lib
     // while stable-gnu channel (gcc) expects libconstantine.a
     // hence we use +verbatim


### PR DESCRIPTION
https://github.com/privacy-scaling-explorations/halo2curves/pull/107#issuecomment-1841456570

For CPU only and because Constantine can work directly in projective coordinates like Halo2curves, we don't really need the caching API so it's just forwarding everything to the MSM.
Though technically we might want to implement Fr (Montgomery repr) -> Bigint (canonical repr) in the scalar descriptors.