### PR TITLE
Export BLS12-381 serialization/deserialization to C/Rust

### DIFF
--- a/constantine-rust/constantine-sys/src/bindings.rs
+++ b/constantine-rust/constantine-sys/src/bindings.rs
@@ -3554,6 +3554,85 @@ fn bindgen_test_layout_big254() {
     );
 }
 extern "C" {
+    #[must_use]
+    #[doc = " Validate a scalar\n  Regarding timing attacks, this will leak information\n  if the scalar is 0 or larger than the curve order."]
+    pub fn ctt_bls12_381_validate_scalar(scalar: *const big255) -> ctt_codec_scalar_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Validate a G1 point\n  This is an expensive operation that can be cached"]
+    pub fn ctt_bls12_381_validate_g1(point: *const bls12_381_g1_aff) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Validate a G2 point\n  This is an expensive operation that can be cached"]
+    pub fn ctt_bls12_381_validate_g2(point: *const bls12_381_g2_aff) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Serialize a scalar\n  Returns cttCodecScalar_Success if successful"]
+    pub fn ctt_bls12_381_serialize_scalar(
+        dst: *mut byte,
+        scalar: *const big255,
+    ) -> ctt_codec_scalar_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Deserialize a scalar\n  Also validates the scalar range\n\n  This is protected against side-channel unless the scalar is invalid.\n  In that case it will leak whether it's all zeros or larger than the curve order.\n\n  This special-cases (and leaks) 0 scalar as this is a special-case in most protocols\n  or completely invalid (for secret keys)."]
+    pub fn ctt_bls12_381_deserialize_scalar(
+        dst: *mut big255,
+        src: *const byte,
+    ) -> ctt_codec_scalar_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Serialize a BLS12-381 G1 point in compressed (Zcash) format\n\n  Returns cttCodecEcc_Success if successful"]
+    pub fn ctt_bls12_381_serialize_g1_compressed(
+        dst: *mut byte,
+        src: *const bls12_381_g1_aff,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Deserialize a BLS12-381 G1 point in compressed (Zcash) format.\n\n  Warning ⚠:\n    This procedure skips the very expensive subgroup checks.\n    Not checking subgroup exposes a protocol to small subgroup attacks."]
+    pub fn ctt_bls12_381_deserialize_g1_compressed_unchecked(
+        dst: *mut bls12_381_g1_aff,
+        src: *const byte,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Deserialize a BLS12-381 G1 point in compressed (Zcash) format\n  This also validates the G1 point"]
+    pub fn ctt_bls12_381_deserialize_g1_compressed(
+        dst: *mut bls12_381_g1_aff,
+        src: *const byte,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Serialize a BLS12-381 G2 point in compressed (Zcash) format\n\n  Returns cttCodecEcc_Success if successful"]
+    pub fn ctt_bls12_381_serialize_g2_compressed(
+        dst: *mut byte,
+        src: *const bls12_381_g2_aff,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Deserialize a BLS12-381 G2 point in compressed (Zcash) format.\n\n  Warning ⚠:\n    This procedure skips the very expensive subgroup checks.\n    Not checking subgroup exposes a protocol to small subgroup attacks."]
+    pub fn ctt_bls12_381_deserialize_g2_compressed_unchecked(
+        dst: *mut bls12_381_g2_aff,
+        src: *const byte,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
+    #[must_use]
+    #[doc = " Deserialize a BLS12-381 G2 point in compressed (Zcash) format\n  This also validates the G2 point"]
+    pub fn ctt_bls12_381_deserialize_g2_compressed(
+        dst: *mut bls12_381_g2_aff,
+        src: *const byte,
+    ) -> ctt_codec_ecc_status;
+}
+extern "C" {
     pub fn ctt_bls12_381_g1_jac_multi_scalar_mul_big_coefs_vartime_parallel(
         tp: *const ctt_threadpool,
         r: *mut bls12_381_g1_jac,

--- a/constantine/serialization/codecs_bls12_381.nim
+++ b/constantine/serialization/codecs_bls12_381.nim
@@ -49,15 +49,18 @@ import
     ./codecs_status_codes
 
 type
-  Scalar* = matchingOrderBigInt(BLS12_381)
-  G1P* = ECP_ShortW_Aff[Fp[BLS12_381], G1]
-  G2P* = ECP_ShortW_Aff[Fp2[BLS12_381], G2]
+  Scalar = matchingOrderBigInt(BLS12_381)
+  G1P = ECP_ShortW_Aff[Fp[BLS12_381], G1]
+  G2P = ECP_ShortW_Aff[Fp2[BLS12_381], G2]
 
+
+const pre = "ctt_bls12_381_"
+import ../zoo_exports
 
 # Input validation
 # ------------------------------------------------------------------------------------------------
 
-func validate_scalar*(scalar: matchingOrderBigInt(BLS12_381)): CttCodecScalarStatus =
+func validate_scalar*(scalar: Scalar): CttCodecScalarStatus {.libPrefix: pre.} =
   ## Validate a scalar
   ## Regarding timing attacks, this will leak information
   ## if the scalar is 0 or larger than the curve order.
@@ -67,7 +70,7 @@ func validate_scalar*(scalar: matchingOrderBigInt(BLS12_381)): CttCodecScalarSta
     return cttCodecScalar_ScalarLargerThanCurveOrder
   return cttCodecScalar_Success
 
-func validate_g1*(g1Point: G1P): CttCodecEccStatus =
+func validate_g1*(g1Point: G1P): CttCodecEccStatus {.libPrefix: pre.} =
   ## Validate a G1 point
   ## This is an expensive operation that can be cached
   if g1Point.isInf().bool():
@@ -78,7 +81,7 @@ func validate_g1*(g1Point: G1P): CttCodecEccStatus =
     return cttCodecEcc_PointNotInSubgroup
   return cttCodecEcc_Success
 
-func validate_g2*(g2Point: G2P): CttCodecEccStatus =
+func validate_g2*(g2Point: G2P): CttCodecEccStatus {.libPrefix: pre.} =
   ## Validate a G2 point.
   ## This is an expensive operation that can be cached
   if g2Point.isInf().bool():
@@ -92,13 +95,13 @@ func validate_g2*(g2Point: G2P): CttCodecEccStatus =
 # Codecs
 # ------------------------------------------------------------------------------------------------
 
-func serialize_scalar*(dst: var array[32, byte], scalar: matchingOrderBigInt(BLS12_381)): CttCodecScalarStatus =
+func serialize_scalar*(dst: var array[32, byte], scalar: Scalar): CttCodecScalarStatus {.libPrefix: pre.} =
   ## Serialize a scalar
   ## Returns cttCodecScalar_Success if successful
   dst.marshal(scalar, bigEndian)
   return cttCodecScalar_Success
 
-func deserialize_scalar*(dst: var matchingOrderBigInt(BLS12_381), src: array[32, byte]): CttCodecScalarStatus =
+func deserialize_scalar*(dst: var Scalar, src: array[32, byte]): CttCodecScalarStatus {.libPrefix: pre.} =
   ## Deserialize a scalar
   ## Also validates the scalar range
   ##
@@ -115,7 +118,7 @@ func deserialize_scalar*(dst: var matchingOrderBigInt(BLS12_381), src: array[32,
   return cttCodecScalar_Success
 
 
-func serialize_g1_compressed*(dst: var array[48, byte], g1Point: G1P): CttCodecEccStatus =
+func serialize_g1_compressed*(dst: var array[48, byte], g1Point: G1P): CttCodecEccStatus {.libPrefix: pre.} =
   ## Serialize a BLS12-381 G1 point in compressed (Zcash) format
   ##
   ## Returns cttCodecEcc_Success if successful
@@ -138,7 +141,7 @@ func serialize_g1_compressed*(dst: var array[48, byte], g1Point: G1P): CttCodecE
 
   return cttCodecEcc_Success
 
-func deserialize_g1_compressed_unchecked*(dst: var G1P, src: array[48, byte]): CttCodecEccStatus =
+func deserialize_g1_compressed_unchecked*(dst: var G1P, src: array[48, byte]): CttCodecEccStatus {.libPrefix: pre.} =
   ## Deserialize a BLS12-381 G1 point in compressed (Zcash) format.
   ##
   ## Warning ⚠:
@@ -182,7 +185,7 @@ func deserialize_g1_compressed_unchecked*(dst: var G1P, src: array[48, byte]): C
 
   return cttCodecEcc_Success
 
-func deserialize_g1_compressed*(dst: var G1P, src: array[48, byte]): CttCodecEccStatus =
+func deserialize_g1_compressed*(dst: var G1P, src: array[48, byte]): CttCodecEccStatus {.libPrefix: pre.} =
   ## Deserialize a BLS12-381 G1 point in compressed (Zcash) format
   ## This also validates the G1 point
   ##
@@ -198,7 +201,7 @@ func deserialize_g1_compressed*(dst: var G1P, src: array[48, byte]): CttCodecEcc
   return cttCodecEcc_Success
 
 
-func serialize_g2_compressed*(dst: var array[96, byte], g2Point: G2P): CttCodecEccStatus =
+func serialize_g2_compressed*(dst: var array[96, byte], g2Point: G2P): CttCodecEccStatus {.libPrefix: pre.} =
   ## Serialize a BLS12-381 G2 point in compressed (Zcash) format
   ##
   ## Returns cttCodecEcc_Success if successful
@@ -220,7 +223,7 @@ func serialize_g2_compressed*(dst: var array[96, byte], g2Point: G2P): CttCodecE
 
   return cttCodecEcc_Success
 
-func deserialize_g2_compressed_unchecked*(dst: var G2P, src: array[96, byte]): CttCodecEccStatus =
+func deserialize_g2_compressed_unchecked*(dst: var G2P, src: array[96, byte]): CttCodecEccStatus {.libPrefix: pre.} =
   ## Deserialize a BLS12-381 G2 point in compressed (Zcash) format.
   ##
   ## Warning ⚠:
@@ -275,7 +278,7 @@ func deserialize_g2_compressed_unchecked*(dst: var G2P, src: array[96, byte]): C
 
   return cttCodecEcc_Success
 
-func deserialize_g2_compressed*(dst: var G2P, src: array[96, byte]): CttCodecEccStatus =
+func deserialize_g2_compressed*(dst: var G2P, src: array[96, byte]): CttCodecEccStatus {.libPrefix: pre.} =
   ## Deserialize a BLS12-381 G2 point in compressed (Zcash) format
   ##
   ## Returns cttCodecEcc_Success if successful

--- a/include/constantine.h
+++ b/include/constantine.h
@@ -26,6 +26,8 @@
 #include "constantine/curves/pallas.h"
 #include "constantine/curves/vesta.h"
 
+#include "constantine/curves/bls12_381_codecs.h"
+
 #include "constantine/curves/bls12_381_parallel.h"
 #include "constantine/curves/bn254_snarks_parallel.h"
 #include "constantine/curves/pallas_parallel.h"

--- a/include/constantine/curves/bls12_381_codecs.h
+++ b/include/constantine/curves/bls12_381_codecs.h
@@ -1,0 +1,94 @@
+/** Constantine
+ *  Copyright (c) 2018-2019    Status Research & Development GmbH
+ *  Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+ *  Licensed and distributed under either of
+ *    * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+ *    * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+ *  at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+#ifndef __CTT_H_BLS12_381_CODECS__
+#define __CTT_H_BLS12_381_CODECS__
+
+#include "constantine/core/datatypes.h"
+#include "constantine/core/serialization.h"
+#include "constantine/curves/bigints.h"
+#include "constantine/curves/bls12_381.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Validate a scalar
+ *  Regarding timing attacks, this will leak information
+ *  if the scalar is 0 or larger than the curve order.
+ */
+ctt_codec_scalar_status ctt_bls12_381_validate_scalar(const big255* scalar)  __attribute__((warn_unused_result));
+
+/** Validate a G1 point
+ *  This is an expensive operation that can be cached
+ */
+ctt_codec_ecc_status ctt_bls12_381_validate_g1(const bls12_381_g1_aff* point)  __attribute__((warn_unused_result));
+
+/** Validate a G2 point
+ *  This is an expensive operation that can be cached
+ */
+ctt_codec_ecc_status ctt_bls12_381_validate_g2(const bls12_381_g2_aff* point)  __attribute__((warn_unused_result));
+
+/** Serialize a scalar
+ *  Returns cttCodecScalar_Success if successful
+ */
+ctt_codec_scalar_status ctt_bls12_381_serialize_scalar(byte dst[32], const big255* scalar) __attribute__((warn_unused_result));
+
+/** Deserialize a scalar
+ *  Also validates the scalar range
+ *
+ *  This is protected against side-channel unless the scalar is invalid.
+ *  In that case it will leak whether it's all zeros or larger than the curve order.
+ *
+ *  This special-cases (and leaks) 0 scalar as this is a special-case in most protocols
+ *  or completely invalid (for secret keys).
+ */
+ctt_codec_scalar_status ctt_bls12_381_deserialize_scalar(big255* dst, const byte src[32]) __attribute__((warn_unused_result));
+
+/** Serialize a BLS12-381 G1 point in compressed (Zcash) format
+ *
+ *  Returns cttCodecEcc_Success if successful
+ */
+ctt_codec_ecc_status ctt_bls12_381_serialize_g1_compressed(byte dst[48], const bls12_381_g1_aff* src) __attribute__((warn_unused_result));
+
+/** Deserialize a BLS12-381 G1 point in compressed (Zcash) format.
+ *
+ *  Warning ⚠:
+ *    This procedure skips the very expensive subgroup checks.
+ *    Not checking subgroup exposes a protocol to small subgroup attacks.
+ */
+ctt_codec_ecc_status ctt_bls12_381_deserialize_g1_compressed_unchecked(bls12_381_g1_aff* dst, const byte src[48]) __attribute__((warn_unused_result));
+
+/** Deserialize a BLS12-381 G1 point in compressed (Zcash) format
+ *  This also validates the G1 point
+ */
+ctt_codec_ecc_status ctt_bls12_381_deserialize_g1_compressed(bls12_381_g1_aff* dst, const byte src[48]) __attribute__((warn_unused_result));
+
+/** Serialize a BLS12-381 G2 point in compressed (Zcash) format
+ *
+ *  Returns cttCodecEcc_Success if successful
+ */
+ctt_codec_ecc_status ctt_bls12_381_serialize_g2_compressed(byte dst[96], const bls12_381_g2_aff* src) __attribute__((warn_unused_result));
+
+/** Deserialize a BLS12-381 G2 point in compressed (Zcash) format.
+ *
+ *  Warning ⚠:
+ *    This procedure skips the very expensive subgroup checks.
+ *    Not checking subgroup exposes a protocol to small subgroup attacks.
+ */
+ctt_codec_ecc_status ctt_bls12_381_deserialize_g2_compressed_unchecked(bls12_381_g2_aff* dst, const byte src[96]) __attribute__((warn_unused_result));
+
+/** Deserialize a BLS12-381 G2 point in compressed (Zcash) format
+ *  This also validates the G2 point
+ */
+ctt_codec_ecc_status ctt_bls12_381_deserialize_g2_compressed(bls12_381_g2_aff* dst, const byte src[96]) __attribute__((warn_unused_result));
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __CTT_H_BLS12_381_CODECS__


### PR DESCRIPTION
This exports the Zcash serialization for BLS12-381 scalar and curve elements.

Requested by @Armantidas for https://github.com/lynxcs/rust-kzg/commit/c7930bdc3afb3b0e3cccc9958aefbfe7e723fe1f to add a Constantine-based KZG backend to https://github.com/sifraitech/rust-kzg