### PR TITLE
make_lib_rust - use position independent code

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -228,12 +228,13 @@ proc genDynamicLib(outdir, nimcache: string) =
   else:
     compile "libconstantine.so"
 
-proc genStaticLib(outdir, nimcache: string) =
+proc genStaticLib(outdir, nimcache: string, extFlags = "") =
   proc compile(libName: string, flags = "") =
     echo &"Compiling static library:  {outdir}/" & libName
 
     exec "nim c " &
          flags &
+         extFlags &
          releaseBuildOptions(bmStaticLib) &
          " --threads:on " &
          " --noMain --app:staticlib " &
@@ -271,7 +272,8 @@ task make_lib, "Build Constantine library":
 task make_lib_rust, "Build Constantine library (use within a Rust build.rs script)":
   doAssert existsEnv"OUT_DIR", "Cargo needs to set the \"OUT_DIR\" environment variable"
   let rustOutDir = getEnv"OUT_DIR"
-  genStaticLib(rustOutDir, rustOutDir/"nimcache")
+  # Compile as position independent, since rust does the same by default 
+  genStaticLib(rustOutDir, rustOutDir/"nimcache", "--passC:-fPIC")
 
 proc testLib(path, testName: string, useGMP: bool) =
   let dynlibName = if defined(windows): "constantine.dll"

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -272,8 +272,10 @@ task make_lib, "Build Constantine library":
 task make_lib_rust, "Build Constantine library (use within a Rust build.rs script)":
   doAssert existsEnv"OUT_DIR", "Cargo needs to set the \"OUT_DIR\" environment variable"
   let rustOutDir = getEnv"OUT_DIR"
-  # Compile as position independent, since rust does the same by default 
-  genStaticLib(rustOutDir, rustOutDir/"nimcache", "--passC:-fPIC")
+  # Compile as position independent, since rust does the same by default
+  let extflags = if defined(windows): "" # Windows is fully position independent, flag is a no-op or on error depending on compiler.
+                 else: "--passC:-fPIC"
+  genStaticLib(rustOutDir, rustOutDir/"nimcache", extflags)
 
 proc testLib(path, testName: string, useGMP: bool) =
   let dynlibName = if defined(windows): "constantine.dll"


### PR DESCRIPTION
added -fPIC when using make_lib_rust, since [rust already does that by default.](https://github.com/rust-lang/rust/pull/16340)

This change is required by [rust-kzg constantine backend](https://github.com/sifraitech/rust-kzg/pull/251) to make c-kzg-4844 bindings work.

@mratsim if enabling for all rust builds is not acceptable, I can also add as optional feature in Cargo.toml & change how it's passed in build.rs

I am not familiar with Nim so if there's a better/more preferred way of doing this lmk, will be happy to fix.