### PR TITLE
Add Uncompressed Serde

### DIFF
--- a/benchmarks/bench_verkle_primitives.nim
+++ b/benchmarks/bench_verkle_primitives.nim
@@ -140,6 +140,35 @@ proc deserializeBenchUnchecked_vartime*(T: typedesc, iters: int) =
   bench("Banderwagon Deserialization Unchecked Vartime (Precomp)", T, iters):
     discard P.deserialize_unchecked_vartime(bytes)
 
+proc serializeUncompressedBench*(T: typedesc, iters: int) =
+  var bytes: array[64, byte]
+  var P: Prj
+  P.fromAffine(Banderwagon.getGenerator())
+  for i in 0 ..< 6:
+    P.double()
+  bench("Banderwagon Serialization Uncompressed", T, iters):
+    discard bytes.serializeUncompressed(P)
+
+proc deserializeUncompressedBench*(T: typedesc, iters: int) =
+  var bytes: array[64, byte]
+  var P: Prj
+  P.fromAffine(Banderwagon.getGenerator())
+  for i in 0 ..< 6:
+    P.double()
+  discard bytes.serializeUncompressed(P)
+  bench("Banderwagon Deserialization Uncompressed", T, iters):
+    discard P.deserializeUncompressed(bytes)
+
+proc deserializeUncompressedBenchUnchecked*(T: typedesc, iters: int) =
+  var bytes: array[64, byte]
+  var P: Prj
+  P.fromAffine(Banderwagon.getGenerator())
+  for i in 0 ..< 6:
+    P.double()
+  discard bytes.serializeUncompressed(P)
+  bench("Banderwagon Deserialization Uncompressed Unchecked", T, iters):
+    discard P.deserializeUncompressed_unchecked(bytes)
+
 
 proc main() =
   equalityBench(Prj, Iters)
@@ -150,6 +179,10 @@ proc main() =
   separator()
   deserializeBench_vartime(Prj, Iters)
   deserializeBenchUnchecked_vartime(Prj, Iters)
+  separator()
+  serializeUncompressedBench(Prj, Iters)
+  deserializeUncompressedBench(Prj, Iters)
+  deserializeUncompressedBenchUnchecked(Prj, Iters)
 
 main()
 notes()

--- a/constantine/serialization/codecs_banderwagon.nim
+++ b/constantine/serialization/codecs_banderwagon.nim
@@ -315,7 +315,7 @@ func serializeUncompressed*(dst: var array[64, byte], P: EC_Prj): CttCodecEccSta
 
 func deserializeUncompressed_unchecked*(dst: var EC_Prj, src: array[64, byte]): CttCodecEccStatus =
   ## Deserialize a Banderwagon point (x, y) in format
-  ## 
+  ## Doesn't check if the point is in the banderwagon scheme subgroup
   ## Returns cttCodecEcc_Success if successful
   var xSerialized: array[32, byte]
   var ySerialized: array[32, byte]

--- a/constantine/serialization/codecs_banderwagon.nim
+++ b/constantine/serialization/codecs_banderwagon.nim
@@ -285,3 +285,66 @@ func serializeBatch*[N: static int](
         dst: var array[N, array[32, byte]],
         points: array[N, EC_Prj]): CttCodecEccStatus {.inline.} =
   return serializeBatch(dst.asUnchecked(), points.asUnchecked(), N)
+
+
+## ############################################################
+##
+##       Banderwagon Point Uncompressed Serialization
+##
+## ############################################################
+
+func serializeUncompressed*(dst: var array[64, byte], P: EC_Prj): CttCodecEccStatus =
+  ## Serialize a Banderwagon point(x, y) in the format
+  ## 
+  ## serialize = [ bigEndian( x ) , bigEndian( y ) ]
+  ## 
+  ## Returns cttCodecEcc_Success if successful
+  var aff {.noInit.}: EC_Aff
+  aff.affine(P)
+
+  var xSerialized: array[32, byte]
+  xSerialized.marshal(aff.x, bigEndian)
+  var ySerialized: array[32, byte]
+  ySerialized.marshal(aff.y, bigEndian)
+
+  for i in 0 ..< 32:
+    dst[i] = xSerialized[i]
+    dst[i + 32] = ySerialized[i]
+
+  return cttCodecEcc_Success
+
+func deserializeUncompressed_unchecked*(dst: var EC_Prj, src: array[64, byte]): CttCodecEccStatus =
+  ## Deserialize a Banderwagon point (x, y) in format
+  ## 
+  ## Returns cttCodecEcc_Success if successful
+  var xSerialized: array[32, byte]
+  var ySerialized: array[32, byte]
+
+  for i in 0 ..< 32:
+    xSerialized[i] = src[i]
+    ySerialized[i] = src[i + 32]
+
+  var t{.noInit.}: matchingBigInt(Banderwagon)
+  t.unmarshal(xSerialized, bigEndian)
+
+  if bool(t >= Banderwagon.Mod()):
+    return cttCodecEcc_CoordinateGreaterThanOrEqualModulus
+
+  dst.x.fromBig(t)
+
+  t.unmarshal(ySerialized, bigEndian)
+  if bool(t >= Banderwagon.Mod()):
+    return cttCodecEcc_CoordinateGreaterThanOrEqualModulus
+
+  dst.y.fromBig(t)
+  return cttCodecEcc_Success
+
+func deserializeUncompressed*(dst: var EC_Prj, src: array[64, byte]): CttCodecEccStatus =
+  ## Deserialize a Banderwagon point (x, y) in format
+  ## 
+  ## Also checks if the point lies in the banderwagon scheme subgroup
+  ## 
+  ## Returns cttCodecEcc_Success if successful
+  result = dst.deserializeUncompressed_unchecked(src)
+  if not(bool dst.isInSubgroup()):
+    return cttCodecEcc_PointNotInSubgroup

--- a/tests/t_ethereum_verkle_primitives.nim
+++ b/tests/t_ethereum_verkle_primitives.nim
@@ -267,6 +267,23 @@ suite "Banderwagon Serialization Tests":
     
     testWrongLength()
 
+  ## Tests for Uncompressed point serialization
+  test "Uncompressed Point Serialization":
+    proc testUncompressedSerialization() =
+      var point, point_regen {.noInit.}: EC
+      point.fromAffine(generator)
+
+      var arr: array[64, byte]
+      let stat = arr.serializeUncompressed(point)
+
+      doAssert stat == cttCodecEcc_Success, "Uncompressed Serialization Failed"
+      
+      let stat2 = point_regen.deserializeUncompressed(arr)
+      doAssert stat2 == cttCodecEcc_Success, "Uncompressed Deserialization Failed"
+      doAssert (point == point_regen).bool(), "Uncompressed SerDe Inconsistent"
+
+    testUncompressedSerialization()
+
 
 # ############################################################
 #


### PR DESCRIPTION
Fixes #317 

Adds the uncompressed point serialisation and deserialisation, which would be further needed in nim-eth-verkle for VerkleNode serialization