### PR TITLE
BatchSerialization for Uncompressed Points

### DIFF
--- a/constantine/serialization/codecs_banderwagon.nim
+++ b/constantine/serialization/codecs_banderwagon.nim
@@ -281,16 +281,16 @@ func serializeBatch*(
 
   return cttCodecEcc_Success
 
-## Batch Serialization of Banderwagon Points
-## In uncompressed format
-## serialize = [ bigEndian( x ) , bigEndian( y ) ]
-## Returns cttCodecEcc_Success if successful
 func serializeBatchUncompressed*(
     dst: ptr UncheckedArray[array[64, byte]],
     points: ptr UncheckedArray[EC_Prj],
     N: int,
   ) : CttCodecEccStatus {.noInline.} =
-
+  ## Batch Serialization of Banderwagon Points
+  ## In uncompressed format
+  ## serialize = [ bigEndian( x ) , bigEndian( y ) ]
+  ## Returns cttCodecEcc_Success if successful
+  
   # collect all the z coordinates
   var zs = allocStackArray(Fp[Banderwagon], N)
   var zs_inv = allocStackArray(Fp[Banderwagon], N)

--- a/tests/t_ethereum_verkle_primitives.nim
+++ b/tests/t_ethereum_verkle_primitives.nim
@@ -514,3 +514,26 @@ suite "Batch Operations on Banderwagon":
         doAssert expected_bit_strings[i] == arr[i].toHex(), "bit string does not match expected"
 
     testBatchSerialize(expected_bit_strings.len)
+
+  ## Check batch Uncompressed encoding
+  test "Batch Uncompressed Point Serialization":
+    proc testBatchUncompressedSerialization() =
+      var points: array[10, EC]
+      var point, point_regen {.noInit.}: EC
+      point.fromAffine(generator)
+
+      for i in 0 ..< 10:
+        points[i] = point
+        point.double()
+
+      var arr: array[10, array[64, byte]]
+      let stat = arr.serializeBatchUncompressed(points)
+
+      doAssert stat == cttCodecEcc_Success, "Uncompressed Serialization Failed"
+      
+      for i in 0 ..< 10:
+        let stat2 = point_regen.deserializeUncompressed(arr[i])
+        doAssert stat2 == cttCodecEcc_Success, "Uncompressed Deserialization Failed"
+        doAssert (points[i] == point_regen).bool(), "Uncompressed SerDe Inconsistent"
+
+    testBatchUncompressedSerialization()


### PR DESCRIPTION
Adds BatchSerialisation in Uncompressed format.
Needed for LeafNode serialisation in `nim-eth-verkle`