### PR TITLE
CI: Github MacOS now uses ARM64. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
             BACKEND: ASM
 
           - os: macos
-            cpu: amd64
+            cpu: arm64
             TEST_LANG: c
             BACKEND: NO_ASM
           - os: macos
-            cpu: amd64
+            cpu: arm64
             TEST_LANG: c
             BACKEND: ASM
         include:


### PR DESCRIPTION
See #372

Github runners now use ARM64 instead of x86 for MacOS.

Constantine failed to compile for inline assembly when the target CPU architecture is not explicit.

This suggests that the wrong architecture (x86) was used for compiling on ARM64.

Looking at `nim -v`, Nim x86 was installed and used, probably transparently through Rosetta. And the x86 check at https://github.com/mratsim/constantine/blob/976c8bb215a3f0b21ce3d05f894eb506072a6285/constantine/platforms/config.nim#L12-L13
use the "native" compiler config.

Hence this only affects the CI, and this should be fixable with just a change to arm64.