### PR TITLE
EVM precompiles - SHA256 and BN254

### DIFF
--- a/benchmarks/bench_eth_evm_precompiles.nim
+++ b/benchmarks/bench_eth_evm_precompiles.nim
@@ -23,7 +23,7 @@ import
 # For EIP-2537, we use the worst case vectors:
 #   https://eips.ethereum.org/assets/eip-2537/bench_vectors
 
-proc separator*() = separator(116)
+proc separator() = separator(116)
 
 proc report(op: string, gas: int, startTime, stopTime: MonoTime, startClk, stopClk: int64, iters: int) =
   let ns = inNanoseconds((stopTime-startTime) div iters)
@@ -39,17 +39,28 @@ template bench(op: string, gas: int, iters: int, body: untyped): untyped =
   measure(iters, startTime, stopTime, startClk, stopClk, body)
   report(op, gas, startTime, stopTime, startClk, stopClk, iters)
 
+# Gas schedule
+# -----------------------------------------------------------------------------------------------------
+
 const gasSchedule = {
+  # EIP-196 and 197, gas cost from EIP-1108
+  "BN254_G1ADD":           150,
+  "BN254_G1MUL":          6000,
+  "BN254_PAIRINGCHECK":     -1,
+  # EIP 2537
   "BLS12_G1ADD":           500,
   "BLS12_G1MUL":         12000,
   "BLS12_G1MSM":            -1,
   "BLS12_G2ADD":           800,
   "BLS12_G2MUL":         45000,
   "BLS12_G2MSM":            -1,
-  "BLS12_PAIRING":          -1,
+  "BLS12_PAIRINGCHECK":     -1,
   "BLS12_MAP_FP_TO_G1":   5500,
   "BLS12_MAP_FP2_TO_G2": 75000,
 }.toTable()
+
+func gasBN254PairingCheck(length: int): int =
+  return 34000*length + 45000
 
 func gasBls12Msm(length: int, baseCost: int): int =
   const discount: array[1..128, int] = [1200, 888, 764, 641, 594, 547, 500, 453, 438, 423, 408, 394, 379, 364, 349, 334, 330, 326, 322, 318, 314, 310, 306, 302, 298, 294, 289, 285, 281, 277, 273, 269, 268, 266, 265, 263, 262, 260, 259, 257, 256, 254, 253, 251, 250, 248, 247, 245, 244, 242, 241, 239, 238, 236, 235, 233, 232, 231, 229, 228, 226, 225, 223, 222, 221, 220, 219, 219, 218, 217, 216, 216, 215, 214, 213, 213, 212, 211, 211, 210, 209, 208, 208, 207, 206, 205, 205, 204, 203, 202, 202, 201, 200, 199, 199, 198, 197, 196, 196, 195, 194, 193, 193, 192, 191, 191, 190, 189, 188, 188, 187, 186, 185, 185, 184, 183, 182, 182, 181, 180, 179, 179, 178, 177, 176, 176, 175, 174]
@@ -59,7 +70,98 @@ func gasBls12Msm(length: int, baseCost: int): int =
 func gasBls12PairingCheck(length: int): int =
   return 43000*length + 65000
 
-proc benchBls12G1Add*(iters: int) =
+# Constructors
+# -----------------------------------------------------------------------------------------------------
+
+func clearCofactor[F; G: static Subgroup](ec: var ECP_ShortW_Aff[F, G]) =
+  # For now we don't have any affine operation defined
+  var t {.noInit.}: ECP_ShortW_Prj[F, G]
+  t.fromAffine(ec)
+  t.clearCofactor()
+  ec.affine(t)
+
+proc createPairingInputsBN254(length: int): seq[byte] =
+  var buf: array[32, byte]
+  const C = BN254_Snarks
+  for _ in 0 ..< length:
+    var P = rng.random_unsafe(ECP_ShortW_Aff[Fp[C], G1])
+    P.clearCofactor()
+    var Q = rng.random_unsafe(ECP_ShortW_Aff[Fp2[C], G2])
+    Q.clearCofactor()
+
+    buf.marshal(P.x, bigEndian)
+    result.add buf
+    buf.marshal(P.y, bigEndian)
+    result.add buf
+
+    # Coordinates are serialized in a swapped order
+
+    buf.marshal(Q.x.c1, bigEndian)
+    result.add buf
+    buf.marshal(Q.x.c0, bigEndian)
+    result.add buf
+
+    buf.marshal(Q.y.c1, bigEndian)
+    result.add buf
+    buf.marshal(Q.y.c0, bigEndian)
+    result.add buf
+
+
+proc createPairingInputsBLS12381(length: int): seq[byte] =
+  var buf: array[64, byte]
+  const C = BLS12_381
+  for _ in 0 ..< length:
+    var P = rng.random_unsafe(ECP_ShortW_Aff[Fp[C], G1])
+    P.clearCofactor()
+    var Q = rng.random_unsafe(ECP_ShortW_Aff[Fp2[C], G2])
+    Q.clearCofactor()
+
+    buf.marshal(P.x, bigEndian)
+    result.add buf
+    buf.marshal(P.y, bigEndian)
+    result.add buf
+
+    buf.marshal(Q.x.c0, bigEndian)
+    result.add buf
+    buf.marshal(Q.x.c1, bigEndian)
+    result.add buf
+    buf.marshal(Q.y.c0, bigEndian)
+    result.add buf
+    buf.marshal(Q.y.c1, bigEndian)
+    result.add buf
+
+# EIP-196 & EIP-197
+# -----------------------------------------------------------------------------------------------------
+
+proc benchBN254G1Add(iters: int) =
+  var inputs = newSeq[byte](128)
+  var output = newSeq[byte](64)
+  inputs.fromHex("18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f3726607c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7")
+
+  let opName = "BN254_G1ADD"
+  bench(opName, gasSchedule[opName], iters):
+    discard output.eth_evm_bn254_g1add(inputs)
+
+proc benchBN254G1Mul(iters: int) =
+  var inputs = newSeq[byte](96)
+  var output = newSeq[byte](64)
+  inputs.fromHex("070a8d6a982153cae4be29d434e8faef8a47b274a053f5a4ee2a6c9c13c31e5c031b8ce914eba3a9ffb989f9cdd5b0f01943074bf4f0f315690ec3cec6981afc30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46")
+
+  let opName = "BN254_G1MUL"
+  bench(opName, gasSchedule[opName], iters):
+    discard output.eth_evm_bn254_g1mul(inputs)
+
+proc benchBN254PairingCheck(pairingCtx: seq[byte], size, iters: int) =
+  var inputs = @(pairingCtx.toOpenArray(0, 192*size-1))
+  var output = newSeq[byte](32)
+
+  bench(&"BN254_PAIRINGCHECK {size:>3}", gasBN254PairingCheck(size), iters):
+    discard output.eth_evm_bn254_ecpairingcheck(inputs)
+
+# EIP-2537
+# -----------------------------------------------------------------------------------------------------
+
+proc benchBls12G1Add(iters: int) =
   var inputs = newSeq[byte](256)
   var output = newSeq[byte](128)
   inputs.fromHex("0x0000000000000000000000000000000012196c5a43d69224d8713389285f26b98f86ee910ab3dd668e413738282003cc5b7357af9a7af54bb713d62255e80f560000000000000000000000000000000006ba8102bfbeea4416b710c73e8cce3032c31c6269c44906f8ac4f7874ce99fb17559992486528963884ce429a992fee000000000000000000000000000000000001101098f5c39893765766af4512a0c74e1bb89bc7e6fdf14e3e7337d257cc0f94658179d83320b99f31ff94cd2bac0000000000000000000000000000000003e1a9f9f44ca2cdab4f43a1a3ee3470fdf90b2fc228eb3b709fcd72f014838ac82a6d797aeefed9a0804b22ed1ce8f7")
@@ -68,7 +170,7 @@ proc benchBls12G1Add*(iters: int) =
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_g1add(inputs)
 
-proc benchBls12G2Add*(iters: int) =
+proc benchBls12G2Add(iters: int) =
   var inputs = newSeq[byte](512)
   var output = newSeq[byte](256)
   inputs.fromHex("0x0000000000000000000000000000000018c0ada6351b70661f053365deae56910798bd2ace6e2bf6ba4192d1a229967f6af6ca1c9a8a11ebc0a232344ee0f6d6000000000000000000000000000000000cc70a587f4652039d8117b6103858adcd9728f6aebe230578389a62da0042b7623b1c0436734f463cfdd187d20903240000000000000000000000000000000009f50bd7beedb23328818f9ffdafdb6da6a4dd80c5a9048ab8b154df3cad938ccede829f1156f769d9e149791e8e0cd900000000000000000000000000000000079ba50d2511631b20b6d6f3841e616e9d11b68ec3368cd60129d9d4787ab56c4e9145a38927e51c9cd6271d493d938800000000000000000000000000000000192fa5d8732ff9f38e0b1cf12eadfd2608f0c7a39aced7746837833ae253bb57ef9c0d98a4b69eeb2950901917e99d1e0000000000000000000000000000000009aeb10c372b5ef1010675c6a4762fda33636489c23b581c75220589afbc0cc46249f921eea02dd1b761e036ffdbae220000000000000000000000000000000002d225447600d49f932b9dd3ca1e6959697aa603e74d8666681a2dca8160c3857668ae074440366619eb8920256c4e4a00000000000000000000000000000000174882cdd3551e0ce6178861ff83e195fecbcffd53a67b6f10b4431e423e28a480327febe70276036f60bb9c99cf7633")
@@ -77,7 +179,7 @@ proc benchBls12G2Add*(iters: int) =
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_g2add(inputs)
 
-proc benchBls12G1Mul*(iters: int) =
+proc benchBls12G1Mul(iters: int) =
   var inputs = newSeq[byte](160)
   var output = newSeq[byte](128)
   # G1 Mul worst-case
@@ -87,7 +189,7 @@ proc benchBls12G1Mul*(iters: int) =
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_g1mul(inputs)
 
-proc benchBls12G2Mul*(iters: int) =
+proc benchBls12G2Mul(iters: int) =
   var inputs = newSeq[byte](288)
   var output = newSeq[byte](256)
   # G2 Mul worst-case
@@ -97,7 +199,7 @@ proc benchBls12G2Mul*(iters: int) =
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_g2mul(inputs)
 
-proc benchBls12MapToG1*(iters: int) =
+proc benchBls12MapToG1(iters: int) =
   var inputs = newSeq[byte](64)
   var output = newSeq[byte](128)
   # G1 Mul worst-case
@@ -107,7 +209,7 @@ proc benchBls12MapToG1*(iters: int) =
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_map_fp_to_g1(inputs)
 
-proc benchBls12MapToG2*(iters: int) =
+proc benchBls12MapToG2(iters: int) =
   var inputs = newSeq[byte](128)
   var output = newSeq[byte](256)
   # G2 Mul worst-case
@@ -116,35 +218,6 @@ proc benchBls12MapToG2*(iters: int) =
   let opName = "BLS12_MAP_FP2_TO_G2"
   bench(opName, gasSchedule[opName], iters):
     discard output.eth_evm_bls12381_map_fp2_to_g2(inputs)
-
-func clearCofactor[F; G: static Subgroup](ec: var ECP_ShortW_Aff[F, G]) =
-  # For now we don't have any affine operation defined
-  var t {.noInit.}: ECP_ShortW_Prj[F, G]
-  t.fromAffine(ec)
-  t.clearCofactor()
-  ec.affine(t)
-
-proc createPairingInputs(length: int): seq[byte] =
-  var buf64: array[64, byte]
-  for _ in 0 ..< length:
-    var P = rng.random_unsafe(ECP_ShortW_Aff[Fp[BLS12_381], G1])
-    P.clearCofactor()
-    var Q = rng.random_unsafe(ECP_ShortW_Aff[Fp2[BLS12_381], G2])
-    Q.clearCofactor()
-
-    buf64.marshal(P.x, bigEndian)
-    result.add buf64
-    buf64.marshal(P.y, bigEndian)
-    result.add buf64
-
-    buf64.marshal(Q.x.c0, bigEndian)
-    result.add buf64
-    buf64.marshal(Q.x.c1, bigEndian)
-    result.add buf64
-    buf64.marshal(Q.y.c0, bigEndian)
-    result.add buf64
-    buf64.marshal(Q.y.c1, bigEndian)
-    result.add buf64
 
 proc benchBls12PairingCheck(pairingCtx: seq[byte], size, iters: int) =
   var inputs = @(pairingCtx.toOpenArray(0, 384*size-1))
@@ -181,14 +254,14 @@ proc createMsmInputs(EC: typedesc, length: int): seq[byte] =
     buf32.marshal(k, bigEndian)
     result.add buf32
 
-proc benchBls12MsmG1*(msmCtx: seq[byte], size, iters: int) =
+proc benchBls12MsmG1(msmCtx: seq[byte], size, iters: int) =
   var inputs = @(msmCtx.toOpenArray(0, 160*size-1))
   var output = newSeq[byte](128)
 
   bench(&"BLS12_G1MSM {size:>3}", gasBls12Msm(size, gasSchedule["BLS12_G1MUL"]), iters):
     discard output.eth_evm_bls12381_g1msm(inputs)
 
-proc benchBls12MsmG2*(msmCtx: seq[byte], size, iters: int) =
+proc benchBls12MsmG2(msmCtx: seq[byte], size, iters: int) =
   var inputs = @(msmCtx.toOpenArray(0, 288*size-1))
   var output = newSeq[byte](256)
 
@@ -200,6 +273,13 @@ const ItersPairing =    10
 const ItersMsm     =    10
 proc main() =
   separator()
+  benchBn254G1Add(Iters)
+  benchBn254G1Mul(Iters)
+  separator()
+  let pairingCtxBN = createPairingInputsBN254(8)
+  for i in 1..8:
+    pairingCtxBN.benchBn254PairingCheck(i, ItersPairing)
+  separator()
   benchBls12G1Add(Iters)
   benchBls12G2Add(Iters)
   benchBls12G1Mul(Iters)
@@ -207,9 +287,9 @@ proc main() =
   benchBls12MapToG1(Iters)
   benchBls12MapToG2(Iters)
   separator()
-  let pairingCtx = createPairingInputs(8)
+  let pairingCtxBLS = createPairingInputsBLS12381(8)
   for i in 1..8:
-    pairingCtx.benchBls12PairingCheck(i, ItersPairing)
+    pairingCtxBLS.benchBls12PairingCheck(i, ItersPairing)
   separator()
   let msmG1Ctx = createMsmInputs(ECP_ShortW_Jac[Fp[BLS12_381], G1], 128)
   msmG1Ctx.benchBls12MsmG1(  2, ItersMsm)

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -7,6 +7,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
+  ./hashes,
   ./platforms/abstractions,
   ./serialization/io_limbs,
   ./math/config/curves,
@@ -37,6 +38,24 @@ type
     cttEVM_IntLargerThanModulus
     cttEVM_PointNotOnCurve
     cttEVM_PointNotInSubgroup
+
+func eth_evm_sha256*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.meter.} =
+  ## SHA256
+  ##
+  ## Inputs:
+  ## - Message to hash
+  ##
+  ## Output:
+  ## - 32-byte digest
+  ## - status code:
+  ##   cttEVM_Success
+  ##   cttEVM_InvalidOutputSize
+
+  if r.len != 32:
+    return cttEVM_InvalidOutputSize
+
+  sha256.hash(cast[ptr array[32, byte]](r[0].addr)[], inputs)
+  return cttEVM_Success
 
 func eth_evm_modexp*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.noInline, tags:[Alloca, Vartime], meter.} =
   ## Modular exponentiation

--- a/tests/t_ethereum_evm_precompiles.nim
+++ b/tests/t_ethereum_evm_precompiles.nim
@@ -68,6 +68,37 @@ template runPrecompileTests(filename: string, funcname: untyped) =
 
     `PrecompileTestrunner _ funcname`()
 
+proc testSha256() =
+  # https://github.com/ethereum/go-ethereum/blob/v1.14.0/core/vm/contracts_test.go#L206-L214
+  let input = "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e000000000000000000000000000000000000000000000000000000000000001b38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02"
+  let expected = "811c7003375852fabd0d362e40e68607a12bdabae61a7d068fe5fdd1dbbf2a5d"
+
+  echo "Running SHA256 tests"
+  stdout.write "    Testing SHA256 ... "
+
+  var inputbytes = newSeq[byte](input.len div 2)
+  inputbytes.fromHex(input)
+
+  var expectedbytes = newSeq[byte](expected.len div 2)
+  expectedbytes.fromHex(expected)
+
+  var r = newSeq[byte](expected.len div 2)
+
+  let status = eth_evm_sha256(r, inputbytes)
+  if status != cttEVM_Success:
+    reset(r)
+
+  doAssert r == expectedbytes, "[Test Failure]\n" &
+    "  eth_evm_sha256 status: " & $status & "\n" &
+    "  " & "result:   " & r.toHex() & "\n" &
+    "  " & "expected: " & expectedbytes.toHex() & '\n'
+
+  stdout.write "Success\n"
+
+# ----------------------------------------------------------------------
+
+testSha256()
+
 runPrecompileTests("modexp.json", eth_evm_modexp)
 runPrecompileTests("modexp_eip2565.json", eth_evm_modexp)
 


### PR DESCRIPTION
This adds a benchmark for BN254 precompiles and support for SHA256 precompile.

Bench on Ryzen 7840U

```
CC=clang nimble bench_eth_evm_precompiles
```

![image](https://github.com/mratsim/constantine/assets/22738317/5f16d09d-d71c-4029-b033-3a97b84f45aa)


```
--------------------------------------------------------------------------------------------------------------------------------
SHA256 -  32 bytes            72 gas    2117.65 MGas/s    29411764.706 ops/s           34 ns/op          114 CPU cycles (approx)
SHA256 -  64 bytes            84 gas    1714.29 MGas/s    20408163.265 ops/s           49 ns/op          161 CPU cycles (approx)
SHA256 -  96 bytes            96 gas    1959.18 MGas/s    20408163.265 ops/s           49 ns/op          163 CPU cycles (approx)
SHA256 - 128 bytes           108 gas    1459.46 MGas/s    13513513.514 ops/s           74 ns/op          245 CPU cycles (approx)
SHA256 - 160 bytes           120 gas    1600.00 MGas/s    13333333.333 ops/s           75 ns/op          247 CPU cycles (approx)
SHA256 - 192 bytes           132 gas    1333.33 MGas/s    10101010.101 ops/s           99 ns/op          326 CPU cycles (approx)
SHA256 - 224 bytes           144 gas    1425.74 MGas/s     9900990.099 ops/s          101 ns/op          333 CPU cycles (approx)
SHA256 - 256 bytes           156 gas    1200.00 MGas/s     7692307.692 ops/s          130 ns/op          429 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BN254_G1ADD                  150 gas      92.88 MGas/s      619195.046 ops/s         1615 ns/op         5321 CPU cycles (approx)
BN254_G1MUL                 6000 gas     234.48 MGas/s       39079.292 ops/s        25589 ns/op        84284 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BN254_PAIRINGCHECK 1       79000 gas     202.61 MGas/s        2564.648 ops/s       389917 ns/op      1284241 CPU cycles (approx)
BN254_PAIRINGCHECK 2      113000 gas     205.44 MGas/s        1818.066 ops/s       550035 ns/op      1811617 CPU cycles (approx)
BN254_PAIRINGCHECK 3      147000 gas     205.72 MGas/s        1399.443 ops/s       714570 ns/op      2353553 CPU cycles (approx)
BN254_PAIRINGCHECK 4      181000 gas     207.10 MGas/s        1144.199 ops/s       873974 ns/op      2878570 CPU cycles (approx)
BN254_PAIRINGCHECK 5      215000 gas     205.83 MGas/s         957.353 ops/s      1044547 ns/op      3440385 CPU cycles (approx)
BN254_PAIRINGCHECK 6      249000 gas     208.77 MGas/s         838.437 ops/s      1192696 ns/op      3928333 CPU cycles (approx)
BN254_PAIRINGCHECK 7      283000 gas     183.55 MGas/s         648.591 ops/s      1541804 ns/op      5078185 CPU cycles (approx)
BN254_PAIRINGCHECK 8      317000 gas     205.62 MGas/s         648.647 ops/s      1541670 ns/op      5077739 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BLS12_G1ADD                  500 gas     172.06 MGas/s      344115.623 ops/s         2906 ns/op         9572 CPU cycles (approx)
BLS12_G2ADD                  800 gas     203.30 MGas/s      254129.606 ops/s         3935 ns/op        12960 CPU cycles (approx)
BLS12_G1MUL                12000 gas     146.57 MGas/s       12214.486 ops/s        81870 ns/op       269654 CPU cycles (approx)
BLS12_G2MUL                45000 gas     349.88 MGas/s        7775.022 ops/s       128617 ns/op       423623 CPU cycles (approx)
BLS12_MAP_FP_TO_G1          5500 gas     162.56 MGas/s       29556.068 ops/s        33834 ns/op       111439 CPU cycles (approx)
BLS12_MAP_FP2_TO_G2        75000 gas     702.31 MGas/s        9364.173 ops/s       106790 ns/op       351733 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BLS12_PAIRINGCHECK 1      108000 gas     234.83 MGas/s        2174.390 ops/s       459899 ns/op      1514739 CPU cycles (approx)
BLS12_PAIRINGCHECK 2      151000 gas     242.23 MGas/s        1604.145 ops/s       623385 ns/op      2053210 CPU cycles (approx)
BLS12_PAIRINGCHECK 3      194000 gas     242.44 MGas/s        1249.711 ops/s       800185 ns/op      2635535 CPU cycles (approx)
BLS12_PAIRINGCHECK 4      237000 gas     243.68 MGas/s        1028.169 ops/s       972603 ns/op      3203422 CPU cycles (approx)
BLS12_PAIRINGCHECK 5      280000 gas     243.03 MGas/s         867.957 ops/s      1152131 ns/op      3794722 CPU cycles (approx)
BLS12_PAIRINGCHECK 6      323000 gas     203.64 MGas/s         630.460 ops/s      1586144 ns/op      5224160 CPU cycles (approx)
BLS12_PAIRINGCHECK 7      366000 gas     223.21 MGas/s         609.866 ops/s      1639704 ns/op      5400588 CPU cycles (approx)
BLS12_PAIRINGCHECK 8      409000 gas     223.22 MGas/s         545.768 ops/s      1832279 ns/op      6034865 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BLS12_G1MSM   2            21312 gas     120.53 MGas/s        5655.469 ops/s       176820 ns/op       582377 CPU cycles (approx)
BLS12_G1MSM   4            30768 gas     101.18 MGas/s        3288.392 ops/s       304100 ns/op      1001592 CPU cycles (approx)
BLS12_G1MSM   8            43488 gas      82.00 MGas/s        1885.558 ops/s       530347 ns/op      1746772 CPU cycles (approx)
BLS12_G1MSM  16            64128 gas      67.17 MGas/s        1047.452 ops/s       954698 ns/op      3144454 CPU cycles (approx)
BLS12_G1MSM  32           103296 gas      58.75 MGas/s         568.737 ops/s      1758282 ns/op      5791189 CPU cycles (approx)
BLS12_G1MSM  64           170496 gas      51.16 MGas/s         300.083 ops/s      3332407 ns/op     10975839 CPU cycles (approx)
BLS12_G1MSM 128           267264 gas      42.32 MGas/s         158.335 ops/s      6315731 ns/op     20801919 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
BLS12_G2MSM   2            79920 gas     273.26 MGas/s        3419.224 ops/s       292464 ns/op       963266 CPU cycles (approx)
BLS12_G2MSM   4           115380 gas     166.78 MGas/s        1445.473 ops/s       691815 ns/op      2278600 CPU cycles (approx)
BLS12_G2MSM   8           163080 gas     176.59 MGas/s        1082.859 ops/s       923481 ns/op      3041633 CPU cycles (approx)
BLS12_G2MSM  16           240480 gas     151.50 MGas/s         630.007 ops/s      1587285 ns/op      5227985 CPU cycles (approx)
BLS12_G2MSM  32           387360 gas     137.60 MGas/s         355.231 ops/s      2815073 ns/op      9271911 CPU cycles (approx)
BLS12_G2MSM  64           639360 gas     118.29 MGas/s         185.020 ops/s      5404829 ns/op     17801714 CPU cycles (approx)
BLS12_G2MSM 128          1002240 gas     102.00 MGas/s         101.775 ops/s      9825581 ns/op     32362139 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
```