### PR TITLE
update dependency for halo2 MsmAccel trait

### DIFF
--- a/constantine-rust/constantine-halo2-zal/Cargo.toml
+++ b/constantine-rust/constantine-halo2-zal/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/mratsim/constantine"
 constantine-sys = { path = "../constantine-sys" }
 constantine-core = { path = "../constantine-core" }
 halo2_middleware = { git = 'https://github.com/privacy-scaling-explorations/halo2' }
-halo2curves = { version = "0.6.1", default-features = false }
 
 [dev-dependencies]
 ark-std = "0.3"

--- a/constantine-rust/constantine-halo2-zal/Cargo.toml
+++ b/constantine-rust/constantine-halo2-zal/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/mratsim/constantine"
 [dependencies]
 constantine-sys = { path = "../constantine-sys" }
 constantine-core = { path = "../constantine-core" }
-halo2curves = { git = 'https://github.com/taikoxyz/halo2curves', branch = "pr-pse-exec-engine" }
+halo2_middleware = { git = 'https://github.com/privacy-scaling-explorations/halo2' }
+halo2curves = { version = "0.6.1", default-features = false }
 
 [dev-dependencies]
 ark-std = "0.3"
@@ -22,7 +23,7 @@ rand_xorshift = "0.3"
 rayon = "1.8"
 
 # In CI "asm" needs to be disabled as some agents don't support ADX.
-halo2curves = { git = 'https://github.com/taikoxyz/halo2curves', branch = "pr-pse-exec-engine" }
+# halo2curves = { git = 'https://github.com/taikoxyz/halo2curves', branch = "pr-pse-exec-engine" }
 
 [[bench]]
 name = "msm"

--- a/constantine-rust/constantine-halo2-zal/src/lib.rs
+++ b/constantine-rust/constantine-halo2-zal/src/lib.rs
@@ -16,7 +16,7 @@ use ::core::mem::MaybeUninit;
 use std::mem;
 
 use halo2curves::bn256;
-use halo2curves::zal::MsmAccel;
+use halo2_middleware::zal::traits::MsmAccel;
 use halo2curves::CurveAffine;
 
 #[derive(Debug)]

--- a/constantine-rust/constantine-halo2-zal/src/lib.rs
+++ b/constantine-rust/constantine-halo2-zal/src/lib.rs
@@ -15,9 +15,9 @@ use constantine_sys::*;
 use ::core::mem::MaybeUninit;
 use std::mem;
 
-use halo2curves::bn256;
+use halo2_middleware::halo2curves::bn256;
 use halo2_middleware::zal::traits::MsmAccel;
-use halo2curves::CurveAffine;
+use halo2_middleware::halo2curves::CurveAffine;
 
 #[derive(Debug)]
 pub struct CttEngine(Threadpool);

--- a/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
+++ b/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
@@ -17,7 +17,7 @@ use halo2curves::ff::Field;
 use halo2curves::group::prime::PrimeCurveAffine;
 use halo2curves::group::{Curve, Group};
 use halo2curves::msm::best_multiexp;
-use halo2curves::zal::MsmAccel;
+use halo2_middleware::zal::traits::MsmAccel;
 
 #[test]
 fn t_threadpool() {

--- a/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
+++ b/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
@@ -12,11 +12,11 @@ use constantine_halo2_zal::CttEngine;
 use ark_std::{end_timer, start_timer};
 use rand_core::OsRng;
 
-use halo2curves::bn256;
-use halo2curves::ff::Field;
-use halo2curves::group::prime::PrimeCurveAffine;
-use halo2curves::group::{Curve, Group};
-use halo2curves::msm::best_multiexp;
+use halo2_middleware::halo2curves::bn256;
+use halo2_middleware::halo2curves::ff::Field;
+use halo2_middleware::halo2curves::group::prime::PrimeCurveAffine;
+use halo2_middleware::halo2curves::group::{Curve, Group};
+use halo2_middleware::halo2curves::msm::best_multiexp;
 use halo2_middleware::zal::traits::MsmAccel;
 
 #[test]


### PR DESCRIPTION
Replaces the dependency for the MSM acceleration layer to use the version from the Privacy Scaling Explorations repo (https://github.com/privacy-scaling-explorations/halo2/)

Still needs to depend on `halo2curves` explicitly, as `halo2_middleware` does not reexport it (and currently I didn't manage to figure out how to fix that).