### PR TITLE
C API for BLS signature `aggregate_verify` & `batch_verify` (incl parallel)

### DIFF
--- a/bindings/lib_constantine.nim
+++ b/bindings/lib_constantine.nim
@@ -21,6 +21,7 @@ import
   ../constantine/csprngs,
   # Protocols
   ../constantine/ethereum_bls_signatures,
+  ../constantine/ethereum_bls_signatures_parallel,
   ../constantine/trusted_setups/ethereum_kzg_srs,
   ../constantine/ethereum_eip4844_kzg,
   ../constantine/ethereum_eip4844_kzg_parallel,

--- a/constantine/ethereum_bls_signatures.nim
+++ b/constantine/ethereum_bls_signatures.nim
@@ -411,11 +411,11 @@ func aggregate_verify*[Msg](pubkeys: openArray[PublicKey], messages: openArray[M
   return cttEthBls_VerificationFailure
 
 # C FFI
-func batch_verify*[Msg](pubkeys: ptr UncheckedArray[PublicKey],
-                        messages: ptr UncheckedArray[View[byte]],
-                        signatures: ptr UncheckedArray[Signature],
-                        len: int,
-                        secureRandomBytes: array[32, byte]): cttEthBlsStatus {.libPrefix: prefix_ffi.} =
+func batch_verify*(pubkeys: ptr UncheckedArray[PublicKey],
+                   messages: ptr UncheckedArray[View[byte]],
+                   signatures: ptr UncheckedArray[Signature],
+                   len: int,
+                   secureRandomBytes: array[32, byte]): cttEthBlsStatus {.libPrefix: prefix_ffi.} =
   ## Verify that all (pubkey, message, signature) triplets are valid
   ## returns `true` if all signatures are valid, `false` if at least one is invalid.
   ##
@@ -454,7 +454,7 @@ func batch_verify*[Msg](pubkeys: ptr UncheckedArray[PublicKey],
 
   let verified = batchVerify(
     pubkeys.toOpenArray(len).unwrap(),
-    messages,
+    messages.toOpenArray(len),
     signatures.toOpenArray(len).unwrap(),
     sha256, 128, DomainSeparationTag, secureRandomBytes)
   if verified:

--- a/constantine/ethereum_bls_signatures_parallel.nim
+++ b/constantine/ethereum_bls_signatures_parallel.nim
@@ -32,7 +32,7 @@ import
 {.push checks: off.}
 
 # C FFI
-proc batch_verify_parallel*[Msg](
+proc batch_verify_parallel*(
         tp: Threadpool,
         pubkeys: ptr UncheckedArray[PublicKey],
         messages: ptr UncheckedArray[View[byte]],
@@ -80,7 +80,7 @@ proc batch_verify_parallel*[Msg](
 
   let verified = tp.batchVerify_parallel(
     pubkeys.toOpenArray(len).unwrap(),
-    messages,
+    messages.toOpenArray(len),
     signatures.toOpenArray(len).unwrap(),
     sha256, 128, DomainSeparationTag, secureRandomBytes)
   if verified:

--- a/constantine/signatures/bls_signatures.nim
+++ b/constantine/signatures/bls_signatures.nim
@@ -475,7 +475,7 @@ func update*[Pubkey, Sig: ECP_ShortW_Aff](
        pubkey: Pubkey,
        message: View[byte],
        signature: Sig): bool {.inline.} =
-  ctx.update(pubkey, message, signature)
+  ctx.update(pubkey, message.toOpenArray(), signature)
 
 func handover*(ctx: var BLSBatchSigAccumulator) {.inline.} =
   ## Prepare accumulator for cheaper merging.

--- a/examples-c/README.md
+++ b/examples-c/README.md
@@ -8,7 +8,7 @@ in `lib/`.
 To compile and run the example / test case, for example:
 
 ```sh
-gcc ethereum_bls_signatures.c -o ethereum_bls_signatures -I../include -L../lib -lconstantine
+clang ethereum_bls_signatures.c -o ethereum_bls_signatures -I../include -L../lib -lconstantine
 ```
 
 For the test case, you also need to link in `-lgmp`.
@@ -17,7 +17,7 @@ And depending on your setup you might need to specify where
 `libconstantine.so` can be found:
 
 ```sh
-LD_LIBRARY_PATH=../lib ./ethereum_bls_signutares
+LD_LIBRARY_PATH=../lib ./ethereum_bls_signatures
 ```
 
 (in case you compile and run from this directory).

--- a/examples-c/README.md
+++ b/examples-c/README.md
@@ -2,4 +2,26 @@
 
 This folder holds tests (prefixed with `t_`) and examples for the C bindings.
 
-Headers are located in `include/` and the static and dynamic libraries in `lib/`
+Headers are located in `include/` and the static and dynamic libraries
+in `lib/`.
+
+To compile and run the example / test case, for example:
+
+```sh
+gcc ethereum_bls_signatures.c -o ethereum_bls_signatures -I../include -L../lib -lconstantine
+```
+
+For the test case, you also need to link in `-lgmp`.
+
+And depending on your setup you might need to specify where
+`libconstantine.so` can be found:
+
+```sh
+LD_LIBRARY_PATH=../lib ./ethereum_bls_signutares
+```
+
+(in case you compile and run from this directory).
+
+The above of course assumes you have already compiled
+`libconstantine.so` (using `nimble make_lib` from the root directory
+of the repository).

--- a/examples-c/ethereum_bls_signatures.c
+++ b/examples-c/ethereum_bls_signatures.c
@@ -64,7 +64,14 @@ int main(){
       { message, 32 }
   };
   const ctt_eth_bls_signature sigs[3] = { sig, sig, sig };
-  byte srb[32] = {0}; // just a bunch of zeros as random "secure" bytes.
+
+  // Use constantine's `sysrand` to fill the secure random bytes
+  byte srb[32];
+  if(!ctt_csprng_sysrand(srb, 32)){
+      printf("Failed to fill `srb` using `sysrand`\n");
+      exit(1);
+  }
+
   bls_status = ctt_eth_bls_batch_verify(pkeys, messages, sigs, 3, srb);
   if (bls_status != cttEthBls_Success) {
     printf("Batch verification failure: status %d - %s\n", bls_status, ctt_eth_bls_status_to_string(bls_status));

--- a/examples-c/ethereum_bls_signatures.c
+++ b/examples-c/ethereum_bls_signatures.c
@@ -58,7 +58,7 @@ int main(){
 
   // try to use batch verify; We just reuse the data from above 3 times
   const ctt_eth_bls_pubkey pkeys[3] = { pubkey, pubkey, pubkey };
-  ByteView messages[3] = { // already hashed message, reuse 3 times
+  ctt_span messages[3] = { // already hashed message, reuse 3 times
       { message, 32 },
       { message, 32 },
       { message, 32 }

--- a/examples-c/ethereum_bls_signatures.c
+++ b/examples-c/ethereum_bls_signatures.c
@@ -49,7 +49,6 @@ int main(){
     printf("Signature verification failure: status %d - %s\n", bls_status, ctt_eth_bls_status_to_string(bls_status));
     exit(1);
   }
-
   printf("Example BLS signature/verification protocol completed successfully\n");
 
 
@@ -73,5 +72,26 @@ int main(){
   }
 
   printf("Example BLS batch verification completed successfully\n");
+
+  // ------------------------------
+  // Batch verification, parallel
+  // ------------------------------
+
+  // and now try to use a threadpool and do the same in parallel
+
+  struct ctt_threadpool* tp = ctt_threadpool_new(4);
+  printf("Constantine: Threadpool init successful.\n");
+  bls_status = ctt_eth_bls_batch_verify_parallel(tp, pkeys, messages, sigs, 3, srb);
+  if (bls_status != cttEthBls_Success) {
+    printf("Batch verification failure: status %d - %s\n", bls_status, ctt_eth_bls_status_to_string(bls_status));
+    exit(1);
+  }
+  printf("Example parallel BLS batch verification completed successfully\n");
+
+  ctt_threadpool_shutdown(tp);
+  printf("Constantine: Threadpool shutdown successful.\n");
+
+
+
   return 0;
 }

--- a/examples-c/ethereum_bls_signatures.c
+++ b/examples-c/ethereum_bls_signatures.c
@@ -51,5 +51,27 @@ int main(){
   }
 
   printf("Example BLS signature/verification protocol completed successfully\n");
+
+
+  // ------------------------------
+  // Batch verification
+  // ------------------------------
+
+  // try to use batch verify; We just reuse the data from above 3 times
+  const ctt_eth_bls_pubkey pkeys[3] = { pubkey, pubkey, pubkey };
+  ByteView messages[3] = { // already hashed message, reuse 3 times
+      { message, 32 },
+      { message, 32 },
+      { message, 32 }
+  };
+  const ctt_eth_bls_signature sigs[3] = { sig, sig, sig };
+  byte srb[32] = {0}; // just a bunch of zeros as random "secure" bytes.
+  bls_status = ctt_eth_bls_batch_verify(pkeys, messages, sigs, 3, srb);
+  if (bls_status != cttEthBls_Success) {
+    printf("Batch verification failure: status %d - %s\n", bls_status, ctt_eth_bls_status_to_string(bls_status));
+    exit(1);
+  }
+
+  printf("Example BLS batch verification completed successfully\n");
   return 0;
 }

--- a/include/constantine.h
+++ b/include/constantine.h
@@ -35,6 +35,7 @@
 
 // Protocols
 #include "constantine/protocols/ethereum_bls_signatures.h"
+#include "constantine/protocols/ethereum_bls_signatures_parallel.h"
 #include "constantine/protocols/ethereum_eip4844_kzg.h"
 #include "constantine/protocols/ethereum_eip4844_kzg_parallel.h"
 

--- a/include/constantine/protocols/ethereum_bls_signatures.h
+++ b/include/constantine/protocols/ethereum_bls_signatures.h
@@ -256,10 +256,10 @@ ctt_eth_bls_status ctt_eth_bls_fast_aggregate_verify(const ctt_eth_bls_pubkey pu
  *  1. Public keys signing the same message MUST be aggregated and checked for 0 before calling this function.
  *  2. Augmentation or Proof of possessions must used for each public keys.
  */
-ctt_eth_bls_status aggregate_verify(const ctt_eth_bls_pubkey* pubkeys,
-				    const ctt_span messages[],
-				    ptrdiff_t len,
-				    const ctt_eth_bls_signature* aggregate_sig) __attribute__((warn_unused_result));
+ctt_eth_bls_status ctt_eth_bls_aggregate_verify(const ctt_eth_bls_pubkey* pubkeys,
+						const ctt_span messages[],
+						ptrdiff_t len,
+						const ctt_eth_bls_signature* aggregate_sig) __attribute__((warn_unused_result));
 
 
 /** Verify that all (pubkey, message, signature) triplets are valid

--- a/include/constantine/protocols/ethereum_bls_signatures.h
+++ b/include/constantine/protocols/ethereum_bls_signatures.h
@@ -55,7 +55,8 @@ static const char* ctt_eth_bls_status_to_string(ctt_eth_bls_status status) {
 // type View*[byte] = object # with T = byte
 //  data: ptr UncheckedArray[byte] # 8 bytes
 //  len*: int                      # 8 bytes (Nim `int` is a 64bit int type)
-typedef struct { byte* data; size_t len; } ByteView;
+// `span` naming following C++20 std::span<T>
+typedef struct { byte* data; size_t len; } ctt_span;
 
 // Comparisons
 // ------------------------------------------------------------------------------------------------
@@ -256,7 +257,7 @@ ctt_eth_bls_status ctt_eth_bls_fast_aggregate_verify(const ctt_eth_bls_pubkey pu
  *  2. Augmentation or Proof of possessions must used for each public keys.
  */
 ctt_eth_bls_status aggregate_verify(const ctt_eth_bls_pubkey* pubkeys,
-				    const ByteView messages[],
+				    const ctt_span messages[],
 				    ptrdiff_t len,
 				    const ctt_eth_bls_signature* aggregate_sig) __attribute__((warn_unused_result));
 
@@ -286,8 +287,7 @@ ctt_eth_bls_status aggregate_verify(const ctt_eth_bls_pubkey* pubkeys,
  */
 
 ctt_eth_bls_status ctt_eth_bls_batch_verify(const ctt_eth_bls_pubkey pubkeys[],
-					    //const struct { byte* data; size_t len; } messages[],
-					    const ByteView messages[],
+					    const ctt_span messages[],
 					    const ctt_eth_bls_signature signatures[],
 					    ptrdiff_t len,
 					    const byte secure_random_bytes[32]

--- a/include/constantine/protocols/ethereum_bls_signatures_parallel.h
+++ b/include/constantine/protocols/ethereum_bls_signatures_parallel.h
@@ -50,7 +50,7 @@ extern "C" {
 ctt_eth_bls_status ctt_eth_bls_batch_verify_parallel(
         const ctt_threadpool* tp,
         const ctt_eth_bls_pubkey pubkey[],
-	const ByteView messages[],
+	const ctt_span messages[],
         const ctt_eth_bls_signature sig[],
         ptrdiff_t len,
         const byte secure_random_bytes[32]

--- a/include/constantine/protocols/ethereum_bls_signatures_parallel.h
+++ b/include/constantine/protocols/ethereum_bls_signatures_parallel.h
@@ -1,0 +1,64 @@
+/** Constantine
+ *  Copyright (c) 2018-2019    Status Research & Development GmbH
+ *  Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+ *  Licensed and distributed under either of
+ *    * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+ *    * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+ *  at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+#ifndef __CTT_H_ETHEREUM_BLS_SIGNATURES_PARALLEL__
+#define __CTT_H_ETHEREUM_BLS_SIGNATURES_PARALLEL__
+
+#include "constantine/core/datatypes.h"
+#include "constantine/core/threadpool.h"
+#include "constantine/protocols/ethereum_bls_signatures.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Ethereum BLS signatures parallel interface
+// ------------------------------------------------------------------------------------------------
+
+/**
+ *  Verify that all (pubkey, message, signature) triplets are valid
+ *  returns `true` if all signatures are valid, `false` if at least one is invalid.
+ *
+ *  For message domain separation purpose, the tag is `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`
+ *
+ *  Input:
+ *  - Public keys initialized by one of the key derivation or deserialization procedure.
+ *    Or validated via validate_pubkey
+ *  - Messages as an anonymous struct of `(data = byte*, length = size_t)` pairs
+ *    (the `View` type on the Nim side uses `int` for the length field, which depends on the
+ *    system)
+ *  - Signatures initialized by one of the key derivation or deserialization procedure.
+ *    Or validated via validate_signature
+ *  - `len`: number of elements in `pubkey`, `messages`, `sig` arrays
+ *
+ *  In particular, the public keys and signature are assumed to be on curve subgroup checked.
+ *
+ *  To avoid splitting zeros and rogue keys attack:
+ *  1. Cryptographically-secure random bytes must be provided.
+ *  2. Augmentation or Proof of possessions must used for each public keys.
+ *
+ *  The secureRandomBytes will serve as input not under the attacker control to foil potential splitting zeros inputs.
+ *  The scheme assumes that the attacker cannot
+ *  resubmit 2^64 times forged (publickey, message, signature) triplets
+ *  against the same `secureRandomBytes`
+*/
+ctt_eth_bls_status ctt_eth_bls_batch_verify_parallel(
+        const ctt_threadpool* tp,
+        const ctt_eth_bls_pubkey pubkey[],
+	const ByteView messages[],
+        const ctt_eth_bls_signature sig[],
+        ptrdiff_t len,
+        const byte secure_random_bytes[32]
+    ) __attribute__((warn_unused_result));
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __CTT_H_ETHEREUM_BLS_SIGNATURES_PARALLEL__


### PR DESCRIPTION
Adds the C API for BLS signature `aggregate_verify` and `batch_verify` functions. The parallel version using a threadpool is also exposed.

Note: For the batched API we currently provide a `ByteView` typedef on the C side (happy to choose a different name, probably better snake_case and lower case, maybe `ctt_byte_view` ?). We _could_ do an anonymous struct in the function signatures, but at least I'm not aware of a way to get around 'incompatible pointer' warnings with GCC / Clang in that case.

It includes 2 minor fixes for the `batch_verify(_parallel)` Nim C targeted procs. They were accidentally generic and missing a `toOpenArray` for the `messages`. In addition it fixes a minor bug in the `update` proc for the `View[byte]` overload, which lead to an infinite recursion.