### PR TITLE
C API for EVM precompiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Protocols are a set of routines, designed for specific goals or a combination th
 
 Constantine supports the following protocols in its public API.
 
-|                                       |        Nim         |            C            | Rust                    |         Go         |
-|---------------------------------------|:------------------:|:-----------------------:|-------------------------|:------------------:|
-| Ethereum BLS signatures               | :white_check_mark: | :building_construction: | :building_construction: |   :see_no_evil:    |
-| Ethereum KZG commitments for EIP-4844 | :white_check_mark: |   :white_check_mark:    | :white_check_mark:      | :white_check_mark: |
-| Ethereum Virtual Machine Precompiles (ECADD, ECMUL, ECPAIRING, MODEXP) | :white_check_mark: | :see_no_evil: | :see_no_evil: | :see_no_evil: | :see_no_evil: |
-| Zk Accel layer for Halo2 proof system (experimental) | not applicable | not applicable | :white_check_mark: | not applicable |
+|                                                                        | Nim                | C                  | Rust                    | Go                 |
+|------------------------------------------------------------------------|:------------------:|:------------------:|-------------------------|:------------------:|
+| Ethereum BLS signatures                                                | :white_check_mark: | :white_check_mark: | :building_construction: | :see_no_evil:      |
+| Ethereum KZG commitments for EIP-4844                                  | :white_check_mark: | :white_check_mark: | :white_check_mark:      | :white_check_mark: |
+| Ethereum Virtual Machine Precompiles (ECADD, ECMUL, ECPAIRING, MODEXP) | :white_check_mark: | :white_check_mark: | :see_no_evil:           | :see_no_evil:      |
+| Zk Accel layer for Halo2 proof system (experimental)                   | not applicable     | not applicable     | :white_check_mark:      | not applicable     |
 
 ### Elliptic Curves
 

--- a/bindings/lib_constantine.nim
+++ b/bindings/lib_constantine.nim
@@ -26,5 +26,7 @@ import
   ../constantine/ethereum_eip4844_kzg,
   ../constantine/ethereum_eip4844_kzg_parallel,
 
+  ../constantine/ethereum_evm_precompiles,
+
   # Ensure globals like proc from kernel32.dll are populated at library load time
   ./lib_autoload

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -27,6 +27,9 @@ import
 #
 # ############################################################
 
+import ./zoo_exports
+const prefix_ffi = "ctt_" # all funcs already have an `eth_evm` prefix in Nim
+
 # No exceptions for the EVM API
 {.push raises: [].}
 
@@ -39,7 +42,7 @@ type
     cttEVM_PointNotOnCurve
     cttEVM_PointNotInSubgroup
 
-func eth_evm_sha256*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_sha256*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## SHA256
   ##
   ## Inputs:
@@ -57,7 +60,7 @@ func eth_evm_sha256*(r: var openArray[byte], inputs: openArray[byte]): CttEVMSta
   sha256.hash(cast[ptr array[32, byte]](r[0].addr)[], inputs)
   return cttEVM_Success
 
-func eth_evm_modexp*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.noInline, tags:[Alloca, Vartime], meter.} =
+func eth_evm_modexp*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.noInline, tags:[Alloca, Vartime], libPrefix: prefix_ffi, meter.} =
   ## Modular exponentiation
   ##
   ## Name: MODEXP
@@ -308,7 +311,7 @@ func fromRawCoords[C: static Curve, G: static Subgroup](
     return status
   dst.fromAffine(aff)
 
-func eth_evm_bn254_g1add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bn254_g1add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve addition on BN254_Snarks
   ## (also called alt_bn128 in Ethereum specs
   ##  and bn256 in Ethereum tests)
@@ -366,7 +369,7 @@ func eth_evm_bn254_g1add*(r: var openArray[byte], inputs: openarray[byte]): CttE
   r.toOpenArray(32, 63).marshal(aff.y, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bn254_g1mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bn254_g1mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve multiplication on BN254_Snarks
   ## (also called alt_bn128 in Ethereum specs
   ##  and bn256 in Ethereum tests)
@@ -439,7 +442,7 @@ func eth_evm_bn254_g1mul*(r: var openArray[byte], inputs: openarray[byte]): CttE
   return cttEVM_Success
 
 func eth_evm_bn254_ecpairingcheck*(
-      r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+      r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve pairing check on BN254_Snarks
   ## (also called alt_bn128 in Ethereum specs
   ##  and bn256 in Ethereum tests)
@@ -523,7 +526,7 @@ func eth_evm_bn254_ecpairingcheck*(
     r[r.len-1] = byte 1
   return cttEVM_Success
 
-func eth_evm_bls12381_g1add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g1add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve addition on BLS12-381 G1
   ##
   ## Name: BLS12_G1ADD
@@ -583,7 +586,7 @@ func eth_evm_bls12381_g1add*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(64, 128-1).marshal(aff.y, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_g2add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g2add*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve addition on BLS12-381 G2
   ##
   ## Name: BLS12_G2ADD
@@ -649,7 +652,7 @@ func eth_evm_bls12381_g2add*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(192, 256-1).marshal(aff.y.c1, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_g1mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g1mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve scalar multiplication on BLS12-381 G1
   ##
   ## Name: BLS12_G1MUL
@@ -717,7 +720,7 @@ func eth_evm_bls12381_g1mul*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(64, 128-1).marshal(aff.y, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_g2mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g2mul*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve scalar multiplication on BLS12-381 G2
   ##
   ## Name: BLS12_G2MUL
@@ -789,7 +792,7 @@ func eth_evm_bls12381_g2mul*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(192, 256-1).marshal(aff.y.c1, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_g1msm*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g1msm*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve addition on BLS12-381 G1
   ##
   ## Name: BLS12_G1MSM
@@ -869,7 +872,7 @@ func eth_evm_bls12381_g1msm*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(64, 128-1).marshal(aff.y, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_g2msm*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_g2msm*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic Curve addition on BLS12-381 G2
   ##
   ## Name: BLS12_G2MSM
@@ -953,7 +956,7 @@ func eth_evm_bls12381_g2msm*(r: var openArray[byte], inputs: openarray[byte]): C
   r.toOpenArray(192, 256-1).marshal(aff.y.c1, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_pairingcheck*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_pairingcheck*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Elliptic curve pairing check on BLS12-381
   ##
   ## Name: BLS12_PAIRINGCHECK
@@ -1032,7 +1035,7 @@ func eth_evm_bls12381_pairingcheck*(r: var openArray[byte], inputs: openarray[by
     r[r.len-1] = byte 1
   return cttEVM_Success
 
-func eth_evm_bls12381_map_fp_to_g1*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_map_fp_to_g1*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Map a field element to G1
   ##
   ## Name: BLS12_MAP_FP_TO_G1
@@ -1081,7 +1084,7 @@ func eth_evm_bls12381_map_fp_to_g1*(r: var openArray[byte], inputs: openarray[by
   r.toOpenArray(64, 128-1).marshal(aff.y, bigEndian)
   return cttEVM_Success
 
-func eth_evm_bls12381_map_fp2_to_g2*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.meter.} =
+func eth_evm_bls12381_map_fp2_to_g2*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## Map an Fp2 extension field element to G1
   ##
   ## Name: BLS12_MAP_FP2_TO_G2

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -1085,7 +1085,7 @@ func eth_evm_bls12381_map_fp_to_g1*(r: var openArray[byte], inputs: openarray[by
   return cttEVM_Success
 
 func eth_evm_bls12381_map_fp2_to_g2*(r: var openArray[byte], inputs: openarray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
-  ## Map an Fp2 extension field element to G1
+  ## Map an Fp2 extension field element to G2
   ##
   ## Name: BLS12_MAP_FP2_TO_G2
   ##

--- a/examples-c/ethereum_bls_signatures.c
+++ b/examples-c/ethereum_bls_signatures.c
@@ -40,7 +40,7 @@ int main(){
   // Sign a message
   byte message[32];
   ctt_eth_bls_signature sig;
-  ctt_sha256_hash(message, "Mr F was here", 13, /* clear_memory = */ 0);
+  ctt_sha256_hash(message, (const byte*)"Mr F was here", 13, /* clear_memory = */ 0);
   ctt_eth_bls_sign(&sig, &seckey, message, 32);
 
   // Verify that a signature is valid for a message under the provided public key

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -1,0 +1,97 @@
+/** Constantine
+ *  Copyright (c) 2018-2019    Status Research & Development GmbH
+ *  Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+ *  Licensed and distributed under either of
+ *    * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+ *    * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+ *  at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <constantine.h>
+
+int hexStringToBytes(const char *hexStr, byte *buffer) {
+    // converts the given `hexStr` to a byte buffer. `buffer` must already be
+    // allocated to len(hexStr) // 2!
+    size_t len = strlen(hexStr);
+    if (len % 2 != 0) return -1; // Length must be even
+
+    size_t byteLen = len / 2;
+    unsigned int b;
+    for (size_t i = 0; i < byteLen; i++) {
+        if (sscanf(&hexStr[i * 2], "%2x", &b) != 1) {
+            return -2; // Failed to convert hex to byte
+        }
+        buffer[i] = (byte)b;
+    }
+    return 0; // Success
+}
+
+int compare_binary(const byte* buf1, size_t len1, const byte* buf2, size_t len2) {
+    // compares the two binary buffers with length len1 and len2 byte by byte.
+    if (len1 != len2){
+	return -1; // mismatching length
+    }
+    for(size_t i = 0; i < len1; i++){
+	if(buf1[i] != buf2[i]){
+	    return -2; // found a mismatched byte
+	}
+	else{
+	    printf("Byte at %i = %x matches!\n", i, buf1[i]);
+	}
+    }
+    return 0; // success
+}
+
+
+int main(){
+    ctt_evm_status evm_status;
+
+    // just attempt to compute the sha256 hash of some text
+    byte result[32] = {0};
+    const byte* txt = "Foo, Bar and Baz are all friends.";
+
+    evm_status = ctt_eth_evm_sha256(result, 32, txt, strlen(txt));
+    if (evm_status != cttEVM_Success) {
+	printf(
+	    "SHA256 hash calc from input failed",
+	    evm_status,
+	    ctt_evm_status_to_string(evm_status)
+	    );
+	exit(1);
+    }
+
+    // Random test case from `map_fp2_to_G2_bls.json` to see if generally the API seems to work
+    const char* inputStr = "0000000000000000000000000000000003f80ce4ff0ca2f576d797a3660e3f65b274285c054feccc3215c879e2c0589d376e83ede13f93c32f05da0f68fd6a1000000000000000000000000000000000006488a837c5413746d868d1efb7232724da10eca410b07d8b505b9363bdccf0a1fc0029bad07d65b15ccfe6dd25e20d";
+    const char* expectedStr = "000000000000000000000000000000000ea4e7c33d43e17cc516a72f76437c4bf81d8f4eac69ac355d3bf9b71b8138d55dc10fd458be115afa798b55dac34be1000000000000000000000000000000001565c2f625032d232f13121d3cfb476f45275c303a037faa255f9da62000c2c864ea881e2bcddd111edc4a3c0da3e88d00000000000000000000000000000000043b6f5fe4e52c839148dc66f2b3751e69a0f6ebb3d056d6465d50d4108543ecd956e10fa1640dfd9bc0030cc2558d28000000000000000000000000000000000f8991d2a1ad662e7b6f58ab787947f1fa607fce12dde171bc17903b012091b657e15333e11701edcf5b63ba2a561247";
+    byte    input[128]; hexStringToBytes(inputStr, input);
+    byte expected[256]; hexStringToBytes(expectedStr, expected);
+    byte    g2Res[256];
+
+    evm_status = ctt_eth_evm_bls12381_map_fp2_to_g2(g2Res, 256, input, 128);
+    if(evm_status != cttEVM_Success){
+	printf(
+	    "Mapping input from Fp2 to G2 failed.",
+	    evm_status,
+	    ctt_evm_status_to_string(evm_status)
+	    );
+	exit(1);
+    }
+
+    evm_status = compare_binary(g2Res, 256, expected, 256);
+    if(evm_status != cttEVM_Success){
+	printf(
+	    "Unexpected output from Fp2 to G2 mapping..",
+	    evm_status,
+	    ctt_evm_status_to_string(evm_status)
+	    );
+	exit(1);
+    }
+    printf("EVM precompiles example ran successfully .\n");
+
+    return 0;
+}

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -46,9 +46,9 @@ int main(){
 
     // just attempt to compute the sha256 hash of some text
     byte result[32] = {0};
-    const byte* txt = "Foo, Bar and Baz are all friends.";
+    const char txt[] = "Foo, Bar and Baz are all friends.";
 
-    evm_status = ctt_eth_evm_sha256(result, 32, txt, strlen(txt));
+    evm_status = ctt_eth_evm_sha256(result, 32, (const byte*)txt, sizeof(txt));
     if (evm_status != cttEVM_Success) {
 	printf(
 	    "SHA256 hash calc from input failed %d - %s\n",
@@ -59,10 +59,10 @@ int main(){
     }
 
     // Random test case from `map_fp2_to_G2_bls.json` to see if generally the API seems to work
-    const char* inputStr = "0000000000000000000000000000000003f80ce4ff0ca2f576d797a3660e3f65b274285c054feccc3215c879e2c0589d376e83ede13f93c32f05da0f68fd6a1000000000000000000000000000000000006488a837c5413746d868d1efb7232724da10eca410b07d8b505b9363bdccf0a1fc0029bad07d65b15ccfe6dd25e20d";
-    const char* expectedStr = "000000000000000000000000000000000ea4e7c33d43e17cc516a72f76437c4bf81d8f4eac69ac355d3bf9b71b8138d55dc10fd458be115afa798b55dac34be1000000000000000000000000000000001565c2f625032d232f13121d3cfb476f45275c303a037faa255f9da62000c2c864ea881e2bcddd111edc4a3c0da3e88d00000000000000000000000000000000043b6f5fe4e52c839148dc66f2b3751e69a0f6ebb3d056d6465d50d4108543ecd956e10fa1640dfd9bc0030cc2558d28000000000000000000000000000000000f8991d2a1ad662e7b6f58ab787947f1fa607fce12dde171bc17903b012091b657e15333e11701edcf5b63ba2a561247";
-    byte    input[128]; hexStringToBytes(inputStr, input);
-    byte expected[256]; hexStringToBytes(expectedStr, expected);
+    const char input_str[] = "0000000000000000000000000000000003f80ce4ff0ca2f576d797a3660e3f65b274285c054feccc3215c879e2c0589d376e83ede13f93c32f05da0f68fd6a1000000000000000000000000000000000006488a837c5413746d868d1efb7232724da10eca410b07d8b505b9363bdccf0a1fc0029bad07d65b15ccfe6dd25e20d";
+    const char expected_str[] = "000000000000000000000000000000000ea4e7c33d43e17cc516a72f76437c4bf81d8f4eac69ac355d3bf9b71b8138d55dc10fd458be115afa798b55dac34be1000000000000000000000000000000001565c2f625032d232f13121d3cfb476f45275c303a037faa255f9da62000c2c864ea881e2bcddd111edc4a3c0da3e88d00000000000000000000000000000000043b6f5fe4e52c839148dc66f2b3751e69a0f6ebb3d056d6465d50d4108543ecd956e10fa1640dfd9bc0030cc2558d28000000000000000000000000000000000f8991d2a1ad662e7b6f58ab787947f1fa607fce12dde171bc17903b012091b657e15333e11701edcf5b63ba2a561247";
+    byte    input[128]; from_hex(input, 128, input_str, 256);
+    byte expected[256]; from_hex(expected, 256, expected_str, 512);
     byte    g2Res[256];
 
     evm_status = ctt_eth_evm_bls12381_map_fp2_to_g2(g2Res, 256, input, 128);

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -58,7 +58,7 @@ int main(){
     evm_status = ctt_eth_evm_sha256(result, 32, txt, strlen(txt));
     if (evm_status != cttEVM_Success) {
 	printf(
-	    "SHA256 hash calc from input failed",
+	    "SHA256 hash calc from input failed %d - %s\n",
 	    evm_status,
 	    ctt_evm_status_to_string(evm_status)
 	    );
@@ -75,7 +75,7 @@ int main(){
     evm_status = ctt_eth_evm_bls12381_map_fp2_to_g2(g2Res, 256, input, 128);
     if(evm_status != cttEVM_Success){
 	printf(
-	    "Mapping input from Fp2 to G2 failed.",
+	    "Mapping input from Fp2 to G2 failed %d - %s\n",
 	    evm_status,
 	    ctt_evm_status_to_string(evm_status)
 	    );
@@ -85,7 +85,7 @@ int main(){
     evm_status = compare_binary(g2Res, 256, expected, 256);
     if(evm_status != cttEVM_Success){
 	printf(
-	    "Unexpected output from Fp2 to G2 mapping..",
+	    "Unexpected output from Fp2 to G2 mapping %d - %s\n",
 	    evm_status,
 	    ctt_evm_status_to_string(evm_status)
 	    );

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -10,23 +10,19 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <constantine.h>
 
-int hexStringToBytes(const char *hexStr, byte *buffer) {
-    // converts the given `hexStr` to a byte buffer. `buffer` must already be
-    // allocated to len(hexStr) // 2!
-    size_t len = strlen(hexStr);
-    if (len % 2 != 0) return -1; // Length must be even
+int from_hex(byte *dst, size_t dst_len, const char *hex_src, size_t src_len) {
+    // converts the given `hex_src` to a byte buffer. `buffer` must already be
+    // allocated to len(hex_src) // 2!
+    if (src_len % 2 != 0) return -1; // Length must be even
+    else if(dst_len * 2 != src_len) return -2; // dest length must be half src len
 
-    size_t byteLen = len / 2;
-    unsigned int b;
-    for (size_t i = 0; i < byteLen; i++) {
-        if (sscanf(&hexStr[i * 2], "%2x", &b) != 1) {
-            return -2; // Failed to convert hex to byte
+    for (size_t i = 0; i < dst_len; i++) {
+        if (sscanf(&hex_src[i * 2], "%2hhx", &dst[i]) != 1) {
+            return -(i+3); // Failed to convert hex to byte
         }
-        buffer[i] = (byte)b;
     }
     return 0; // Success
 }
@@ -38,10 +34,7 @@ int compare_binary(const byte* buf1, size_t len1, const byte* buf2, size_t len2)
     }
     for(size_t i = 0; i < len1; i++){
 	if(buf1[i] != buf2[i]){
-	    return -2; // found a mismatched byte
-	}
-	else{
-	    printf("Byte at %i = %x matches!\n", i, buf1[i]);
+	    return -(i+2); // found a mismatched byte
 	}
     }
     return 0; // success

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -17,11 +17,11 @@ int from_hex(byte *dst, size_t dst_len, const char *hex_src, size_t src_len) {
     // converts the given `hex_src` to a byte buffer. `buffer` must already be
     // allocated to len(hex_src) // 2!
     if (src_len % 2 != 0) return -1; // Length must be even
-    else if(dst_len * 2 != src_len) return -2; // dest length must be half src len
+    else if(dst_len * 2 != src_len) return -1; // dest length must be half src len
 
     for (size_t i = 0; i < dst_len; i++) {
         if (sscanf(&hex_src[i * 2], "%2hhx", &dst[i]) != 1) {
-            return -(i+3); // Failed to convert hex to byte
+            return -(i+1); // Failed to convert hex to byte
         }
     }
     return 0; // Success
@@ -34,7 +34,7 @@ int compare_binary(const byte* buf1, size_t len1, const byte* buf2, size_t len2)
     }
     for(size_t i = 0; i < len1; i++){
 	if(buf1[i] != buf2[i]){
-	    return -(i+2); // found a mismatched byte
+	    return -(i+1); // found a mismatched byte
 	}
     }
     return 0; // success

--- a/examples-c/ethereum_evm_precompiles.c
+++ b/examples-c/ethereum_evm_precompiles.c
@@ -84,7 +84,7 @@ int main(){
 	    );
 	exit(1);
     }
-    printf("EVM precompiles example ran successfully .\n");
+    printf("EVM precompiles example ran successfully.\n");
 
     return 0;
 }

--- a/include/constantine.h
+++ b/include/constantine.h
@@ -39,4 +39,6 @@
 #include "constantine/protocols/ethereum_eip4844_kzg.h"
 #include "constantine/protocols/ethereum_eip4844_kzg_parallel.h"
 
+#include "constantine/protocols/ethereum_evm_precompiles.h"
+
 #endif

--- a/include/constantine/protocols/ethereum_evm_precompiles.h
+++ b/include/constantine/protocols/ethereum_evm_precompiles.h
@@ -432,7 +432,7 @@ ctt_evm_status ctt_eth_evm_bls12381_map_fp_to_g1(
 ) __attribute__((warn_unused_result));
 
 /**
-  *  Map an Fp2 extension field element to G1
+  *  Map an Fp2 extension field element to G2
   *
   *  Name: BLS12_MAP_FP2_TO_G2
   *

--- a/include/constantine/protocols/ethereum_evm_precompiles.h
+++ b/include/constantine/protocols/ethereum_evm_precompiles.h
@@ -1,0 +1,464 @@
+/** Constantine
+ *  Copyright (c) 2018-2019    Status Research & Development GmbH
+ *  Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+ *  Licensed and distributed under either of
+ *    * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+ *    * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+ *  at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+#ifndef __CTT_H_ETHEREUM_EVM_PRECOMPILES__
+#define __CTT_H_ETHEREUM_EVM_PRECOMPILES__
+
+#include "constantine/core/datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum __attribute__((__packed__)) {
+    cttEVM_Success,
+    cttEVM_InvalidInputSize,
+    cttEVM_InvalidOutputSize,
+    cttEVM_IntLargerThanModulus,
+    cttEVM_PointNotOnCurve,
+    cttEVM_PointNotInSubgroup,
+} ctt_evm_status;
+
+static const char* ctt_evm_status_to_string(ctt_evm_status status) {
+  static const char* const statuses[] = {
+      "cttEVM_Success",
+      "cttEVM_InvalidInputSize",
+      "cttEVM_InvalidOutputSize",
+      "cttEVM_IntLargerThanModulus",
+      "cttEVM_PointNotOnCurve",
+      "cttEVM_PointNotInSubgroup",
+  };
+  size_t length = sizeof statuses / sizeof *statuses;
+  if (0 <= status && status < length) {
+    return statuses[status];
+  }
+  return "cttEVM_InvalidStatusCode";
+}
+
+/**
+ *  SHA256
+ *
+ *  Inputs:
+ *  - r: array with 32 bytes of storage for the result
+ *  - r_len: length of `r`. Must be 32
+ *  - inputs: Message to hash
+ *  - inputs_len: length of the inputs array
+ *
+ *  Output:
+ *  - 32-byte digest
+ *  - status code:
+ *    cttEVM_Success
+ *    cttEVM_InvalidOutputSize
+ */
+ctt_evm_status ctt_eth_evm_sha256(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+    ) __attribute__((warn_unused_result));
+
+/**
+ *  Modular exponentiation
+ *
+ *  Name: MODEXP
+ *
+ *  Inputs:
+ *  - `baseLen`:     32 bytes base integer length (in bytes)
+ *  - `exponentLen`: 32 bytes exponent length (in bytes)
+ *  - `modulusLen`:  32 bytes modulus length (in bytes)
+ *  - `base`:        base integer (`baseLen` bytes)
+ *  - `exponent`:    exponent (`exponentLen` bytes)
+ *  - `modulus`:     modulus (`modulusLen` bytes)
+ *
+ *  Output:
+ *  - baseᵉˣᵖᵒⁿᵉⁿᵗ (mod modulus)
+ *    The result buffer size `r` MUST match the modulusLen
+ *  - status code:
+ *    cttEVM_Success
+ *    cttEVM_InvalidInputSize if the lengths require more than 32-bit or 64-bit addressing (depending on hardware)
+ *    cttEVM_InvalidOutputSize
+ *
+ *  Spec
+ *    Yellow Paper Appendix E
+ *    EIP-198 - https://github.com/ethereum/EIPs/blob/master/EIPS/eip-198.md
+ *
+ *  Hardware considerations:
+ *    This procedure stack allocates a table of (16+1)*modulusLen and many stack temporaries.
+ *    Make sure to validate gas costs and reject large inputs to bound stack usage.
+ */
+ctt_evm_status ctt_eth_evm_modexp(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+
+/**
+  *  Elliptic Curve addition on BN254_Snarks
+  *  (also called alt_bn128 in Ethereum specs
+  *   and bn256 in Ethereum tests)
+  *
+  *  Name: ECADD
+  *
+  *  Inputs:
+  *  - A G1 point P with coordinates (Px, Py)
+  *  - A G1 point Q with coordinates (Qx, Qy)
+  *
+  *  Each coordinate is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [Px, Py, Qx, Qy]
+  *  If the length is less than 128 bytes, input is virtually padded with zeros.
+  *  If the length is greater than 128 bytes, input is truncated to 128 bytes.
+  *
+  *  Output
+  *  - Output buffer MUST be of length 64 bytes
+  *  - A G1 point R = P+Q with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-196
+  */
+ctt_evm_status ctt_eth_evm_bn254_g1add(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve multiplication on BN254_Snarks
+  *  (also called alt_bn128 in Ethereum specs
+  *   and bn256 in Ethereum tests)
+  *
+  *  Name: ECMUL
+  *
+  *  Inputs:
+  *  - A G1 point P with coordinates (Px, Py)
+  *  - A scalar s in 0 ..< 2²⁵⁶
+  *
+  *  Each coordinate is a 32-byte bigEndian integer
+  *  r is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [Px, Py, r]
+  *  If the length is less than 96 bytes, input is virtually padded with zeros.
+  *  If the length is greater than 96 bytes, input is truncated to 96 bytes.
+  *
+  *  Output
+  *  - Output buffer MUST be of length 64 bytes
+  *  - A G1 point R = [s]P
+  *  - Status codes:
+  *    cttEVM_Success
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-196
+  */
+ctt_evm_status ctt_eth_evm_bn254_g1mul(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve pairing check on BN254_Snarks
+  *  (also called alt_bn128 in Ethereum specs
+  *   and bn256 in Ethereum tests)
+  *
+  *  Name: ECPAIRING / Pairing check
+  *
+  *  Inputs:
+  *  - An array of [(P0, Q0), (P1, Q1), ... (Pk, Qk)] points in (G1, G2)
+  *
+  *  Output
+  *  - Output buffer MUST be of length 32 bytes
+  *  - 0 or 1 in uint256 BigEndian representation
+  *  - Status codes:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *    cttEVM_PointNotInSubgroup
+  *
+  *  Specs https://eips.ethereum.org/EIPS/eip-197
+  *        https://eips.ethereum.org/EIPS/eip-1108
+  */
+ctt_evm_status ctt_eth_evm_bn254_ecpairingcheck(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve addition on BLS12-381 G1
+  *
+  *  Name: BLS12_G1ADD
+  *
+  *  Inputs:
+  *  - A G1 point P with coordinates (Px, Py)
+  *  - A G1 point Q with coordinates (Qx, Qy)
+  *  - Input buffer MUST be 256 bytes
+  *
+  *  Each coordinate is a 64-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [Px, Py, Qx, Qy]
+  *
+  *  Inputs are NOT subgroup-checked.
+  *
+  *  Output
+  *  - Output buffer MUST be of length 128 bytes
+  *  - A G1 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status codes:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g1add(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve addition on BLS12-381 G2
+  *
+  *  Name: BLS12_G2ADD
+  *
+  *  Inputs:
+  *  - A G2 point P with coordinates (Px, Py)
+  *  - A G2 point Q with coordinates (Qx, Qy)
+  *  - Input buffer MUST be 512 bytes
+  *
+  *  Each coordinate is a 128-byte bigEndian integer pair (a+𝑖b) with 𝑖 = √-1
+  *  They are serialized concatenated in a byte array [Px, Py, Qx, Qy]
+  *
+  *  Inputs are NOT subgroup-checked.
+  *
+  *  Output
+  *  - Output buffer MUST be of length 256 bytes
+  *  - A G2 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status codes:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g2add(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve scalar multiplication on BLS12-381 G1
+  *
+  *  Name: BLS12_G1MUL
+  *
+  *  Inputs:
+  *  - A G1 point P with coordinates (Px, Py)
+  *  - A scalar s in 0 ..< 2²⁵⁶
+  *  - Input buffer MUST be 160 bytes
+  *
+  *  Each coordinate is a 64-byte bigEndian integer
+  *  s is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [Px, Py, s]
+  *
+  *  Output
+  *  - Output buffer MUST be of length 128 bytes
+  *  - A G1 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g1mul(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+     *  Elliptic Curve scalar multiplication on BLS12-381 G2
+  *
+  *  Name: BLS12_G2MUL
+  *
+  *  Inputs:
+  *  - A G2 point P with coordinates (Px, Py)
+  *  - A scalar s in 0 ..< 2²⁵⁶
+  *  - Input buffer MUST be 288 bytes
+  *
+  *  Each coordinate is a 128-byte bigEndian integer pair (a+𝑖b) with 𝑖 = √-1
+  *  s is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [Px, Py, s]
+  *
+  *  Output
+  *  - Output buffer MUST be of length 256 bytes
+  *  - A G2 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g2mul(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve addition on BLS12-381 G1
+  *
+  *  Name: BLS12_G1MSM
+  *
+  *  Inputs:
+  *  - A sequence of pairs of points
+  *    - G1 points Pᵢ with coordinates (Pᵢx, Pᵢy)
+  *    - scalar sᵢ in 0 ..< 2²⁵⁶
+  *  - Each pair MUST be 160 bytes
+  *  - The total length MUST be a multiple of 160 bytes
+  *
+  *  Each coordinate is a 64-byte bigEndian integer
+  *  s is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [(P₀x, P₀y, r₀), (P₁x, P₁y, r₁) ..., (Pₙx, Pₙy, rₙ)]
+  *
+  *  Output
+  *  - Output buffer MUST be of length 128 bytes
+  *  - A G1 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g1msm(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic Curve addition on BLS12-381 G2
+  *
+  *  Name: BLS12_G2MSM
+  *
+  *  Inputs:
+  *  - A sequence of pairs of points
+  *    - G2 points Pᵢ with coordinates (Pᵢx, Pᵢy)
+  *    - scalar sᵢ in 0 ..< 2²⁵⁶
+  *  - Each pair MUST be 288 bytes
+  *  - The total length MUST be a multiple of 288 bytes
+  *
+  *  Each coordinate is a 128-byte bigEndian integer pair (a+𝑖b) with 𝑖 = √-1
+  *  s is a 32-byte bigEndian integer
+  *  They are serialized concatenated in a byte array [(P₀x, P₀y, r₀), (P₁x, P₁y, r₁) ..., (Pₙx, Pₙy, rₙ)]
+  *
+  *  Output
+  *  - Output buffer MUST be of length 512 bytes
+  *  - A G2 point R=P+Q with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_g2msm(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Elliptic curve pairing check on BLS12-381
+  *
+  *  Name: BLS12_PAIRINGCHECK
+  *
+  *  Inputs:
+  *  - An array of [(P0, Q0), (P1, Q1), ... (Pk, Qk)] points in (G1, G2)
+  *
+  *  Output
+  *  - Output buffer MUST be of length 32 bytes
+  *  - 0 or 1 in uint256 BigEndian representation
+  *  - Status codes:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *    cttEVM_PointNotOnCurve
+  *    cttEVM_PointNotInSubgroup
+  *
+  *  specs https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_pairingcheck(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Map a field element to G1
+  *
+  *  Name: BLS12_MAP_FP_TO_G1
+  *
+  *  Input:
+  *  - A field element in 0 ..< p, p the prime field of BLS12-381
+  *  - The length MUST be a 48-byte (381-bit) number serialized in 64-byte big-endian number
+  *
+  *  Output
+  *  - Output buffer MUST be of length 64 bytes
+  *  - A G1 point R with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_map_fp_to_g1(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+/**
+  *  Map an Fp2 extension field element to G1
+  *
+  *  Name: BLS12_MAP_FP2_TO_G2
+  *
+  *  Input:
+  *  - An extension field element in (0, 0) ..< (p, p), p the prime field of BLS12-381
+  *  - The length MUST be a tuple of 48-byte (381-bit) number serialized in tuple of 64-byte big-endian numbers
+  *
+  *  Output
+  *  - Output buffer MUST be of length 128 bytes
+  *  - A G2 point R with coordinates (Rx, Ry)
+  *  - Status code:
+  *    cttEVM_Success
+  *    cttEVM_InvalidInputSize
+  *    cttEVM_InvalidOutputSize
+  *    cttEVM_IntLargerThanModulus
+  *
+  *  Spec https://eips.ethereum.org/EIPS/eip-2537
+  */
+ctt_evm_status ctt_eth_evm_bls12381_map_fp2_to_g2(
+    byte* r, ptrdiff_t r_len,
+    const byte* inputs, ptrdiff_t inputs_len
+) __attribute__((warn_unused_result));
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __CTT_H_ETHEREUM_EVM_PRECOMPILES__


### PR DESCRIPTION
This is based on and continues from #381. It now also adds a C API for the EVM precompiles module.

One example is added that generally checks the API works and it includes a test case from:

https://github.com/mratsim/constantine/blob/master/tests/protocol_ethereum_evm_precompiles/eip-2537/map_fp2_to_G2_bls.json

which passes as expected.