### PR TITLE
Go API for EVM precompiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Constantine supports the following protocols in its public API.
 
 |                                                                        | Nim                | C                  | Rust                    | Go                 |
 |------------------------------------------------------------------------|:------------------:|:------------------:|-------------------------|:------------------:|
-| Ethereum BLS signatures                                                | :white_check_mark: | :white_check_mark: | :building_construction: | :see_no_evil:      |
+| Ethereum BLS signatures                                                | :white_check_mark: | :white_check_mark: | :building_construction: | :white_check_mark: |
 | Ethereum KZG commitments for EIP-4844                                  | :white_check_mark: | :white_check_mark: | :white_check_mark:      | :white_check_mark: |
-| Ethereum Virtual Machine Precompiles (ECADD, ECMUL, ECPAIRING, MODEXP) | :white_check_mark: | :white_check_mark: | :see_no_evil:           | :see_no_evil:      |
+| Ethereum Virtual Machine Precompiles (ECADD, ECMUL, ECPAIRING, MODEXP) | :white_check_mark: | :white_check_mark: | :see_no_evil:           | :white_check_mark: |
 | Zk Accel layer for Halo2 proof system (experimental)                   | not applicable     | not applicable     | :white_check_mark:      | not applicable     |
 
 ### Elliptic Curves

--- a/constantine-go/constantine.go
+++ b/constantine-go/constantine.go
@@ -283,7 +283,7 @@ func (pub EthBlsPubKey) IsZero() bool {
 
 func (sec *EthBlsSecKey) Deserialize(src [32]byte) (bool, error) {
 	status := C.ctt_eth_bls_deserialize_seckey((*C.ctt_eth_bls_seckey)(sec),
-		(*C.byte)(unsafe.Pointer(&src[0])))
+		(*C.byte)(&src[0]))
 	if status != C.cttCodecScalar_Success {
 		err := errors.New(
 			C.GoString(C.ctt_codec_scalar_status_to_string(status)),
@@ -299,7 +299,7 @@ func (pub *EthBlsPubKey) DerivePubKey(sec EthBlsSecKey) {
 
 func (pub *EthBlsPubKey) Verify(message []byte, sig EthBlsSignature) (bool, error) {
 	status := C.ctt_eth_bls_verify((*C.ctt_eth_bls_pubkey)(pub),
-		(*C.byte)(unsafe.Pointer(&message[0])),
+		(*C.byte)(getAddr(message)),
 		(C.ptrdiff_t)(len(message)),
 		(*C.ctt_eth_bls_signature)(&sig),
 	)
@@ -401,7 +401,7 @@ func (sig *EthBlsSignature) SerializeCompressed(dst *[96]byte) (bool, error) {
 
 func (pub *EthBlsPubKey) DeserializeCompressedUnchecked(src [48]byte) (bool, error) {
 	status := C.ctt_eth_bls_deserialize_pubkey_compressed_unchecked((*C.ctt_eth_bls_pubkey)(pub),
-		(*C.byte)(unsafe.Pointer(&src[0])),
+		(*C.byte)(&src[0]),
 	)
 	if status != C.cttCodecEcc_Success {
 		err := errors.New(
@@ -414,7 +414,7 @@ func (pub *EthBlsPubKey) DeserializeCompressedUnchecked(src [48]byte) (bool, err
 
 func (sig *EthBlsSignature) DeserializeCompressedUnchecked(src [96]byte) (bool, error) {
 	status := C.ctt_eth_bls_deserialize_signature_compressed_unchecked((*C.ctt_eth_bls_signature)(sig),
-		(*C.byte)(unsafe.Pointer(&src[0])),
+		(*C.byte)(&src[0]),
 	)
 	if status != C.cttCodecEcc_Success {
 		err := errors.New(
@@ -427,7 +427,7 @@ func (sig *EthBlsSignature) DeserializeCompressedUnchecked(src [96]byte) (bool, 
 
 func (pub *EthBlsPubKey) DeserializeCompressed(src [48]byte) (bool, error) {
 	status := C.ctt_eth_bls_deserialize_pubkey_compressed((*C.ctt_eth_bls_pubkey)(pub),
-		(*C.byte)(unsafe.Pointer(&src[0])),
+		(*C.byte)(&src[0]),
 	)
 	if status != C.cttCodecEcc_Success && status != C.cttCodecEcc_PointAtInfinity {
 		err := errors.New(
@@ -440,7 +440,7 @@ func (pub *EthBlsPubKey) DeserializeCompressed(src [48]byte) (bool, error) {
 
 func (sig *EthBlsSignature) DeserializeCompressed(src [96]byte) (bool, error) {
 	status := C.ctt_eth_bls_deserialize_signature_compressed((*C.ctt_eth_bls_signature)(sig),
-		(*C.byte)(unsafe.Pointer(&src[0])),
+		(*C.byte)(&src[0]),
 	)
 	if status != C.cttCodecEcc_Success && status != C.cttCodecEcc_PointAtInfinity {
 		err := errors.New(
@@ -453,7 +453,7 @@ func (sig *EthBlsSignature) DeserializeCompressed(src [96]byte) (bool, error) {
 
 func (sig *EthBlsSignature) Sign(sec EthBlsSecKey, message []byte) {
 	C.ctt_eth_bls_sign((*C.ctt_eth_bls_signature)(sig), (*C.ctt_eth_bls_seckey)(&sec),
-		(*C.byte)(unsafe.Pointer(&message[0])),
+		(*C.byte)(getAddr(message)),
 		(C.ptrdiff_t)(len(message)),
 	)
 }
@@ -465,9 +465,9 @@ func FastAggregateVerify(pubkeys []EthBlsPubKey, message []byte, aggregate_sig E
 		)
 		return false, err
 	}
-	status := C.ctt_eth_bls_fast_aggregate_verify((*C.ctt_eth_bls_pubkey)(unsafe.Pointer(&pubkeys[0])),
+	status := C.ctt_eth_bls_fast_aggregate_verify((*C.ctt_eth_bls_pubkey)(getAddr(pubkeys)),
 		(C.ptrdiff_t)(len(pubkeys)),
-		(*C.byte)(unsafe.Pointer(&message[0])),
+		(*C.byte)(getAddr(message)),
 		(C.ptrdiff_t)(len(message)),
 		(*C.ctt_eth_bls_signature)(&aggregate_sig),
 	)
@@ -528,6 +528,7 @@ func BatchVerifySoA(pubkeys []EthBlsPubKey, messages [][]byte, signatures []EthB
 			),
 		)
 		return false, err
+
 	} else if len(pubkeys) != len(messages) {
 		err := errors.New("Number of public keys must match number of messages.")
 		return false, err

--- a/constantine-go/constantine.go
+++ b/constantine-go/constantine.go
@@ -622,3 +622,217 @@ func BatchVerifyAoS(triplets []BatchVerifyTriplet, secureRandomBytes [32]byte) (
 
 	return accum.finalVerify(), nil
 }
+
+// --------------------------------
+// ------- EVM precompiles --------
+// --------------------------------
+
+func EvmSha256(result *[32]byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_sha256((*C.byte)(&result[0]),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmModexp(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_modexp((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBn254G1Add(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bn254_g1add((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBn254G1Mul(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bn254_g1mul((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBn254G1EcPairingCheck(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bn254_ecpairingcheck((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G1Add(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g1add((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G1Mul(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g1mul((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G1Msm(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g1msm((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G2Add(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g2add((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G2Mul(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g2mul((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381G2Msm(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_g2msm((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381PairingCheck(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_pairingcheck((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381MapFpToG1(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_map_fp_to_g1((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}
+
+func EvmBls12381MapFp2ToG2(result []byte, inputs []byte) (bool, error) {
+	status := C.ctt_eth_evm_bls12381_map_fp2_to_g2((*C.byte)(getAddr(result)),
+		(C.ptrdiff_t)(len(result)),
+		(*C.byte)(getAddr(inputs)),
+		(C.ptrdiff_t)(len(inputs)),
+	)
+	if status != C.cttEVM_Success {
+		err := errors.New(
+			C.GoString(C.ctt_evm_status_to_string(status)),
+		)
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
This continues from #383 by porting over the EVM precompiles C API into Go. All test cases are ported from Nim and should all pass.