### PR TITLE
reenable nim v2.0.x in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        nim_version: [version-1-6] # version-2-0 has a regression: https://github.com/nim-lang/Nim/issues/23547
+        nim_version: [version-1-6, version-2-0]
         rust_toolchain: [stable] # [beta, nightly]
         go_toolchain: [stable]
         target:


### PR DESCRIPTION
- Disabled in https://github.com/mratsim/constantine/pull/375
- Regression reverted in backport in https://github.com/nim-lang/Nim/commit/767a901267c782765e010d106fae277b27e04981