### PR TITLE
API: argument order (breaking external Nim/C/Go/Rust EIP-4844 API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,35 @@
+# Architecture
+
+## APIs
+
+### Argument orders
+
+Function calls have arguments ordered the following way:
+
+1. Context arguments
+2. Threadpool context
+3. OUT arguments (only written to)
+4. INOUT arguments
+5. IN arguments
+
+The first context argument should allow method call syntax
+
+In C, length of arrays immediately follow the array, unless there are multiple array arguments with same length.
+If an argument is associated with a label, for domain separation for example,
+that label precedes the argument.
+
+### Return values
+
+Constantine avoids returning values bigger than the word size
+and prefer mutable out parameters.
+
+1. In some cases they introduce extra copies.
+2. There is less guarantees over stack space usage.
+3. Nim will zero the values without {.noInit.}
+   and that zeroing might not be optimized away by the compiler
+   on large inputs like `Fp12[BLS12_381]` 48\*12 bytes = 576 bytes.
+4. As we sometimes return SecretBool or status code, this keeps the API consistent.
+
+## Code organization
+
+TBD

--- a/benchmarks/bench_eth_eip4844_kzg.nim
+++ b/benchmarks/bench_eth_eip4844_kzg.nim
@@ -79,7 +79,7 @@ proc benchBlobToKzgCommitment(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
   block:
     bench("blob_to_kzg_commitment", $tp.numThreads & " threads", iters):
       var commitment {.noInit.}: array[48, byte]
-      doAssert cttEthKzg_Success == ctx.blob_to_kzg_commitment_parallel(tp, commitment, b.blobs[0].addr)
+      doAssert cttEthKzg_Success == tp.blob_to_kzg_commitment_parallel(ctx, commitment, b.blobs[0].addr)
   let stopParallel = getMonotime()
 
   tp.shutdown()
@@ -108,7 +108,7 @@ proc benchComputeKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) 
     bench("compute_kzg_proof", $tp.numThreads & " threads", iters):
       var proof {.noInit.}: array[48, byte]
       var eval_at_challenge {.noInit.}: array[32, byte]
-      doAssert cttEthKzg_Success == ctx.compute_kzg_proof_parallel(tp, proof, eval_at_challenge, b.blobs[0].addr, b.challenge)
+      doAssert cttEthKzg_Success == tp.compute_kzg_proof_parallel(ctx, proof, eval_at_challenge, b.blobs[0].addr, b.challenge)
   let stopParallel = getMonotime()
 
   tp.shutdown()
@@ -135,7 +135,7 @@ proc benchComputeBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
   block:
     bench("compute_blob_kzg_proof", $tp.numThreads & " threads", iters):
       var proof {.noInit.}: array[48, byte]
-      doAssert cttEthKzg_Success == ctx.compute_blob_kzg_proof_parallel(tp, proof, b.blobs[0].addr, b.commitments[0])
+      doAssert cttEthKzg_Success == tp.compute_blob_kzg_proof_parallel(ctx, proof, b.blobs[0].addr, b.commitments[0])
   let stopParallel = getMonotime()
 
   tp.shutdown()
@@ -167,7 +167,7 @@ proc benchVerifyBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: in
   let startParallel = getMonotime()
   block:
     bench("verify_blob_kzg_proof", $tp.numThreads & " threads", iters):
-      discard ctx.verify_blob_kzg_proof_parallel(tp, b.blobs[0].addr, b.commitments[0], b.proofs[0])
+      discard tp.verify_blob_kzg_proof_parallel(ctx, b.blobs[0].addr, b.commitments[0], b.proofs[0])
   let stopParallel = getMonotime()
 
   tp.shutdown()
@@ -205,8 +205,8 @@ proc benchVerifyBlobKzgProofBatch(b: BenchSet, ctx: ptr EthereumKZGContext, iter
     let startParallel = getMonotime()
     block:
       bench("verify_blob_kzg_proof (batch " & $i & ')', $tp.numThreads & " threads", iters):
-        discard ctx.verify_blob_kzg_proof_batch_parallel(
-                  tp,
+        discard tp.verify_blob_kzg_proof_batch_parallel(
+                  ctx,
                   b.blobs.asUnchecked(),
                   b.commitments.asUnchecked(),
                   b.proofs.asUnchecked(),

--- a/constantine-go/constantine.go
+++ b/constantine-go/constantine.go
@@ -57,6 +57,7 @@ type (
 
 type EthKzgContext struct {
 	cCtx *C.ctt_eth_kzg_context
+	threadpool Threadpool
 }
 
 func EthKzgContextNew(trustedSetupFile string) (ctx EthKzgContext, err error) {
@@ -72,7 +73,12 @@ func EthKzgContextNew(trustedSetupFile string) (ctx EthKzgContext, err error) {
 			C.GoString(C.ctt_eth_trusted_setup_status_to_string(status)),
 		)
 	}
+	ctx.threadpool.ctx = nil
 	return ctx, err
+}
+
+func (ctx *EthKzgContext) SetThreadpool(tp Threadpool) {
+	ctx.threadpool = tp
 }
 
 func (ctx EthKzgContext) Delete() {
@@ -183,9 +189,12 @@ func (ctx EthKzgContext) VerifyBlobKzgProofBatch(blobs []EthBlob, commitments []
 // Ethereum EIP-4844 KZG API - Parallel
 // -----------------------------------------------------
 
-func (ctx EthKzgContext) BlobToKZGCommitmentParallel(tp Threadpool, blob EthBlob) (commitment EthKzgCommitment, err error) {
+func (ctx EthKzgContext) BlobToKZGCommitmentParallel(blob EthBlob) (commitment EthKzgCommitment, err error) {
+	if ctx.threadpool.ctx == nil {
+		return commitment, errors.New("BlobToKZGCommitmentParallel: The threadpool is not configured.")
+	}
 	status := C.ctt_eth_kzg_blob_to_kzg_commitment_parallel(
-		ctx.cCtx, tp.ctx,
+		ctx.threadpool.ctx, ctx.cCtx,
 		(*C.ctt_eth_kzg_commitment)(unsafe.Pointer(&commitment)),
 		(*C.ctt_eth_kzg_blob)(unsafe.Pointer(&blob)),
 	)
@@ -197,9 +206,12 @@ func (ctx EthKzgContext) BlobToKZGCommitmentParallel(tp Threadpool, blob EthBlob
 	return commitment, err
 }
 
-func (ctx EthKzgContext) ComputeKzgProofParallel(tp Threadpool, blob EthBlob, z EthKzgChallenge) (proof EthKzgProof, y EthKzgEvalAtChallenge, err error) {
+func (ctx EthKzgContext) ComputeKzgProofParallel(blob EthBlob, z EthKzgChallenge) (proof EthKzgProof, y EthKzgEvalAtChallenge, err error) {
+	if ctx.threadpool.ctx == nil {
+		return proof, y, errors.New("ComputeKzgProofParallel: The Constantine's threadpool is not configured.")
+	}
 	status := C.ctt_eth_kzg_compute_kzg_proof_parallel(
-		ctx.cCtx, tp.ctx,
+		ctx.threadpool.ctx, ctx.cCtx,
 		(*C.ctt_eth_kzg_proof)(unsafe.Pointer(&proof)),
 		(*C.ctt_eth_kzg_eval_at_challenge)(unsafe.Pointer(&y)),
 		(*C.ctt_eth_kzg_blob)(unsafe.Pointer(&blob)),
@@ -213,9 +225,12 @@ func (ctx EthKzgContext) ComputeKzgProofParallel(tp Threadpool, blob EthBlob, z 
 	return proof, y, err
 }
 
-func (ctx EthKzgContext) ComputeBlobKzgProofParallel(tp Threadpool, blob EthBlob, commitment EthKzgCommitment) (proof EthKzgProof, err error) {
+func (ctx EthKzgContext) ComputeBlobKzgProofParallel(blob EthBlob, commitment EthKzgCommitment) (proof EthKzgProof, err error) {
+	if ctx.threadpool.ctx == nil {
+		return proof, errors.New("ComputeBlobKzgProofParallel: The threadpool is not configured.")
+	}
 	status := C.ctt_eth_kzg_compute_blob_kzg_proof_parallel(
-		ctx.cCtx, tp.ctx,
+		ctx.threadpool.ctx, ctx.cCtx,
 		(*C.ctt_eth_kzg_proof)(unsafe.Pointer(&proof)),
 		(*C.ctt_eth_kzg_blob)(unsafe.Pointer(&blob)),
 		(*C.ctt_eth_kzg_commitment)(unsafe.Pointer(&commitment)),
@@ -228,9 +243,12 @@ func (ctx EthKzgContext) ComputeBlobKzgProofParallel(tp Threadpool, blob EthBlob
 	return proof, err
 }
 
-func (ctx EthKzgContext) VerifyBlobKzgProofParallel(tp Threadpool, blob EthBlob, commitment EthKzgCommitment, proof EthKzgProof) (bool, error) {
+func (ctx EthKzgContext) VerifyBlobKzgProofParallel(blob EthBlob, commitment EthKzgCommitment, proof EthKzgProof) (bool, error) {
+	if ctx.threadpool.ctx == nil {
+		return false, errors.New("VerifyBlobKzgProofParallel: The threadpool is not configured.")
+	}
 	status := C.ctt_eth_kzg_verify_blob_kzg_proof_parallel(
-		ctx.cCtx, tp.ctx,
+		ctx.threadpool.ctx, ctx.cCtx,
 		(*C.ctt_eth_kzg_blob)(unsafe.Pointer(&blob)),
 		(*C.ctt_eth_kzg_commitment)(unsafe.Pointer(&commitment)),
 		(*C.ctt_eth_kzg_proof)(unsafe.Pointer(&proof)),
@@ -244,14 +262,15 @@ func (ctx EthKzgContext) VerifyBlobKzgProofParallel(tp Threadpool, blob EthBlob,
 	return true, nil
 }
 
-func (ctx EthKzgContext) VerifyBlobKzgProofBatchParallel(tp Threadpool, blobs []EthBlob, commitments []EthKzgCommitment, proofs []EthKzgProof, secureRandomBytes [32]byte) (bool, error) {
-
+func (ctx EthKzgContext) VerifyBlobKzgProofBatchParallel(blobs []EthBlob, commitments []EthKzgCommitment, proofs []EthKzgProof, secureRandomBytes [32]byte) (bool, error) {
 	if len(blobs) != len(commitments) || len(blobs) != len(proofs) {
 		return false, errors.New("VerifyBlobKzgProofBatch: Lengths of inputs do not match.")
 	}
-
+	if ctx.threadpool.ctx == nil {
+		return false, errors.New("VerifyBlobKzgProofBatch: The threadpool is not configured.")
+	}
 	status := C.ctt_eth_kzg_verify_blob_kzg_proof_batch_parallel(
-		ctx.cCtx, tp.ctx,
+		ctx.threadpool.ctx, ctx.cCtx,
 		*(**C.ctt_eth_kzg_blob)(unsafe.Pointer(&blobs)),
 		*(**C.ctt_eth_kzg_commitment)(unsafe.Pointer(&commitments)),
 		*(**C.ctt_eth_kzg_proof)(unsafe.Pointer(&proofs)),

--- a/constantine-rust/constantine-ethereum-kzg/src/lib.rs
+++ b/constantine-rust/constantine-ethereum-kzg/src/lib.rs
@@ -16,19 +16,25 @@ use std::{ffi::CString, path::Path};
 // ------------------------------------------------------------
 
 #[derive(Debug)]
-pub struct EthKzgContext {
+pub struct EthKzgContext<'tp> {
     ctx: *const ctt_eth_kzg_context,
+    threadpool: Option<&'tp Threadpool>,
 }
 
-impl Drop for EthKzgContext {
+pub struct EthKzgContextBuilder<'tp> {
+    ctx: Option<*const ctt_eth_kzg_context>,
+    threadpool: Option<&'tp Threadpool>,
+}
+
+impl<'tp> Drop for EthKzgContext<'tp> {
     #[inline(always)]
     fn drop(&mut self) {
         unsafe { ctt_eth_trusted_setup_delete(self.ctx as *mut ctt_eth_kzg_context) }
     }
 }
 
-impl EthKzgContext {
-    pub fn load_trusted_setup(file_path: &Path) -> Result<Self, ctt_eth_trusted_setup_status> {
+impl<'tp> EthKzgContextBuilder<'tp> {
+    pub fn load_trusted_setup(self, file_path: &Path) -> Result<Self, ctt_eth_trusted_setup_status> {
         // The joy of OS Paths / C Paths:
         // https://users.rust-lang.org/t/easy-way-to-pass-a-path-to-c/51829
         // https://doc.rust-lang.org/std/ffi/index.html#conversions
@@ -64,9 +70,38 @@ impl EthKzgContext {
             )
         };
         match status {
-            ctt_eth_trusted_setup_status::cttEthTS_Success => Ok(Self { ctx }),
+            ctt_eth_trusted_setup_status::cttEthTS_Success => Ok(Self { ctx: Some(ctx), threadpool: self.threadpool }),
             _ => Err(status),
         }
+    }
+
+    pub fn set_threadpool(self, tp: &'tp Threadpool) -> Self {
+        // Copy all other parameters
+        let Self { ctx, .. } = self;
+        // Return with threadpool
+        Self { ctx, threadpool: Some(tp)}
+    }
+
+    pub fn build(self) -> Result<EthKzgContext<'tp>, ctt_eth_trusted_setup_status> {
+        let ctx = self.ctx.ok_or(ctt_eth_trusted_setup_status::cttEthTS_MissingOrInaccessibleFile)?;
+        Ok(EthKzgContext{
+            ctx,
+            threadpool: self.threadpool,
+        })
+    }
+
+}
+
+impl<'tp> EthKzgContext<'tp> {
+    pub fn builder() -> EthKzgContextBuilder<'tp> {
+        EthKzgContextBuilder{ctx: None, threadpool: None}
+    }
+
+    pub fn load_trusted_setup(file_path: &Path) -> Result<Self, ctt_eth_trusted_setup_status> {
+        Ok(Self::builder()
+            .load_trusted_setup(file_path)?
+            .build()
+            .expect("Trusted setup should be loaded properly"))
     }
 
     #[inline]
@@ -215,14 +250,13 @@ impl EthKzgContext {
     #[inline]
     pub fn blob_to_kzg_commitment_parallel(
         &self,
-        tp: &Threadpool,
         blob: &[u8; 4096 * 32],
     ) -> Result<[u8; 48], ctt_eth_kzg_status> {
         let mut result: MaybeUninit<[u8; 48]> = MaybeUninit::uninit();
         unsafe {
             let status = ctt_eth_kzg_blob_to_kzg_commitment_parallel(
+                self.threadpool.expect("Threadpool has been set").get_private_context(),
                 self.ctx,
-                tp.get_private_context(),
                 result.as_mut_ptr() as *mut ctt_eth_kzg_commitment,
                 blob.as_ptr() as *const ctt_eth_kzg_blob,
             );
@@ -236,7 +270,6 @@ impl EthKzgContext {
     #[inline]
     pub fn compute_kzg_proof_parallel(
         &self,
-        tp: &Threadpool,
         blob: &[u8; 4096 * 32],
         z_challenge: &[u8; 32],
     ) -> Result<([u8; 48], [u8; 32]), ctt_eth_kzg_status> {
@@ -244,8 +277,8 @@ impl EthKzgContext {
         let mut y_eval = MaybeUninit::<[u8; 32]>::uninit();
         unsafe {
             let status = ctt_eth_kzg_compute_kzg_proof_parallel(
+                self.threadpool.expect("Threadpool has been set").get_private_context(),
                 self.ctx,
-                tp.get_private_context(),
                 proof.as_mut_ptr() as *mut ctt_eth_kzg_proof,
                 y_eval.as_mut_ptr() as *mut ctt_eth_kzg_eval_at_challenge,
                 blob.as_ptr() as *const ctt_eth_kzg_blob,
@@ -263,15 +296,14 @@ impl EthKzgContext {
     #[inline]
     pub fn compute_blob_kzg_proof_parallel(
         &self,
-        tp: &Threadpool,
         blob: &[u8; 4096 * 32],
         commitment: &[u8; 48],
     ) -> Result<[u8; 48], ctt_eth_kzg_status> {
         let mut proof = MaybeUninit::<[u8; 48]>::uninit();
         unsafe {
             let status = ctt_eth_kzg_compute_blob_kzg_proof_parallel(
+                self.threadpool.expect("Threadpool has been set").get_private_context(),
                 self.ctx,
-                tp.get_private_context(),
                 proof.as_mut_ptr() as *mut ctt_eth_kzg_proof,
                 blob.as_ptr() as *const ctt_eth_kzg_blob,
                 commitment.as_ptr() as *const ctt_eth_kzg_commitment,
@@ -286,15 +318,14 @@ impl EthKzgContext {
     #[inline]
     pub fn verify_blob_kzg_proof_parallel(
         &self,
-        tp: &Threadpool,
         blob: &[u8; 4096 * 32],
         commitment: &[u8; 48],
         proof: &[u8; 48],
     ) -> Result<bool, ctt_eth_kzg_status> {
         let status = unsafe {
             ctt_eth_kzg_verify_blob_kzg_proof_parallel(
+                self.threadpool.expect("Threadpool has been set").get_private_context(),
                 self.ctx,
-                tp.get_private_context(),
                 blob.as_ptr() as *const ctt_eth_kzg_blob,
                 commitment.as_ptr() as *const ctt_eth_kzg_commitment,
                 proof.as_ptr() as *const ctt_eth_kzg_proof,
@@ -310,7 +341,6 @@ impl EthKzgContext {
     #[inline]
     pub fn verify_blob_kzg_proof_batch_parallel(
         &self,
-        tp: &Threadpool,
         blobs: &[[u8; 4096 * 32]],
         commitments: &[[u8; 48]],
         proofs: &[[u8; 48]],
@@ -322,8 +352,8 @@ impl EthKzgContext {
 
         let status = unsafe {
             ctt_eth_kzg_verify_blob_kzg_proof_batch_parallel(
+                self.threadpool.expect("Threadpool has been set").get_private_context(),
                 self.ctx,
-                tp.get_private_context(),
                 blobs.as_ptr() as *const ctt_eth_kzg_blob,
                 commitments.as_ptr() as *const ctt_eth_kzg_commitment,
                 proofs.as_ptr() as *const ctt_eth_kzg_proof,

--- a/constantine-rust/constantine-ethereum-kzg/tests/t_ethereum_kzg_vectors.rs
+++ b/constantine-rust/constantine-ethereum-kzg/tests/t_ethereum_kzg_vectors.rs
@@ -480,10 +480,13 @@ fn t_blob_to_kzg_commitment_parallel() {
         output: OptBytes<48>,
     }
 
-    let ctx = EthKzgContext::load_trusted_setup(Path::new(SRS_PATH))
-        .expect("Trusted setup should be loaded without error.");
-
     let tp = Threadpool::new(hardware::get_num_threads_os());
+    let ctx = EthKzgContext::builder()
+                .load_trusted_setup(Path::new(SRS_PATH))
+                .expect("Trusted setup loaded successfully")
+                .set_threadpool(&tp)
+                .build()
+                .expect("EthKzgContext initialized successfully");
 
     let test_files: Vec<PathBuf> = glob(BLOB_TO_KZG_COMMITMENT_TESTS)
         .unwrap()
@@ -512,7 +515,7 @@ fn t_blob_to_kzg_commitment_parallel() {
             continue;
         };
 
-        match ctx.blob_to_kzg_commitment_parallel(&tp, &*blob) {
+        match ctx.blob_to_kzg_commitment_parallel(&*blob) {
             Ok(commitment) => {
                 assert_eq!(commitment, *test.output.opt_bytes.0.unwrap());
                 println!("{}=> SUCCESS", tv);
@@ -540,10 +543,13 @@ fn t_compute_kzg_proof_parallel() {
         output: Option<(OptBytes<48>, OptBytes<32>)>,
     }
 
-    let ctx = EthKzgContext::load_trusted_setup(Path::new(SRS_PATH))
-        .expect("Trusted setup should be loaded without error.");
-
     let tp = Threadpool::new(hardware::get_num_threads_os());
+    let ctx = EthKzgContext::builder()
+                .load_trusted_setup(Path::new(SRS_PATH))
+                .expect("Trusted setup loaded successfully")
+                .set_threadpool(&tp)
+                .build()
+                .expect("EthKzgContext initialized successfully");
 
     let test_files: Vec<PathBuf> = glob(COMPUTE_KZG_PROOF_TESTS)
         .unwrap()
@@ -573,7 +579,7 @@ fn t_compute_kzg_proof_parallel() {
             continue;
         };
 
-        match ctx.compute_kzg_proof_parallel(&tp, &*blob, &*challenge) {
+        match ctx.compute_kzg_proof_parallel(&*blob, &*challenge) {
             Ok((proof, eval)) => {
                 let (true_proof, true_eval) = test.output.unwrap();
                 assert_eq!(proof, *true_proof.opt_bytes.0.unwrap());
@@ -602,10 +608,13 @@ fn t_compute_blob_kzg_proof_parallel() {
         output: OptBytes<48>,
     }
 
-    let ctx = EthKzgContext::load_trusted_setup(Path::new(SRS_PATH))
-        .expect("Trusted setup should be loaded without error.");
-
     let tp = Threadpool::new(hardware::get_num_threads_os());
+    let ctx = EthKzgContext::builder()
+                .load_trusted_setup(Path::new(SRS_PATH))
+                .expect("Trusted setup loaded successfully")
+                .set_threadpool(&tp)
+                .build()
+                .expect("EthKzgContext initialized successfully");
 
     let test_files: Vec<PathBuf> = glob(COMPUTE_BLOB_KZG_PROOF_TESTS)
         .unwrap()
@@ -637,7 +646,7 @@ fn t_compute_blob_kzg_proof_parallel() {
             continue;
         };
 
-        match ctx.compute_blob_kzg_proof_parallel(&tp, &*blob, &*commitment) {
+        match ctx.compute_blob_kzg_proof_parallel(&*blob, &*commitment) {
             Ok(proof) => {
                 assert_eq!(proof, *test.output.opt_bytes.0.unwrap());
                 println!("{}=> SUCCESS", tv);
@@ -666,10 +675,13 @@ fn t_verify_blob_kzg_proof_parallel() {
         output: Option<bool>,
     }
 
-    let ctx = EthKzgContext::load_trusted_setup(Path::new(SRS_PATH))
-        .expect("Trusted setup should be loaded without error.");
-
     let tp = Threadpool::new(hardware::get_num_threads_os());
+    let ctx = EthKzgContext::builder()
+                .load_trusted_setup(Path::new(SRS_PATH))
+                .expect("Trusted setup loaded successfully")
+                .set_threadpool(&tp)
+                .build()
+                .expect("EthKzgContext initialized successfully");
 
     let test_files: Vec<PathBuf> = glob(VERIFY_BLOB_KZG_PROOF_TESTS)
         .unwrap()
@@ -702,7 +714,7 @@ fn t_verify_blob_kzg_proof_parallel() {
             continue;
         };
 
-        match ctx.verify_blob_kzg_proof_parallel(&tp, &*blob, &*commitment, &*proof) {
+        match ctx.verify_blob_kzg_proof_parallel(&*blob, &*commitment, &*proof) {
             Ok(valid) => {
                 assert_eq!(valid, test.output.unwrap());
                 if valid {
@@ -735,10 +747,13 @@ fn t_verify_blob_kzg_proof_batch_parallel() {
         output: Option<bool>,
     }
 
-    let ctx = EthKzgContext::load_trusted_setup(Path::new(SRS_PATH))
-        .expect("Trusted setup should be loaded without error.");
-
     let tp = Threadpool::new(hardware::get_num_threads_os());
+    let ctx = EthKzgContext::builder()
+                .load_trusted_setup(Path::new(SRS_PATH))
+                .expect("Trusted setup loaded successfully")
+                .set_threadpool(&tp)
+                .build()
+                .expect("EthKzgContext initialized successfully");
 
     let mut secure_random_bytes = [0u8; 32];
     csprngs::sysrand(secure_random_bytes.as_mut_slice());
@@ -788,7 +803,6 @@ fn t_verify_blob_kzg_proof_batch_parallel() {
             .collect();
 
         match ctx.verify_blob_kzg_proof_batch_parallel(
-            &tp,
             &blobs,
             &commitments,
             &proofs,

--- a/constantine-rust/constantine-sys/src/bindings32.rs
+++ b/constantine-rust/constantine-sys/src/bindings32.rs
@@ -5010,8 +5010,8 @@ extern "C" {
     #[must_use]
     #[doc = " Compute a commitment to the `blob`.\n  The commitment can be verified without needing the full `blob`\n\n  Mathematical description\n    commitment = [p(τ)]₁\n\n    The blob data is used as a polynomial,\n    the polynomial is evaluated at powers of tau τ, a trusted setup.\n\n    Verification can be done by verifying the relation:\n      proof.(τ - z) = p(τ)-p(z)\n    which doesn't require the full blob but only evaluations of it\n    - at τ, p(τ) is the commitment\n    - and at the verification challenge z.\n\n    with proof = [(p(τ) - p(z)) / (τ-z)]₁"]
     pub fn ctt_eth_kzg_blob_to_kzg_commitment_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         dst: *mut ctt_eth_kzg_commitment,
         blob: *const ctt_eth_kzg_blob,
     ) -> ctt_eth_kzg_status;
@@ -5020,8 +5020,8 @@ extern "C" {
     #[must_use]
     #[doc = " Generate:\n  - A proof of correct evaluation.\n  - y = p(z), the evaluation of p at the challenge z, with p being the Blob interpreted as a polynomial.\n\n  Mathematical description\n    [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁, with p(τ) being the commitment, i.e. the evaluation of p at the powers of τ\n    The notation [a]₁ corresponds to the scalar multiplication of a by the generator of 𝔾1\n\n    Verification can be done by verifying the relation:\n      proof.(τ - z) = p(τ)-p(z)\n    which doesn't require the full blob but only evaluations of it\n    - at τ, p(τ) is the commitment\n    - and at the verification challenge z."]
     pub fn ctt_eth_kzg_compute_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         proof: *mut ctt_eth_kzg_proof,
         y: *mut ctt_eth_kzg_eval_at_challenge,
         blob: *const ctt_eth_kzg_blob,
@@ -5032,8 +5032,8 @@ extern "C" {
     #[must_use]
     #[doc = " Given a blob, return the KZG proof that is used to verify it against the commitment.\n  This method does not verify that the commitment is correct with respect to `blob`."]
     pub fn ctt_eth_kzg_compute_blob_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         proof: *mut ctt_eth_kzg_proof,
         blob: *const ctt_eth_kzg_blob,
         commitment: *const ctt_eth_kzg_commitment,
@@ -5043,8 +5043,8 @@ extern "C" {
     #[must_use]
     #[doc = " Given a blob and a KZG proof, verify that the blob data corresponds to the provided commitment."]
     pub fn ctt_eth_kzg_verify_blob_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         blob: *const ctt_eth_kzg_blob,
         commitment: *const ctt_eth_kzg_commitment,
         proof: *const ctt_eth_kzg_proof,
@@ -5054,8 +5054,8 @@ extern "C" {
     #[must_use]
     #[doc = " Verify `n` (blob, commitment, proof) sets efficiently\n\n  `n` is the number of verifications set\n  - if n is negative, this procedure returns verification failure\n  - if n is zero, this procedure returns verification success\n\n  `secure_random_bytes` random bytes must come from a cryptographically secure RNG\n  or computed through the Fiat-Shamir heuristic.\n  It serves as a random number\n  that is not in the control of a potential attacker to prevent potential\n  rogue commitments attacks due to homomorphic properties of pairings,\n  i.e. commitments that are linear combination of others and sum would be zero."]
     pub fn ctt_eth_kzg_verify_blob_kzg_proof_batch_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         blobs: *const ctt_eth_kzg_blob,
         commitments: *const ctt_eth_kzg_commitment,
         proofs: *const ctt_eth_kzg_proof,

--- a/constantine-rust/constantine-sys/src/bindings64.rs
+++ b/constantine-rust/constantine-sys/src/bindings64.rs
@@ -5010,8 +5010,8 @@ extern "C" {
     #[must_use]
     #[doc = " Compute a commitment to the `blob`.\n  The commitment can be verified without needing the full `blob`\n\n  Mathematical description\n    commitment = [p(τ)]₁\n\n    The blob data is used as a polynomial,\n    the polynomial is evaluated at powers of tau τ, a trusted setup.\n\n    Verification can be done by verifying the relation:\n      proof.(τ - z) = p(τ)-p(z)\n    which doesn't require the full blob but only evaluations of it\n    - at τ, p(τ) is the commitment\n    - and at the verification challenge z.\n\n    with proof = [(p(τ) - p(z)) / (τ-z)]₁"]
     pub fn ctt_eth_kzg_blob_to_kzg_commitment_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         dst: *mut ctt_eth_kzg_commitment,
         blob: *const ctt_eth_kzg_blob,
     ) -> ctt_eth_kzg_status;
@@ -5020,8 +5020,8 @@ extern "C" {
     #[must_use]
     #[doc = " Generate:\n  - A proof of correct evaluation.\n  - y = p(z), the evaluation of p at the challenge z, with p being the Blob interpreted as a polynomial.\n\n  Mathematical description\n    [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁, with p(τ) being the commitment, i.e. the evaluation of p at the powers of τ\n    The notation [a]₁ corresponds to the scalar multiplication of a by the generator of 𝔾1\n\n    Verification can be done by verifying the relation:\n      proof.(τ - z) = p(τ)-p(z)\n    which doesn't require the full blob but only evaluations of it\n    - at τ, p(τ) is the commitment\n    - and at the verification challenge z."]
     pub fn ctt_eth_kzg_compute_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         proof: *mut ctt_eth_kzg_proof,
         y: *mut ctt_eth_kzg_eval_at_challenge,
         blob: *const ctt_eth_kzg_blob,
@@ -5032,8 +5032,8 @@ extern "C" {
     #[must_use]
     #[doc = " Given a blob, return the KZG proof that is used to verify it against the commitment.\n  This method does not verify that the commitment is correct with respect to `blob`."]
     pub fn ctt_eth_kzg_compute_blob_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         proof: *mut ctt_eth_kzg_proof,
         blob: *const ctt_eth_kzg_blob,
         commitment: *const ctt_eth_kzg_commitment,
@@ -5043,8 +5043,8 @@ extern "C" {
     #[must_use]
     #[doc = " Given a blob and a KZG proof, verify that the blob data corresponds to the provided commitment."]
     pub fn ctt_eth_kzg_verify_blob_kzg_proof_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         blob: *const ctt_eth_kzg_blob,
         commitment: *const ctt_eth_kzg_commitment,
         proof: *const ctt_eth_kzg_proof,
@@ -5054,8 +5054,8 @@ extern "C" {
     #[must_use]
     #[doc = " Verify `n` (blob, commitment, proof) sets efficiently\n\n  `n` is the number of verifications set\n  - if n is negative, this procedure returns verification failure\n  - if n is zero, this procedure returns verification success\n\n  `secure_random_bytes` random bytes must come from a cryptographically secure RNG\n  or computed through the Fiat-Shamir heuristic.\n  It serves as a random number\n  that is not in the control of a potential attacker to prevent potential\n  rogue commitments attacks due to homomorphic properties of pairings,\n  i.e. commitments that are linear combination of others and sum would be zero."]
     pub fn ctt_eth_kzg_verify_blob_kzg_proof_batch_parallel(
-        ctx: *const ctt_eth_kzg_context,
         tp: *const ctt_threadpool,
+        ctx: *const ctt_eth_kzg_context,
         blobs: *const ctt_eth_kzg_blob,
         commitments: *const ctt_eth_kzg_commitment,
         proofs: *const ctt_eth_kzg_proof,

--- a/constantine/commitments_setups/ethereum_kzg_srs.nim
+++ b/constantine/commitments_setups/ethereum_kzg_srs.nim
@@ -268,6 +268,7 @@ proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
     # Bit-reversal permutations
     ctx.srs_lagrange_g1.evals.bit_reversal_permutation()
     ctx.domain.rootsOfUnity.bit_reversal_permutation()
+    ctx.domain.isBitReversed = true
 
   return tsSuccess
 

--- a/constantine/eth_verkle_ipa/ipa_prover.nim
+++ b/constantine/eth_verkle_ipa/ipa_prover.nim
@@ -145,7 +145,7 @@ func createIPAProof*[IPAProof](
 
   transcript.domain_separator(asBytes"ipa")
   var b: array[EthVerkleDomain, Fr[Banderwagon]]
-  b.getLagrangeBasisPolysAt(ic.domain, evalPoint)
+  ic.domain.getLagrangeBasisPolysAt(b, evalPoint)
 
   var innerProd {.noInit.}: Fr[Banderwagon]
   innerProd.computeInnerProducts(a, b)

--- a/constantine/eth_verkle_ipa/ipa_verifier.nim
+++ b/constantine/eth_verkle_ipa/ipa_verifier.nim
@@ -45,7 +45,7 @@ func checkIPAProof* (ic: IPASettings, transcript: var CryptoHash, got: var EC_P,
 
   var b {.noInit.}: array[EthVerkleDomain, Fr[Banderwagon]]
   # b.computeBarycentricCoefficients(ic.precompWeights,evalPoint)
-  b.getLagrangeBasisPolysAt(ic.domain, evalPoint)
+  ic.domain.getLagrangeBasisPolysAt(b, evalPoint)
 
   transcript.pointAppend(asBytes"C", commitment)
   transcript.scalarAppend(asBytes"input point", evalPoint.toBig())

--- a/constantine/eth_verkle_ipa/multiproof.nim
+++ b/constantine/eth_verkle_ipa/multiproof.nim
@@ -115,7 +115,7 @@ func createMultiProof* [MultiProof] (res: var MultiProof, transcript: var Crypto
       continue
 
     var quotient {.noInit.}: PolynomialEval[EthVerkleDomain, Fr[Banderwagon]]
-    quotient.differenceQuotientEvalInDomain(groupedFs[i], i, ipaSetting.domain)
+    ipaSetting.domain.differenceQuotientEvalInDomain(quotient, groupedFs[i], i)
 
     for j in  0 ..< EthVerkleDomain:
       gx[j] += quotient.evals[j]

--- a/include/constantine/protocols/ethereum_eip4844_kzg_parallel.h
+++ b/include/constantine/protocols/ethereum_eip4844_kzg_parallel.h
@@ -38,8 +38,8 @@ extern "C" {
  *    with proof = [(p(τ) - p(z)) / (τ-z)]₁
  */
 ctt_eth_kzg_status ctt_eth_kzg_blob_to_kzg_commitment_parallel(
-        const ctt_eth_kzg_context* ctx,
         const ctt_threadpool* tp,
+        const ctt_eth_kzg_context* ctx,
         ctt_eth_kzg_commitment* dst,
         const ctt_eth_kzg_blob* blob
 ) __attribute__((warn_unused_result));
@@ -59,8 +59,8 @@ ctt_eth_kzg_status ctt_eth_kzg_blob_to_kzg_commitment_parallel(
  *    - and at the verification challenge z.
  */
 ctt_eth_kzg_status ctt_eth_kzg_compute_kzg_proof_parallel(
-        const ctt_eth_kzg_context* ctx,
         const ctt_threadpool* tp,
+        const ctt_eth_kzg_context* ctx,
         ctt_eth_kzg_proof* proof,
         ctt_eth_kzg_eval_at_challenge* y,
         const ctt_eth_kzg_blob* blob,
@@ -71,8 +71,8 @@ ctt_eth_kzg_status ctt_eth_kzg_compute_kzg_proof_parallel(
  *  This method does not verify that the commitment is correct with respect to `blob`.
  */
 ctt_eth_kzg_status ctt_eth_kzg_compute_blob_kzg_proof_parallel(
-        const ctt_eth_kzg_context* ctx,
         const ctt_threadpool* tp,
+        const ctt_eth_kzg_context* ctx,
         ctt_eth_kzg_proof* proof,
         const ctt_eth_kzg_blob* blob,
         const ctt_eth_kzg_commitment* commitment
@@ -81,8 +81,8 @@ ctt_eth_kzg_status ctt_eth_kzg_compute_blob_kzg_proof_parallel(
 /** Given a blob and a KZG proof, verify that the blob data corresponds to the provided commitment.
  */
 ctt_eth_kzg_status ctt_eth_kzg_verify_blob_kzg_proof_parallel(
-        const ctt_eth_kzg_context* ctx,
         const ctt_threadpool* tp,
+        const ctt_eth_kzg_context* ctx,
         const ctt_eth_kzg_blob* blob,
         const ctt_eth_kzg_commitment* commitment,
         const ctt_eth_kzg_proof* proof
@@ -102,8 +102,8 @@ ctt_eth_kzg_status ctt_eth_kzg_verify_blob_kzg_proof_parallel(
  *  i.e. commitments that are linear combination of others and sum would be zero.
  */
 ctt_eth_kzg_status ctt_eth_kzg_verify_blob_kzg_proof_batch_parallel(
-        const ctt_eth_kzg_context* ctx,
         const ctt_threadpool* tp,
+        const ctt_eth_kzg_context* ctx,
         const ctt_eth_kzg_blob blobs[],
         const ctt_eth_kzg_commitment commitments[],
         const ctt_eth_kzg_proof proofs[],

--- a/tests/t_ethereum_eip4844_deneb_kzg_parallel.nim
+++ b/tests/t_ethereum_eip4844_deneb_kzg_parallel.nim
@@ -139,7 +139,7 @@ testGen(blob_to_kzg_commitment, testVector):
 
   var commitment: array[48, byte]
 
-  let status = ctx.blob_to_kzg_commitment_parallel(tp, commitment, blob[].addr)
+  let status = tp.blob_to_kzg_commitment_parallel(ctx, commitment, blob[].addr)
   stdout.write "[" & $status & "]\n"
 
   if status == cttEthKzg_Success:
@@ -157,7 +157,7 @@ testGen(compute_kzg_proof, testVector):
   var proof: array[48, byte]
   var y: array[32, byte]
 
-  let status = ctx.compute_kzg_proof_parallel(tp, proof, y, blob[].addr, z[])
+  let status = tp.compute_kzg_proof_parallel(ctx, proof, y, blob[].addr, z[])
   stdout.write "[" & $status & "]\n"
 
   if status == cttEthKzg_Success:
@@ -195,7 +195,7 @@ testGen(compute_blob_kzg_proof, testVector):
 
   var proof: array[48, byte]
 
-  let status = ctx.compute_blob_kzg_proof_parallel(tp, proof, blob[].addr, commitment[])
+  let status = tp.compute_blob_kzg_proof_parallel(ctx, proof, blob[].addr, commitment[])
   stdout.write "[" & $status & "]\n"
 
   if status == cttEthKzg_Success:
@@ -212,7 +212,7 @@ testGen(verify_blob_kzg_proof, testVector):
   parseAssign(commitment, 48, testVector["input"]["commitment"].content)
   parseAssign(proof,      48, testVector["input"]["proof"].content)
 
-  let status = ctx.verify_blob_kzg_proof_parallel(tp, blob[].addr, commitment[], proof[])
+  let status = tp.verify_blob_kzg_proof_parallel(ctx, blob[].addr, commitment[], proof[])
   stdout.write "[" & $status & "]\n"
 
   if status == cttEthKzg_Success:
@@ -246,8 +246,8 @@ testGen(verify_blob_kzg_proof_batch, testVector):
     else:
       nil
 
-  let status = ctx.verify_blob_kzg_proof_batch_parallel(
-                 tp,
+  let status = tp.verify_blob_kzg_proof_batch_parallel(
+                 ctx,
                  blobs.asUnchecked(),
                  commitments.asUnchecked(),
                  proofs.asUnchecked(),

--- a/tests/t_ethereum_verkle_ipa_primitives.nim
+++ b/tests/t_ethereum_verkle_ipa_primitives.nim
@@ -100,13 +100,13 @@ suite "Barycentric Form Tests":
         lindom.setupLinearEvaluationDomain()
 
         var bar_coeffs {.noInit.}: array[256, Fr[Banderwagon]]
-        bar_coeffs.getLagrangeBasisPolysAt(lindom, p_outside_dom)
+        lindom.getLagrangeBasisPolysAt(bar_coeffs, p_outside_dom)
 
         var expected0: Fr[Banderwagon]
         expected0.computeInnerProducts(lagrange_values.evals, bar_coeffs)
 
         var expected1: Fr[Banderwagon]
-        expected1.evalPolyAt(lagrange_values, lindom, p_outside_dom)
+        lindom.evalPolyAt(expected1, lagrange_values, p_outside_dom)
 
         # testing with a no-precompute optimized Lagrange Interpolation value from Go-IPA
         doAssert expected0.toHex(littleEndian) == "0x50b9c3b3c42a06347e58d8d33047a7f8868965703567100657aceaf429562d04", "Barycentric Precompute and Lagrange should NOT give different values"
@@ -151,7 +151,7 @@ suite "Barycentric Form Tests":
           evaluations.evals[i] = points[i].y
 
         var quotient: PolynomialEval[EthVerkleDomain, Fr[Banderwagon]]
-        quotient.differenceQuotientEvalInDomain(evaluations, zIndex = 1, lindom)
+        lindom.differenceQuotientEvalInDomain(quotient, evaluations, zIndex = 1)
 
         doAssert quotient.evals[255].toHex(littleEndian) == "0x616b0e203a877177e2090013a77ce4ea8726941aac613b532002f3653d54250b", "Issue with Divide on Domain using Barycentric Precomputes!"
 
@@ -499,7 +499,7 @@ suite "IPA proof tests":
       doAssert stat11 == true, "Problem creating IPA proof 1"
 
       var lagrange_coeffs: array[256, Fr[Banderwagon]]
-      lagrange_coeffs.getLagrangeBasisPolysAt(ipaConfig.domain, point)
+      ipaConfig.domain.getLagrangeBasisPolysAt(lagrange_coeffs, point)
 
       var op_point: Fr[Banderwagon]
       op_point.computeInnerProducts(lagrange_coeffs, poly)
@@ -585,7 +585,7 @@ suite "IPA proof tests":
         doAssert stat == true, "Problem creating IPA proof"
 
         var lagrange_coeffs : array[EthVerkleDomain, Fr[Banderwagon]]
-        lagrange_coeffs.getLagrangeBasisPolysAt(ipaConfig.domain, point)
+        ipaConfig.domain.getLagrangeBasisPolysAt(lagrange_coeffs, point)
 
         var innerProd : Fr[Banderwagon]
         innerProd.computeInnerProducts(poly, lagrange_coeffs)


### PR DESCRIPTION
This changes the threadpool to always be first argument. It is the most "global" of the context, because it's at library/app level and not just KZG or BLS signatures.

As powers-of-tau and polynomial domains are also contexts, they are moved in front and this impacts KZG and IPA modules.

Furthermore, document the API.

It is inspired by libsecp256k1:
- https://github.com/bitcoin-core/secp256k1/blob/v0.5.0/include/secp256k1.h#L10-L25

This breaks Nim, C, Go, Rust API and should be done now before we cut the first ever Constantine release.
This impacts Grandine's branch: https://github.com/mratsim/constantine/pull/331