### PR TITLE
[Go] rename 2 functions in Go API using KZG -> Kzg

### DIFF
--- a/constantine-go/constantine.go
+++ b/constantine-go/constantine.go
@@ -85,7 +85,7 @@ func (ctx EthKzgContext) Delete() {
 	C.ctt_eth_trusted_setup_delete(ctx.cCtx)
 }
 
-func (ctx EthKzgContext) BlobToKZGCommitment(blob EthBlob) (commitment EthKzgCommitment, err error) {
+func (ctx EthKzgContext) BlobToKzgCommitment(blob EthBlob) (commitment EthKzgCommitment, err error) {
 	status := C.ctt_eth_kzg_blob_to_kzg_commitment(
 		ctx.cCtx,
 		(*C.ctt_eth_kzg_commitment)(unsafe.Pointer(&commitment)),
@@ -189,9 +189,9 @@ func (ctx EthKzgContext) VerifyBlobKzgProofBatch(blobs []EthBlob, commitments []
 // Ethereum EIP-4844 KZG API - Parallel
 // -----------------------------------------------------
 
-func (ctx EthKzgContext) BlobToKZGCommitmentParallel(blob EthBlob) (commitment EthKzgCommitment, err error) {
+func (ctx EthKzgContext) BlobToKzgCommitmentParallel(blob EthBlob) (commitment EthKzgCommitment, err error) {
 	if ctx.threadpool.ctx == nil {
-		return commitment, errors.New("BlobToKZGCommitmentParallel: The threadpool is not configured.")
+		return commitment, errors.New("BlobToKzgCommitmentParallel: The threadpool is not configured.")
 	}
 	status := C.ctt_eth_kzg_blob_to_kzg_commitment_parallel(
 		ctx.threadpool.ctx, ctx.cCtx,

--- a/constantine-go/constantine_test.go
+++ b/constantine-go/constantine_test.go
@@ -85,7 +85,7 @@ func (dst *EthKzgEvalAtChallenge) UnmarshalText(input []byte) error {
 	return fromHexImpl(dst[:], input)
 }
 
-func TestBlobToKZGCommitment(t *testing.T) {
+func TestBlobToKzgCommitment(t *testing.T) {
 	type Test struct {
 		Input struct {
 			Blob string `yaml:"blob"`
@@ -117,7 +117,7 @@ func TestBlobToKZGCommitment(t *testing.T) {
 				return
 			}
 
-			commitment, err := ctx.BlobToKZGCommitment(blob)
+			commitment, err := ctx.BlobToKzgCommitment(blob)
 			if err == nil {
 				require.NotNil(t, test.Output)
 				require.Equal(t, test.Output[:], commitment[:])
@@ -462,7 +462,7 @@ func createTestThreadpool(t *testing.T) Threadpool {
 	return tp
 }
 
-func TestBlobToKZGCommitmentParallel(t *testing.T) {
+func TestBlobToKzgCommitmentParallel(t *testing.T) {
 	type Test struct {
 		Input struct {
 			Blob string `yaml:"blob"`
@@ -497,7 +497,7 @@ func TestBlobToKZGCommitmentParallel(t *testing.T) {
 			continue
 		}
 
-		commitment, err := ctx.BlobToKZGCommitmentParallel(blob)
+		commitment, err := ctx.BlobToKzgCommitmentParallel(blob)
 		if err == nil {
 			require.NotNil(t, test.Output)
 			require.Equal(t, test.Output[:], commitment[:])


### PR DESCRIPTION
These two were inconsistent in their naming compared to the rest of the functions, which all use `Kzg` instead.