### PR TITLE
Fix `unmarshal` bugs

### DIFF
--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -206,7 +206,8 @@ func parseRawUint[Name: static Algebra](
   ## Return false if the integer is larger than the field modulus.
   ## Returns true on success.
   var big {.noInit.}: Fp[Name].getBigInt()
-  big.unmarshal(src, bigEndian)
+  if not big.unmarshal(src, bigEndian):
+    return cttEVM_IntLargerThanModulus # `dst` too small for `src`!
 
   if not bool(big < Fp[Name].getModulus()):
     return cttEVM_IntLargerThanModulus

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -196,20 +196,59 @@ func eth_evm_modexp*(r: var openArray[byte], inputs: openArray[byte]): CttEVMSta
 # Elliptic Curves
 # ----------------------------------------------------------------
 
-func parseRawUint[Name: static Algebra](
-       dst: var Fp[Name],
-       src: openarray[byte]): CttEVMStatus =
+proc parseEip2537(dst: var Fp[BLS12_381], src: openArray[byte]): CttEvmStatus {.inline.} =
+  ## Parses a curve point following the encoding rules defined in EIP-2537,
+  ## i.e. requiring the input to be exactly 64 bytes, with the 'upper' 16 bytes
+  ## required to be empty.
+  ## The input is required to be a coordinate of a point on the BLS12-381 curve and
+  ## stored in Big Endian format.
+  ##
+  ## For points on the quadratic extension field Fp2 the individual terms are
+  ## byte concatenated and the caller takes care of splitting the input for a
+  ## before calling this.
+  ##
+  ## Ref: https://eips.ethereum.org/EIPS/eip-2537#fine-points-and-encoding-of-base-elements
+
+  var big {.noInit.}: Fp[BLS12_381].getBigInt()
+  if src.len != 64:
+    return cttEVM_InvalidInputSize
+
+  # Parse the subslice of 48 bytes using regular `unmarshal`
+  var success = big.unmarshal(src.toOpenArray(16, 63), bigEndian)
+
+  # Now check that all lower bytes are empty
+  var allZero = success # if `success` already false we still continue
+  for i in 0 ..< 15: # order irrelevant
+    allZero = allZero and (src[i] == 0)
+
+  if not allZero or not bool(big < Fp[BLS12_381].getModulus()):
+    return cttEVM_IntLargerThanModulus
+
+  # assign result
+  dst.fromBig(big)
+  result = cttEVM_Success
+
+func parseRawUint(dst: var Fp[BLS12_381], src: openarray[byte]): CttEVMStatus =
+  ## Parse an unsigned integer from its canonical
+  ## big-endian or little-endian unsigned representation
+  ## And store it into a field element for
+  ##
+  ## Return false if the integer is larger than the field modulus.
+  ## Returns true on success.
+  result = dst.parseEip2537(src)
+
+func parseRawUint(dst: var Fp[BN254_Snarks], src: openarray[byte]): CttEVMStatus =
   ## Parse an unsigned integer from its canonical
   ## big-endian or little-endian unsigned representation
   ## And store it into a field element.
   ##
   ## Return false if the integer is larger than the field modulus.
   ## Returns true on success.
-  var big {.noInit.}: Fp[Name].getBigInt()
+  var big {.noInit.}: Fp[BN254_Snarks].getBigInt()
   if not big.unmarshal(src, bigEndian):
     return cttEVM_IntLargerThanModulus # `dst` too small for `src`!
 
-  if not bool(big < Fp[Name].getModulus()):
+  if not bool(big < Fp[BN254_Snarks].getModulus()):
     return cttEVM_IntLargerThanModulus
 
   dst.fromBig(big)

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -820,7 +820,7 @@ func eth_evm_bls12381_g1msm*(r: var openArray[byte], inputs: openarray[byte]): C
   ##   cttEVM_PointNotOnCurve
   ##
   ## Spec https://eips.ethereum.org/EIPS/eip-2537
-  if inputs.len mod 160 != 0:
+  if inputs.len == 0 or inputs.len mod 160 != 0:
     return cttEVM_InvalidInputSize
 
   if r.len != 128:
@@ -903,7 +903,7 @@ func eth_evm_bls12381_g2msm*(r: var openArray[byte], inputs: openarray[byte]): C
   ##   cttEVM_PointNotOnCurve
   ##
   ## Spec https://eips.ethereum.org/EIPS/eip-2537
-  if inputs.len mod 288 != 0:
+  if inputs.len == 0 or inputs.len mod 288 != 0:
     return cttEVM_InvalidInputSize
 
   if r.len != 256:

--- a/constantine/serialization/io_limbs.nim
+++ b/constantine/serialization/io_limbs.nim
@@ -63,8 +63,17 @@ func unmarshalLE[T](
 
     # if full, dump
     if acc_len >= wordBitWidth:
-      if dst_idx == dst.len:
-        return false
+      if dst_idx == dst.len: # return, however check if all remaining
+        # elements are 0 (more significant bits beyond `src_idx`)
+        # For example, given a
+        # `src = "DDCCBBAA0000"`
+        # and a 4 byte LittleEndian `BigInt`, `src` is fine, because the most
+        # significant two bytes are all zero.
+        var allZero = true
+        for jidx in src_idx ..< dst.len:
+          if src[jidx] != 0: allZero = false
+        if allZero: return true
+        else: return false
 
       dst[dst_idx] = acc
       inc dst_idx
@@ -118,8 +127,17 @@ func unmarshalBE[T](
 
     # if full, dump
     if acc_len >= wordBitWidth:
-      if dst_idx == dst.len:
-        return false
+      if dst_idx == dst.len: # return, however check if all remaining
+        # elements are 0 (more significant bits beyond `src_idx-1`)
+        # For examplle, given a
+        # `src = "0000AABBCCDD"`
+        # and a 4 byte BigEndian `BigInt`, `src` is fine, because the most
+        # significant two bytes are all zero.
+        var allZero = true
+        for jidx in countdown(src_idx, 0):
+          if src[jidx] != 0: allZero = false
+        if allZero: return true
+        else: return false
 
       dst[dst_idx] = acc
       inc dst_idx

--- a/constantine/serialization/io_limbs.nim
+++ b/constantine/serialization/io_limbs.nim
@@ -63,17 +63,8 @@ func unmarshalLE[T](
 
     # if full, dump
     if acc_len >= wordBitWidth:
-      if dst_idx == dst.len: # return, however check if all remaining
-        # elements are 0 (more significant bits beyond `src_idx`)
-        # For example, given a
-        # `src = "DDCCBBAA0000"`
-        # and a 4 byte LittleEndian `BigInt`, `src` is fine, because the most
-        # significant two bytes are all zero.
-        var allZero = true
-        for jidx in src_idx ..< dst.len:
-          if src[jidx] != 0: allZero = false
-        if allZero: return true
-        else: return false
+      if dst_idx == dst.len:
+        return false
 
       dst[dst_idx] = acc
       inc dst_idx
@@ -127,17 +118,8 @@ func unmarshalBE[T](
 
     # if full, dump
     if acc_len >= wordBitWidth:
-      if dst_idx == dst.len: # return, however check if all remaining
-        # elements are 0 (more significant bits beyond `src_idx-1`)
-        # For examplle, given a
-        # `src = "0000AABBCCDD"`
-        # and a 4 byte BigEndian `BigInt`, `src` is fine, because the most
-        # significant two bytes are all zero.
-        var allZero = true
-        for jidx in countdown(src_idx, 0):
-          if src[jidx] != 0: allZero = false
-        if allZero: return true
-        else: return false
+      if dst_idx == dst.len:
+        return false
 
       dst[dst_idx] = acc
       inc dst_idx


### PR DESCRIPTION
I encountered 3 issues working on the updated Go / Rust APIs. The (now more) static nature of the Go API (using fixed size arrays) showed me that (at least) one case succeeds that is supposed to fail. That test case is:

https://github.com/mratsim/constantine/blob/master/tests/protocol_ethereum_evm_precompiles/eip-2537/fail-add_G1_bls.json#L27-L31

The test is supposed to fail, because the X coordinate of the first point given in the input is way larger than the prime field size (see the string starting with a `10` byte). Investigating led me to realize that the BigInt parsing logic ignored the `false` return value of the `unmarshal`. The actual `unmarshal` call failed with the intended error that the size is too large for the target BigInt. But because we ignored that return value, the not-fully-parsed BigInt ended up being a valid point on the curve. 

After fixing this issue, I noticed that the `io_limbs.nim` unmarshalling logic also had an issue, in the sense that it returns `false` even if the remaining data in the input source string is entirely zero. But of course that must be allowed (and again, this was also hidden by the bug above). I've put in a -- not that great -- manual check for all bytes still left in the input string. If they are all zero, we simply return true. We might want to do this in a different way, but at the moment I'm not sure what is appropriate.



The other issue (to be fixed later) is that our Nim EVM precompiles tests always use the `Expected` field's length as the result buffer length. That causes the functions to prematurely fail, which hid the actual bug described above. This last bug means that we got the "correct" test result by accident, because the resulting buffer size was wrong, failing the wrong test; just for the wrong reasons.


### Edit: Note on `{.discardable.}`

We might want to reconsider whether we want to use `{.discardable.}` in the library. Maybe too dangerous to accidentally ignore such parsing failures etc.?