### PR TITLE
fix(MSM - #366): edge case when scalar bits are divided by MSM 'c' parameter

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -510,6 +510,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_msm.nim", false),
   ("tests/math_elliptic_curves/t_ec_shortw_jac_g1_msm.nim", false),
   ("tests/math_elliptic_curves/t_ec_twedw_prj_msm.nim", false),
+  ("tests/math_elliptic_curves/t_ec_shortw_jac_g2_msm_bug_366.nim", false),
 
   # Subgroups and cofactors
   # ----------------------------------------------------------

--- a/constantine/math/elliptic/ec_multi_scalar_mul.nim
+++ b/constantine/math/elliptic/ec_multi_scalar_mul.nim
@@ -10,8 +10,9 @@ import constantine/named/algebras,
        ./ec_multi_scalar_mul_scheduler,
        ./ec_endomorphism_accel,
        constantine/math/extension_fields,
-       constantine/named/zoo_endomorphisms
-export bestBucketBitSize
+       constantine/named/zoo_endomorphisms,
+       constantine/platforms/abstractions
+export bestBucketBitSize, abstractions
 
 # No exceptions allowed in core cryptographic operations
 {.push raises: [].}
@@ -281,7 +282,7 @@ func multiScalarMul_vartime*[bits: static int, EC, ECaff](
     else:
       # If c divides bits exactly, the signed windowed recoding still needs to see an extra 0
       # Since we did r.setNeutral() earlier, this is a no-op
-      w -= c
+      discard
 
   while w != 0:       # Steady state
     r.miniMSM(buckets, w, kFullWindow, c, coefs, points, N)
@@ -374,7 +375,7 @@ func multiScalarMulAffine_vartime[bits: static int, EC, ECaff](
     else:
       # If c divides bits exactly, the signed windowed recoding still needs to see an extra 0
       # Since we did r.setNeutral() earlier, this is a no-op
-      w -= c
+      discard
 
   while w != 0:       # Steady state
     r.miniMSM_affine(sched, w, kFullWindow, c, coefs, N)

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g2_msm_bug_366.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g2_msm_bug_366.nim
@@ -1,0 +1,40 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  constantine/named/algebras,
+  constantine/math/ec_shortweierstrass,
+  constantine/math/extension_fields,
+  # Test utilities
+  helpers/prng_unsafe
+
+var rng: RngState
+let seed = 1234
+rng.seed(seed)
+echo "\n------------------------------------------------------\n"
+echo "BN254 G2 MSM edge case #366 xoshiro512** seed: ", seed
+
+# https://github.com/mratsim/constantine/issues/366
+# 22529 points leads to c = 13.
+# BN254 on G2 transform 1 254-bit scalar into 4 65-bit scalars.
+# 13 divides 65 and triggered an off-by-one edge case
+var gs = newSeq[EC_ShortW_Aff[Fp2[BN254_Snarks], G2]](22529)
+for g in gs.mitems():
+  g.setGenerator()
+
+var cs = newSeq[Fr[BN254_Snarks]](22529)
+for c in cs.mitems():
+  c = rng.random_long01Seq(Fr[BN254_Snarks])
+
+var r_ref, r_opt: EC_ShortW_Jac[Fp2[BN254_Snarks], G2]
+r_ref.multi_scalar_mul_reference_vartime(cs, gs)
+r_opt.multi_scalar_mul_vartime(cs, gs)
+
+doAssert bool(r_ref == r_opt)
+echo "BN254 G2 MSM edge case #366 - SUCCESS"


### PR DESCRIPTION
This fixes #366

Here is the sequence of events.

- 22529 input coefficients of size 254 bits
- After endomorphism computation, they are transformed into 90116 coefficients of size 65 bits
- 90116 maps to an MSM parameter c of 13
- 13 divides 65 exactly and triggers a bug where 1 mini-MSM iteration is missing.
