### PR TITLE
add: multiproof consistency test

### DIFF
--- a/tests/t_ethereum_verkle_ipa_primitives.nim
+++ b/tests/t_ethereum_verkle_ipa_primitives.nim
@@ -596,9 +596,81 @@ suite "IPA proof tests":
 # TODO: refactor completely the tests - https://github.com/mratsim/constantine/issues/396
 
 suite "Multiproof Tests":
-  echo "Warning! - Skipping all but serialization tests due to issues outlined in https://github.com/mratsim/constantine/issues/396"
+  echo "Warning! - Skipping all but serialization tests and Multiproof consistency test due to issues outlined in https://github.com/mratsim/constantine/issues/396"
   # The comparison between previous and new implementation
   # can be done as of commit 182c4187ccc0751592fe52e7abaaa51fdde7edd6
+
+  test "Test for Multiproof Consistency":
+    proc testMultiproofConsistency() =
+
+      # Common setup
+      var opening_challenges: array[2, Fr[Banderwagon]] # to be added ipa_multi_verify once ready
+      opening_challenges[0].setOne()
+      opening_challenges[1].fromInt(32)
+
+      var opening_challenges_in_domain: array[2, uint8]
+      opening_challenges_in_domain[0] = 0'u8
+      opening_challenges_in_domain[1] = 0'u8
+
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      CRS.evals.generate_random_points()
+
+      var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
+      domain.setupLinearEvaluationDomain()
+
+      # Committer's side
+      var testVals1: array[256, int] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+      ]
+
+      var testVals2: array[256, int] = [
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+      ]
+
+      var polys: array[2, PolynomialEval[256, Fr[Banderwagon]]]
+      polys[0].evals.testPoly256(testVals1)
+      polys[1].evals.testPoly256(testVals2)
+      
+      var comm_1: EC_TwEdw_Prj[Fp[Banderwagon]]
+      CRS.pedersen_commit(comm_1, polys[0])
+      
+      var comm_2: EC_TwEdw_Prj[Fp[Banderwagon]]
+      CRS.pedersen_commit(comm_2, polys[1])
+
+      var commitments: array[2, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      commitments[0].affine(comm_1)
+      commitments[1].affine(comm_2)
+
+      # Prover's side
+      var prover_transcript {.noInit.}: sha256
+      prover_transcript.initTranscript("test")
+
+      var multiproof: IpaMultiProof[8, EC_TwEdw_Aff[Fp[Banderwagon]], Fr[Banderwagon]]
+
+      CRS.ipa_multi_prove(
+        domain, prover_transcript,
+        multiproof, polys,
+        commitments, opening_challenges_in_domain)
+
+      var prover_challenge {.noInit.}: Fr[Banderwagon]
+      prover_transcript.squeezeChallenge("state", prover_challenge)
+      doAssert prover_challenge.toHex(littleEndian) == "0xeee8a80357ff74b766eba39db90797d022e8d6dee426ded71234241be504d519", "Issue with squeezing the prover challenge"
+
+      testMultiproofConsistency()
 
   # test "Multiproof Creation and Verification (old)":
   #   proc testMultiproofCreationAndVerification()=


### PR DESCRIPTION
Adds a Verkle multiproof consistency test, a continuation to addressing issue #396, implements the test https://github.com/crate-crypto/go-ipa/blob/b1e8a79/multiproof_test.go#L63-L132 as per the Verkle trie spec

Skips ipa_multi_verify because of a potential bug in `g2t`, will be addressed and fixed in successive PRs