### PR TITLE
fix `scalarMul_vartime` for tiny multiple 5

### DIFF
--- a/constantine/math/elliptic/ec_scalar_mul_vartime.nim
+++ b/constantine/math/elliptic/ec_scalar_mul_vartime.nim
@@ -81,7 +81,7 @@ func scalarMul_addchain_4bit_vartime[EC](P: var EC, scalar: BigInt) {.tags:[VarT
   of 5:
     var t {.noInit.}: EC
     t.double(P)
-    t.double(P)
+    t.double()
     P ~+= t
   of 6:
     var t {.noInit.}: EC


### PR DESCRIPTION
Another minor issue I encountered playing around with moonmath's BLS6-6. The code previously accidentally only returned 3 for the case 5 using `X.scalarMul_vartime(5)`.

I noticed it when comparing manual addition of the generator vs scalar multiplication, in order to construct all elements of the G1 subgroup:

```nim
# generator for G1
let fx = Fp[BLS6_6].fromUint(13'u32)
let fy = Fp[BLS6_6].fromUint(15'u32)

var gen {.noinit.}: EC_ShortW_Aff[Fp[BLS6_6], G1]
gen.x = fx
gen.y = fy
let genJ = gen.getJacobian()

var curA = genJ
for i in 1 .. 13:
  let x = BigInt[6].fromUint(i.uint32)
  var cur = genJ
  # cur.scalarMul(x) # <- works fine
  cur.scalarMul_vartime(x) # <- element 5 returned element 3 before this fix
  echo "Index: ", i, " [i] g = ", cur.toDecimal() # (I added `toDecimal for EC points)
  echo "Addition: ", curA.toDecimal()
  echo "\n=======================\n"
  curA = curA + genJ # works fine
```

I'd consider adding BLS6-6 as a test curve at a later time. Then I can write a couple of test cases for it (to check all the tiny number code branches) and an example showing some basic curve operations with constantine. Such an example could be quite illustrative. Maybe with some comments of how equivalent operations would look like in SageMath. 