### PR TITLE
fix(cryptofuzz): expose all cryptofuzz tested primitives in lowlevel_*

### DIFF
--- a/constantine/lowlevel_bigints.nim
+++ b/constantine/lowlevel_bigints.nim
@@ -8,7 +8,8 @@
 
 import
     ./platforms/abstractions,
-    ./math/io/io_bigints
+    ./math/io/io_bigints,
+    ./math/arithmetic/bigints
 
 # ############################################################
 #
@@ -32,7 +33,7 @@ export
   abstractions.SecretWord,
   abstractions.BigInt
 
-# BigInt
+# BigInt serialization
 # ------------------------------------------------------------
 
 func unmarshalBE*(dst: var BigInt, src: openarray[byte]): bool =
@@ -44,3 +45,26 @@ func marshalBE*(dst: var openarray[byte], src: BigInt): bool =
   ## Return true on success
   ## Return false if destination is too small compared to source
   return dst.marshal(src, bigEndian)
+
+# BigInt
+# ------------------------------------------------------------
+
+export bigints.setZero
+export bigints.setOne
+
+export bigints.`<`
+export bigints.`<=`
+export bigints.isOdd
+export bigints.isEven
+
+export bigints.add
+export bigints.cadd
+export bigints.sub
+export bigints.csub
+
+export bigints.reduce
+export bigints.reduce_vartime
+export bigints.invmod
+export bigints.invmod_vartime
+
+export bigints.bit0

--- a/constantine/lowlevel_fields.nim
+++ b/constantine/lowlevel_fields.nim
@@ -34,7 +34,11 @@ export
   abstractions.SecretWord,
   abstractions.BigInt,
   algebras.Algebra,
-  algebras.getBigInt
+  algebras.getBigInt,
+  algebras.bits,
+  algebras.baseFieldModulus,
+  algebras.scalarFieldModulus
+
 
 # Scalar field Fr and Prime Field Fp
 # ------------------------------------------------------------
@@ -42,7 +46,11 @@ export
 export
   algebras.Fp,
   algebras.Fr,
-  algebras.FF
+  algebras.FF,
+
+  # Workaround generic sandwich
+  algebras.matchingBigInt,
+  algebras.matchingOrderBigInt
 
 func unmarshalBE*(dst: var FF, src: openarray[byte]): bool =
   ## Return true on success
@@ -112,6 +120,8 @@ export arithmetic.sqrt_if_square
 export arithmetic.invsqrt_if_square
 export arithmetic.sqrt_ratio_if_square
 
+export arithmetic.pow
+export arithmetic.pow_vartime
 
 # Out-of-place functions SHOULD NOT be used in performance-critical subroutines as compilers
 # tend to generate useless memory moves or have difficulties to minimize stack allocation
@@ -122,3 +132,6 @@ export arithmetic.sqrt_ratio_if_square
 export arithmetic.`+`
 export arithmetic.`-`
 export arithmetic.`*`
+export arithmetic.`^`
+export arithmetic.`~^`
+export arithmetic.toBig

--- a/constantine/lowlevel_pairing_curves.nim
+++ b/constantine/lowlevel_pairing_curves.nim
@@ -14,6 +14,7 @@ import
     ./math/pairings/[
       cyclotomic_subgroups,
       lines_eval,
+      miller_accumulators,
       pairings_generic,
       gt_exponentiations,
       gt_exponentiations_vartime]
@@ -50,6 +51,13 @@ export lines_eval.line_double
 export lines_eval.line_add
 export lines_eval.mul_by_line
 export lines_eval.mul_by_2_lines
+
+export miller_accumulators.MillerAccumulator
+export miller_accumulators.init
+export miller_accumulators.update
+export miller_accumulators.handover
+export miller_accumulators.merge
+export miller_accumulators.finish
 
 export cyclotomic_subgroups.finalExpEasy
 export cyclotomic_subgroups.cyclotomic_inv

--- a/constantine/math/arithmetic/bigints.nim
+++ b/constantine/math/arithmetic/bigints.nim
@@ -520,7 +520,7 @@ func invmod*[bits](r: var BigInt[bits], a, M: BigInt[bits]) =
 
 {.push inline.}
 
-func reduce_vartime*[aBits, mBits](r: var BigInt[mBits], a: BigInt[aBits], M: BigInt[mBits]): bool =
+func reduce_vartime*[aBits, mBits](r: var BigInt[mBits], a: BigInt[aBits], M: BigInt[mBits]): bool {.discardable.} =
   ## Reduce `a` modulo `M` and store the result in `r`
   ## Return false if M == 0
   return reduce_vartime(r.limbs, a.limbs, M.limbs)

--- a/constantine/math/arithmetic/finite_fields.nim
+++ b/constantine/math/arithmetic/finite_fields.nim
@@ -529,6 +529,23 @@ func pow*(a: var FF, exponent: openarray[byte]) =
     FF.getSpareBits()
   )
 
+func pow*(a: var FF, exponent: FF) =
+  ## Exponentiation modulo p
+  ## ``a``: a field element to be exponentiated
+  ## ``exponent``: a finite field element
+  const windowSize = 5 # TODO: find best window size for each curves
+  a.pow(exponent.toBig())
+
+func pow*(r: var FF, a: FF, exponent: BigInt or openArray[byte] or FF) =
+  ## Exponentiation modulo p
+  ## ``a``: a field element to be exponentiated
+  ## ``exponent``: a finite field element or big integer
+  r = a
+  a.pow(exponent)
+
+# Vartime exponentiation
+# -------------------------------------------------------------------
+
 func pow_vartime*(a: var FF, exponent: BigInt) =
   ## Exponentiation modulo p
   ## ``a``: a field element to be exponentiated
@@ -566,6 +583,23 @@ func pow_vartime*(a: var FF, exponent: openarray[byte]) =
     FF.getNegInvModWord(), windowSize,
     FF.getSpareBits()
   )
+
+func pow_vartime*(a: var FF, exponent: FF) =
+  ## Exponentiation modulo p
+  ## ``a``: a field element to be exponentiated
+  ## ``exponent``: a finite field element
+  const windowSize = 5 # TODO: find best window size for each curves
+  a.pow_vartime(exponent.toBig())
+
+func pow_vartime*(r: var FF, a: FF, exponent: BigInt or openArray[byte] or FF) =
+  ## Exponentiation modulo p
+  ## ``a``: a field element to be exponentiated
+  ## ``exponent``: a finite field element or big integer
+  r = a
+  a.pow_vartime(exponent)
+
+# Small vartime exponentiation
+# -------------------------------------------------------------------
 
 func pow_squareMultiply_vartime(a: var FF, exponent: SomeUnsignedInt) {.tags:[VarTime], meter.} =
   ## **Variable-time** Exponentiation
@@ -905,7 +939,7 @@ func `+`*(a, b: FF): FF {.noInit, inline.} =
   result.sum(a, b)
 
 func `-`*(a, b: FF): FF {.noInit, inline.} =
-  ## Finite Field addition
+  ## Finite Field substraction
   ##
   ## Out-of-place functions SHOULD NOT be used in performance-critical subroutines as compilers
   ## tend to generate useless memory moves or have difficulties to minimize stack allocation
@@ -914,10 +948,28 @@ func `-`*(a, b: FF): FF {.noInit, inline.} =
   result.diff(a, b)
 
 func `*`*(a, b: FF): FF {.noInit, inline.} =
-  ## Finite Field substraction
+  ## Finite Field multiplication
   ##
   ## Out-of-place functions SHOULD NOT be used in performance-critical subroutines as compilers
   ## tend to generate useless memory moves or have difficulties to minimize stack allocation
   ## and our types might be large (Fp12 ...)
   ## See: https://github.com/mratsim/constantine/issues/145
   result.prod(a, b)
+
+func `^`*(a: FF, b: FF or BigInt or openArray[byte]): FF {.noInit, inline.} =
+  ## Finite Field exponentiation
+  ##
+  ## Out-of-place functions SHOULD NOT be used in performance-critical subroutines as compilers
+  ## tend to generate useless memory moves or have difficulties to minimize stack allocation
+  ## and our types might be large (Fp12 ...)
+  ## See: https://github.com/mratsim/constantine/issues/145
+  result.pow(a, b)
+
+func `~^`*(a: FF, b: FF or BigInt or openArray[byte]): FF {.noInit, inline.} =
+  ## Finite Field vartime exponentiation
+  ##
+  ## Out-of-place functions SHOULD NOT be used in performance-critical subroutines as compilers
+  ## tend to generate useless memory moves or have difficulties to minimize stack allocation
+  ## and our types might be large (Fp12 ...)
+  ## See: https://github.com/mratsim/constantine/issues/145
+  result.pow_vartime(a, b)

--- a/constantine/math/elliptic/ec_scalar_mul.nim
+++ b/constantine/math/elliptic/ec_scalar_mul.nim
@@ -278,7 +278,10 @@ func scalarMulEndo*[scalBits; EC](
   ## Requires:
   ## - Cofactor to be cleared
   ## - 0 <= scalar < curve order
-  static: doAssert scalBits <= EC.getScalarField().bits(), "Do not use endomorphism to multiply beyond the curve order"
+  static: doAssert scalBits <= EC.getScalarField().bits(), block:
+      "Do not use endomorphism to multiply beyond the curve order:\n" &
+      "  scalar: " & $scalBits & "-bit\n" &
+      "  order:  " & $EC.getScalarField().bits() & "-bit\n"
 
   # 1. Compute endomorphisms
   const M = when P.F is Fp:  2
@@ -368,7 +371,11 @@ func scalarMulGLV_m2w2*[scalBits; EC](P0: var EC, scalar: BigInt[scalBits]) {.me
   ## Requires:
   ## - Cofactor to be cleared
   ## - 0 <= scalar < curve order
-  static: doAssert: scalBits <= EC.getScalarField().bits()
+  static: doAssert scalBits <= EC.getScalarField().bits(), block:
+      "Do not use endomorphism to multiply beyond the curve order:\n" &
+      "  scalar: " & $scalBits & "-bit\n" &
+      "  order:  " & $EC.getScalarField().bits() & "-bit\n"
+
   const G = when EC isnot EC_ShortW_Aff|EC_ShortW_Jac|EC_ShortW_Prj: G1
             else: EC.G
 

--- a/constantine/math/pairings/gt_exponentiations.nim
+++ b/constantine/math/pairings/gt_exponentiations.nim
@@ -53,7 +53,10 @@ func gtExpEndo*[Gt: ExtensionField, scalBits: static int](
   ## Requires:
   ## - Cofactor to be cleared
   ## - 0 <= scalar < curve order
-  static: doAssert scalBits <= Fr[Gt.Name].bits(), "Do not use endomorphism to multiply beyond the curve order"
+  static: doAssert scalBits <= Fr[Gt.Name].bits(), block:
+      "Do not use endomorphism to multiply beyond the curve order:\n" &
+      "  scalar: " & $scalBits & "-bit\n" &
+      "  order:  " & $Fr[Gt.Name].bits() & "-bit\n"
 
   # 1. Compute endomorphisms
   const M = when Gt is Fp6:  2

--- a/constantine/named/properties_curves.nim
+++ b/constantine/named/properties_curves.nim
@@ -34,9 +34,9 @@ template getBigInt*(Name: static Algebra, kind: static FieldKind): untyped =
   #
   # and `ptr UncheckedArray[BigInt[Fr[EC.F.Name].bits]]` gets undeclared field: 'Name'
   when kind == kBaseField:
-    BigInt[Fp[Name].bits()]
+    Name.baseFieldModulus().typeof()
   else:
-    BigInt[Fr[Name].bits()]
+    Name.scalarFieldModulus().typeof()
 
 template getField*(Name: static Algebra, kind: static FieldKind): untyped =
   when kind == kBaseField:

--- a/constantine/platforms/allocs.nim
+++ b/constantine/platforms/allocs.nim
@@ -80,7 +80,8 @@ template allocStackUnchecked*(T: typedesc, size: int): ptr T =
   cast[ptr T](alloca(size))
 
 template allocStackArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T] =
-  cast[ptr UncheckedArray[T]](alloca(sizeof(T) * cast[int](len)))
+  {.warning[CastSizes]:off.}:
+    cast[ptr UncheckedArray[T]](alloca(sizeof(T) * cast[int](len)))
 
 # Heap allocation
 # ----------------------------------------------------------------------------------
@@ -93,7 +94,8 @@ proc allocHeapUnchecked*(T: typedesc, size: int): ptr T {.inline.} =
   cast[type result](malloc(size))
 
 proc allocHeapArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T] {.inline.} =
-  cast[type result](malloc(sizeof(T) * cast[int](len)))
+  {.warning[CastSizes]:off.}:
+    cast[type result](malloc(sizeof(T) * cast[int](len)))
 
 proc freeHeap*(p: pointer) {.inline.} =
   free(p)


### PR DESCRIPTION
Constantine is continuously fuzzed on Google OSS-Fuzz through CryptoFuzz.

The test harness is https://github.com/guidovranken/cryptofuzz/blob/042cac0727b99a39dfecfd61d994f5972e2e7e3d/modules/constantine/constantine_harness.nim and has been broken by refactoring preceding the v0.1.0 release:

- https://github.com/mratsim/constantine/pull/399
- https://github.com/mratsim/constantine/pull/400
- https://github.com/mratsim/constantine/pull/402

This PR:
- exposes everything cryptofuzz tests in the `lowlevel_*.nim` files so that it doesn't depend on internal folder structure.
- remove the new CastSizes warning when raw casting between integer of different size for allocation.
- exposes new pow/pow_vartime by a finite field and out-of-place using `^` and `~^`


It also fails to enable creating a generic version of https://github.com/guidovranken/cryptofuzz/blob/042cac0727b99a39dfecfd61d994f5972e2e7e3d/modules/constantine/constantine_harness.nim#L67-L89

```Nim
proc loadScalar_BN254_Snarks(
       dst: var matchingOrderBigInt(BN254_Snarks),
       src: openarray[byte]) =
    const maxBits = 8 * roundNextMultipleOf(BN254_Snarks.getCurveOrderBitwidth(), 8)
    var tmp{.noinit.}: BigInt[maxBits]
    tmp.unmarshal(src, bigEndian)
    dst.reduce(tmp, BN254_Snarks.getCurveOrder())

proc loadScalar_BLS12_381(
       dst: var matchingOrderBigInt(BLS12_381),
       src: openarray[byte]) =
    const maxBits = 8 * roundNextMultipleOf(BLS12_381.getCurveOrderBitwidth(), 8)
    var tmp{.noinit.}: BigInt[maxBits]
    tmp.unmarshal(src, bigEndian)
    dst.reduce(tmp, BLS12_381.getCurveOrder())

proc loadScalar_BLS12_377(
       dst: var matchingOrderBigInt(BLS12_377),
       src: openarray[byte]) =
    const maxBits = 8 * roundNextMultipleOf(BLS12_377.getCurveOrderBitwidth(), 8)
    var tmp{.noinit.}: BigInt[maxBits]
    tmp.unmarshal(src, bigEndian)
    dst.reduce(tmp, BLS12_377.getCurveOrder())
```

When replacing by a generic:
`matchingOrderBigInt(curve)` and `curve.getCurveOrder()` fail to match types.

Changing to `curve.getBigInt(kScalarField)` doesn't work either, and changing the internal impl of `getBigInt` to use `typeof(CurveOrder)` triggers a compiler crash
![image](https://github.com/user-attachments/assets/771fafad-68db-4b8b-a48d-149b0b761115)
