### PR TITLE
fix(arith): bug in vartime inversion when using fused inverse+multiply by factor - found by Guido Vranken

### DIFF
--- a/constantine/math/arithmetic/limbs_exgcd.nim
+++ b/constantine/math/arithmetic/limbs_exgcd.nim
@@ -854,7 +854,7 @@ func invmod_vartime*(
     r.setZero()
     return
   if a.isOne().bool:
-    r.setOne()
+    r = F
     return
 
   const Excess = 2
@@ -888,7 +888,7 @@ func invmod_vartime*(
     r.setZero()
     return
   if a.isOne().bool:
-    r.setOne()
+    r = F
     return
 
   const Excess = 2

--- a/tests/math_bigints/t_bigints.nim
+++ b/tests/math_bigints/t_bigints.nim
@@ -10,6 +10,7 @@ import
   # Standard library
   std/unittest,
   # Internal
+  constantine/named/algebras,
   constantine/math/io/io_bigints,
   constantine/math/arithmetic,
   constantine/platforms/abstractions,
@@ -657,6 +658,22 @@ proc mainModularInverse() =
         check:
           bool(r == expected)
           bool(r2 == expected)
+
+    test "#433 -  CryptoFuzz / Oss-Fuzz bug with unit inversion":
+      block:
+        let a = BigInt[255].fromUint(1'u)
+        let M = BLS12_381.scalarFieldModulus()
+        let F = Fr[BLS12_381].getR2modP()
+
+        var r = canary(BigInt[255])
+        var r2 = canary(BigInt[255])
+
+        r.invmod(a, F, M)
+        r2.invmod_vartime(a, F, M)
+
+        check:
+          bool(r == F)
+          bool(r2 == F)
 
 mainArith()
 mainMul()

--- a/tests/math_fields/t_finite_fields_powinv.nim
+++ b/tests/math_fields/t_finite_fields_powinv.nim
@@ -465,4 +465,14 @@ proc main_anti_regression =
 
       check: bool(a == expected)
 
+  suite "Bug highlighted by 24/7 fuzzing (Guido Vranken's CryptoFuzz / Google-OssFuzz)" & " [" & $WordBitWidth & "-bit words]":
+    test "#433 - Short-circuit when Montgomery a' = aR (mod p) == 1":
+      let a = BigInt[255].fromDecimal("12549076656233958353659347336803947287922716146853412054870763148006372261952")
+      let expected = BigInt[255].fromDecimal("10920338887063814464675503992315976177888879664585288394250266608035967270910")
+      var aa = Fr[BLS12_381].fromBig(a)
+
+      doAssert bool(aa.mres.isOne())
+      aa.inv_vartime()
+      check: bool(aa.toBig() == expected)
+
 main_anti_regression()


### PR DESCRIPTION
Constantine implements a fused inversion+multiply (FIM) that does `FIM(a, F, p) = F.a⁻¹ (mod p)` 

This allows inversion in the Montgomery domain without converting back-and-forth in the canonical representation.

As a reminder, in the Montgomery domain we map a to a' with `a' = aR (mod p)` with R a magic constant, for example for `Fr[BLS12_381]` which is 255 bits,  `R = 2⁶⁴*⁴ (mod p)` i.e. the next multiple of the word size that can fully store the modulus p.

Hence `a'⁻¹ = a⁻¹R (mod p) = (aR)⁻¹.R² (mod p) = FIM(a', R², p)`

Unfortunately the code was shortcutting when `a' == 1` to 1 instead of F.

https://github.com/mratsim/constantine/blob/9a2d23b1e718664d54068a2f374d31e91418ca27/constantine/math/arithmetic/limbs_exgcd.nim#L844-L858

## Impact

Fortunately at the protocol-level Constantine only uses vartime inversion in MSM and KZG:
- MSM are used together with transcript/randomness so that an attacker does not control the inputs
- KZG SRS are spec-level 
- It's also used for a random evaluation point (from transcript) minus roots of unity

In particular BLS signatures do not use `inv_vartime` in `finalExpEasy`

![image](https://github.com/user-attachments/assets/6047187e-42a8-45af-8852-c36b26d52445)

cc @guidovranken
