### PR TITLE
Compatibility with Nim v1.6.x, Nim v2.0.x, Nim v2.2.x

### DIFF
--- a/constantine/math/endomorphisms/split_scalars.nim
+++ b/constantine/math/endomorphisms/split_scalars.nim
@@ -48,11 +48,8 @@ template decomposeEndoImpl[scalBits: static int](
   static: doAssert L >= ceilDiv_vartime(frBits, M) + 1
   const w = frBits.wordsRequired()
 
-  # Upstream bug:
-  #   {.noInit.} variables must be {.inject.} as well
-  #   or they'll be mangled as foo`gensym12345 instead of fooX60gensym12345 in C codegen
-
   when M == 2:
+    # inject works around alphas'gensym codegen in Nim v2.0.8 (not necessary in Nim v2.2.x) - https://github.com/nim-lang/Nim/pull/23801#issue-2393452970
     var alphas{.noInit, inject.}: (
       BigInt[frBits + babai(Name, G)[0][0].bits],
       BigInt[frBits + babai(Name, G)[1][0].bits]
@@ -76,7 +73,8 @@ template decomposeEndoImpl[scalBits: static int](
   # We have k0 = s - 𝛼0 b00 - 𝛼1 b10 ... - 𝛼m bm0
   # and     kj = 0 - 𝛼j b0j - 𝛼1 b1j ... - 𝛼m bmj
   var
-    k {.inject.}: array[M, BigInt[frBits]] # zero-init required
+    k {.inject.}: array[M, BigInt[frBits]] # zero-init required, and inject for caller visibility
+    # inject works around alphas'gensym codegen in Nim v2.0.8 (not necessary in Nim v2.2.x) - https://github.com/nim-lang/Nim/pull/23801#issue-2393452970
     alphaB {.noInit, inject.}: BigInt[frBits]
   k[0].copyTruncatedFrom(scalar)
   staticFor miniScalarIdx, 0, M:

--- a/constantine/math/extension_fields/towers.nim
+++ b/constantine/math/extension_fields/towers.nim
@@ -1436,15 +1436,14 @@ func mul_sparse_by_x0*(a: var QuadraticExt, sparseB: QuadraticExt) =
   ## Sparse in-place multiplication
   a.mul_sparse_by_x0(a, sparseB)
 
-func mulCheckSparse*(a: var QuadraticExt, b: static QuadraticExt) {.inline.} =
+template mulCheckSparse*(a: var QuadraticExt, b: QuadraticExt) =
   when isOne(b).bool:
     discard
   elif isMinusOne(b).bool:
     a.neg()
   elif isZero(c0(b)).bool and isOne(c1(b)).bool:
-    # TODO: raise upstream, in Nim v2 templates {.noInit.} temporaries use incorrect t`gensymXXXX
-    # hence we use an inline function with static argument
-    var t {.noInit.}: type(a.c0)
+    # inject works around t'gensym codegen in Nim v2.0.8 (not necessary in Nim v2.2.x) - https://github.com/nim-lang/Nim/pull/23801#issue-2393452970
+    var t {.noInit, inject.}: type(a.c0)
     when fromComplexExtension(b):
       t.neg(a.c1)
       a.c1 = a.c0
@@ -1454,9 +1453,8 @@ func mulCheckSparse*(a: var QuadraticExt, b: static QuadraticExt) {.inline.} =
       a.c1 = a.c0
       a.c0 = t
   elif isZero(c0(b)).bool and isMinusOne(c1(b)).bool:
-    # TODO: raise upstream, in Nim v2 templates {.noInit.} temporaries use incorrect t`gensymXXXX
-    # hence we use an inline function with static argument
-    var t {.noInit.}: type(a.c0)
+    # inject works around t'gensym codegen in Nim v2.0.8 (not necessary in Nim v2.2.x) - https://github.com/nim-lang/Nim/pull/23801#issue-2393452970
+    var t {.noInit, inject.}: type(a.c0)
     when fromComplexExtension(b):
       t = a.c1
       a.c1.neg(a.c0)


### PR DESCRIPTION
A significant amount of upstream bugs and regressions have been fixed and backported related to statics, generics and templates which Constantine uses heavily.
- https://github.com/nim-lang/Nim/issues/22947
- https://github.com/nim-lang/Nim/issues/23711
- https://github.com/nim-lang/Nim/issues/23755
- https://github.com/nim-lang/Nim/issues/23784

This PR works around the last one that prevent Constantine from compiling on devel:
- https://github.com/nim-lang/Nim/issues/23547

In summary the following cause a type mismatch:

```Nim
func mulCheckSparse*(a: var QuadraticExt, b: static QuadraticExt) {.inline.} =
```

but the following works

```Nim
template mulCheckSparse*(a: var QuadraticExt, b: QuadraticExt) =
```

However there were 2 template symbol generations issue:
- one that was fixed in https://github.com/nim-lang/Nim/pull/23716
- one that exists in Nim v2.0.x but not in devel/v2.2.x

In C, the symbol generated contains invalid backticks like ```t`gensym1234```

Fortunately, another way to workaround this is to tag the variable as `{.inject.}` which makes the library supported in 1.6.x, 2.0.x and 2.2.x