### PR TITLE
fix(gcc): compatibility with GCC14

### DIFF
--- a/constantine/platforms/intrinsics/addcarry_subborrow.nim
+++ b/constantine/platforms/intrinsics/addcarry_subborrow.nim
@@ -108,7 +108,7 @@ when X86:
     subborrow_u32(borrowIn, cast[culong](a), cast[culong](b), cast[ptr culong](sum.addr)[])
 
   template addcarry_u64(carryIn: Carry, a, b: Ct[uint64], sum: var Ct[uint64]): Carry =
-    addcarry_u64(carryIn, cast[culong](a), cast[culong](b), cast[ptr culonglong](sum.addr)[])
+    addcarry_u64(carryIn, cast[culonglong](a), cast[culonglong](b), cast[ptr culonglong](sum.addr)[])
 
   template subborrow_u64(borrowIn: Borrow, a, b: Ct[uint64], sum: var Ct[uint64]): Borrow =
     subborrow_u64(borrowIn, cast[culonglong](a), cast[culonglong](b), cast[ptr culonglong](sum.addr)[])

--- a/constantine/platforms/intrinsics/addcarry_subborrow.nim
+++ b/constantine/platforms/intrinsics/addcarry_subborrow.nim
@@ -94,11 +94,24 @@ when X86:
   else:
     {.pragma: intrinsics, header:"<x86intrin.h>", nodecl.}
 
-  func addcarry_u32(carryIn: Carry, a, b: Ct[uint32], sum: var Ct[uint32]): Carry {.importc: "_addcarry_u32", intrinsics.}
-  func subborrow_u32(borrowIn: Borrow, a, b: Ct[uint32], diff: var Ct[uint32]): Borrow {.importc: "_subborrow_u32", intrinsics.}
+  func addcarry_u32(carryIn: Carry, a, b: culong, sum: var culong): Carry {.importc: "_addcarry_u32", intrinsics.}
+  func subborrow_u32(borrowIn: Borrow, a, b: culong, diff: var culong): Borrow {.importc: "_subborrow_u32", intrinsics.}
 
-  func addcarry_u64(carryIn: Carry, a, b: Ct[uint64], sum: var Ct[uint64]): Carry {.importc: "_addcarry_u64", intrinsics.}
-  func subborrow_u64(borrowIn: Borrow, a, b: Ct[uint64], diff: var Ct[uint64]): Borrow {.importc: "_subborrow_u64", intrinsics.}
+  # Note, Nim uint64 maps to uint64_t which maps to long unsigned int on 64-bit instead of long long unsigned int
+  func addcarry_u64(carryIn: Carry, a, b: culonglong, sum: var culonglong): Carry {.importc: "_addcarry_u64", intrinsics.}
+  func subborrow_u64(borrowIn: Borrow, a, b: culonglong, diff: var culonglong): Borrow {.importc: "_subborrow_u64", intrinsics.}
+
+  template addcarry_u32(carryIn: Carry, a, b: Ct[uint32], sum: var Ct[uint32]): Carry =
+    addcarry_u32(carryIn, cast[culong](a), cast[culong](b), cast[ptr culong](sum.addr)[])
+
+  template subborrow_u32(borrowIn: Borrow, a, b: Ct[uint32], sum: var Ct[uint32]): Borrow =
+    subborrow_u32(borrowIn, cast[culong](a), cast[culong](b), cast[ptr culong](sum.addr)[])
+
+  template addcarry_u64(carryIn: Carry, a, b: Ct[uint64], sum: var Ct[uint64]): Carry =
+    addcarry_u64(carryIn, cast[culong](a), cast[culong](b), cast[ptr culonglong](sum.addr)[])
+
+  template subborrow_u64(borrowIn: Borrow, a, b: Ct[uint64], sum: var Ct[uint64]): Borrow =
+    subborrow_u64(borrowIn, cast[culonglong](a), cast[culonglong](b), cast[ptr culonglong](sum.addr)[])
 
 # ############################################################
 #


### PR DESCRIPTION
GCC 14 made passing an "incompatible" pointer type to another function an error.
- https://gcc.gnu.org/gcc-14/porting_to.html#c
- https://gcc.gnu.org/pipermail/gcc-cvs/2023-December/394351.html

The issue comes from builtin add-carry and sub-borrow.
Nim `uint64` maps to `NU64` which itself maps to `uint64_t` which itself maps to `long unsigned int` on x86-64.

However `_addcarry_u64` has for signature `unsigned char _addcarry_u64 (unsigned char c_in, unsigned __int64 a, unsigned __int64 b, unsigned __int64 * out)`

`unsigned __int64` maps to `unsigned long long` which is deemed incompatible with `uint64_t` so we need an explicit cast.