### PR TITLE
fix: 32-bit on 64-bit compilation

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -86,7 +86,7 @@ proc getEnvVars(): tuple[useAsmIfAble, force32, forceLto, useLtoDefault: bool] =
   else:
     result.useAsmIfAble = true
   if existsEnv"CTT_32":
-    result.force32 = parseBool(getEnv"CTT_ASM")
+    result.force32 = parseBool(getEnv"CTT_32")
   else:
     result.force32 = false
   if existsEnv"CTT_LTO":
@@ -190,7 +190,7 @@ proc releaseBuildOptions(buildMode = bmBinary): string =
   #   "-s -flinker-output=nolto-rel"
   #   with an extra C compiler call
   #   to consolidate all objects into one.
-  let ltoFlags = " -d:lto " & # " --UseAsmSyntaxIntel --passC:-flto=auto --passL:-flto=auto "
+  let ltoFlags = " -d:lto " & # " -d:UseAsmSyntaxIntel --passC:-flto=auto --passL:-flto=auto "
                  # With LTO, the GCC linker produces lots of spurious warnings when copying into openArrays/strings
                  " --passC:-Wno-stringop-overflow --passL:-Wno-stringop-overflow " &
                  " --passC:-Wno-alloc-size-larger-than --passL:-Wno-alloc-size-larger-than "

--- a/constantine/named/deriv/parser_curves.nim
+++ b/constantine/named/deriv/parser_curves.nim
@@ -26,7 +26,6 @@ template getCoef(c: CurveCoef, curveName: untyped): untyped {.dirty.}=
   case c.kind
   of NoCoef:
     error "Unreachable"
-    nnkDiscardStmt.newTree(newLit "Dummy")
   of Small:
     newLit c.coef
   of Large:

--- a/constantine/named/deriv/parser_curves.nim
+++ b/constantine/named/deriv/parser_curves.nim
@@ -25,7 +25,9 @@ export Algebra, CurveFamily, SexticTwist
 template getCoef(c: CurveCoef, curveName: untyped): untyped {.dirty.}=
   case c.kind
   of NoCoef:
-    error "Unreachable"
+    {.warning[UnreachableCode]: off.}: # we need to keep the discard for 1.6.x compat
+      error "Unreachable"
+      nnkDiscardStmt.newTree(newLit "Dummy")
   of Small:
     newLit c.coef
   of Large:

--- a/constantine/platforms/intrinsics/addcarry_subborrow.nim
+++ b/constantine/platforms/intrinsics/addcarry_subborrow.nim
@@ -94,18 +94,18 @@ when X86:
   else:
     {.pragma: intrinsics, header:"<x86intrin.h>", nodecl.}
 
-  func addcarry_u32(carryIn: Carry, a, b: culong, sum: var culong): Carry {.importc: "_addcarry_u32", intrinsics.}
-  func subborrow_u32(borrowIn: Borrow, a, b: culong, diff: var culong): Borrow {.importc: "_subborrow_u32", intrinsics.}
+  func addcarry_u32(carryIn: Carry, a, b: cuint, sum: var cuint): Carry {.importc: "_addcarry_u32", intrinsics.}
+  func subborrow_u32(borrowIn: Borrow, a, b: cuint, diff: var cuint): Borrow {.importc: "_subborrow_u32", intrinsics.}
 
   # Note, Nim uint64 maps to uint64_t which maps to long unsigned int on 64-bit instead of long long unsigned int
   func addcarry_u64(carryIn: Carry, a, b: culonglong, sum: var culonglong): Carry {.importc: "_addcarry_u64", intrinsics.}
   func subborrow_u64(borrowIn: Borrow, a, b: culonglong, diff: var culonglong): Borrow {.importc: "_subborrow_u64", intrinsics.}
 
   template addcarry_u32(carryIn: Carry, a, b: Ct[uint32], sum: var Ct[uint32]): Carry =
-    addcarry_u32(carryIn, cast[culong](a), cast[culong](b), cast[ptr culong](sum.addr)[])
+    addcarry_u32(carryIn, cast[cuint](a), cast[cuint](b), cast[ptr cuint](sum.addr)[])
 
   template subborrow_u32(borrowIn: Borrow, a, b: Ct[uint32], sum: var Ct[uint32]): Borrow =
-    subborrow_u32(borrowIn, cast[culong](a), cast[culong](b), cast[ptr culong](sum.addr)[])
+    subborrow_u32(borrowIn, cast[cuint](a), cast[cuint](b), cast[ptr cuint](sum.addr)[])
 
   template addcarry_u64(carryIn: Carry, a, b: Ct[uint64], sum: var Ct[uint64]): Carry =
     addcarry_u64(carryIn, cast[culonglong](a), cast[culonglong](b), cast[ptr culonglong](sum.addr)[])

--- a/constantine/platforms/x86/macro_assembler_x86_att.nim
+++ b/constantine/platforms/x86/macro_assembler_x86_att.nim
@@ -531,8 +531,17 @@ func getStrOffset(a: Assembler_x86, op: Operand): string =
       return $(op.offset * a.wordSize) & "%" & op.desc.asmId
     else:
       error "Unconfigured compiler"
-  elif op.desc.rm == PointerInReg or
-       op.desc.rm in SpecificRegisters or
+  elif op.desc.rm == PointerInReg:
+    if sizeof(int) == 8: # We might compile in 32-bit mode on a 64-bit machine
+                         # in that case the pointer will be 64-bit, not 32
+      if op.offset == 0:
+        return "0(%q" & op.desc.asmId & ')'
+      return $(op.offset * a.wordSize) & "(%q" & op.desc.asmId & ')'
+    else:
+      if op.offset == 0:
+        return "0(%k" & op.desc.asmId & ')'
+      return $(op.offset * a.wordSize) & "(%k" & op.desc.asmId & ')'
+  elif op.desc.rm in SpecificRegisters or
        (op.desc.rm == ElemsInReg and op.kind == kFromArray):
     if a.wordBitWidth == 64:
       if op.offset == 0:

--- a/tests/math_extension_fields/t_fp_tower_template.nim
+++ b/tests/math_extension_fields/t_fp_tower_template.nim
@@ -31,13 +31,13 @@ echo "\n------------------------------------------------------\n"
 
 template ExtField(degree: static int, name: static Algebra): untyped =
   when degree == 2:
-    Fp2[curve]
+    Fp2[name]
   elif degree == 4:
-    Fp4[curve]
+    Fp4[name]
   elif degree == 6:
-    Fp6[curve]
+    Fp6[name]
   elif degree == 12:
-    Fp12[curve]
+    Fp12[name]
   else:
     {.error: "Unconfigured extension degree".}
 
@@ -58,7 +58,7 @@ func random_elem(rng: var RngState, F: typedesc, gen: RandomGen): F {.inline, no
 proc runTowerTests*[N](
       ExtDegree: static int,
       Iters: static int,
-      TestCurves: static array[N, Curve],
+      TestCurves: static array[N, Algebra],
       moduleName: string,
       testSuiteDesc: string
     ) =

--- a/tests/math_fields/t_finite_fields.nim
+++ b/tests/math_fields/t_finite_fields.nim
@@ -10,7 +10,8 @@ import  std/unittest,
         constantine/math/arithmetic,
         constantine/math/arithmetic/limbs_montgomery,
         constantine/math/io/[io_bigints, io_fields],
-        constantine/named/algebras
+        constantine/named/algebras,
+        constantine/platforms/abstractions
 
 static: doAssert defined(CTT_TEST_CURVES), "This modules requires the -d:CTT_TEST_CURVES compile option"
 
@@ -280,7 +281,7 @@ proc main() =
           # Check equality in the Montgomery domain
           bool(z == r)
           # Check equality when converting back to natural domain
-          cast[uint64](r_bytes) == 100'u64
+          new_r == 100'u64
 
       block:
         var x, y, z, r: Fp[Mersenne61]
@@ -320,7 +321,7 @@ proc largeField() =
 
     test "fromMont doesn't need a final substraction with 256-bit prime (full word used)":
       block:
-        let a = Fp[Secp256k1].getOne()
+        let a = Fp[Secp256k1].getMinusOne()
         let expected = BigInt[256].fromHex"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2E"
 
         var r: BigInt[256]
@@ -338,13 +339,13 @@ proc largeField() =
         var r, expected: BigInt[256]
 
         r.fromField(a)
-        expected.limbs.redc2xMont(d.limbs2x, Secp256k1.Mod().limbs, Fp[Secp256k1].getNegInvModWord(), Fp[Secp256k1].getSpareBits())
+        expected.limbs.redc2xMont(d.limbs2x, Fp[Secp256k1].getModulus().limbs, Fp[Secp256k1].getNegInvModWord(), Fp[Secp256k1].getSpareBits())
 
         check: bool(r == expected)
 
     test "fromMont doesn't need a final substraction with 255-bit prime (1 spare bit)":
       block:
-        let a = Fp[Edwards25519].getOne()
+        let a = Fp[Edwards25519].getMinusOne()
         let expected = BigInt[255].fromHex"0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec"
 
         var r: BigInt[255]
@@ -362,7 +363,7 @@ proc largeField() =
         var r, expected: BigInt[255]
 
         r.fromField(a)
-        expected.limbs.redc2xMont(d.limbs2x, Edwards25519.Mod().limbs, Fp[Edwards25519].getNegInvModWord(), Fp[Edwards25519].getSpareBits())
+        expected.limbs.redc2xMont(d.limbs2x, Fp[Edwards25519].getModulus().limbs, Fp[Edwards25519].getNegInvModWord(), Fp[Edwards25519].getSpareBits())
 
         check: bool(r == expected)
 

--- a/tests/math_fields/t_finite_fields_mulsquare.nim
+++ b/tests/math_fields/t_finite_fields_mulsquare.nim
@@ -10,10 +10,10 @@ import
   # Standard library
   std/[unittest, times],
   # Internal
+  constantine/named/algebras,
   constantine/platforms/abstractions,
   constantine/math/arithmetic,
   constantine/math/io/[io_bigints, io_fields],
-  constantine/math/config/[curves, type_bigint],
   # Test utilities
   helpers/prng_unsafe
 
@@ -28,7 +28,7 @@ echo "test_finite_fields_mulsquare xoshiro512** seed: ", seed
 static: doAssert defined(CTT_TEST_CURVES), "This modules requires the -d:CTT_TEST_CURVES compile option"
 
 proc sanity(Name: static Algebra) =
-  test "Squaring 0,1,2 with " & $Algebra(C) & " [FastSquaring = " & $(Fp[Name].getSpareBits() >= 2) & "]":
+  test "Squaring 0,1,2 with " & $Name & " [FastSquaring = " & $(Fp[Name].getSpareBits() >= 2) & "]":
         block: # 0² mod
           var n: Fp[Name]
 

--- a/tests/math_fields/t_finite_fields_vs_gmp.nim
+++ b/tests/math_fields/t_finite_fields_vs_gmp.nim
@@ -58,8 +58,8 @@ proc binary_prologue[Name: static Algebra, N: static int](
   bTest = rng.random_unsafe(Fp[Name])
 
   # Set modulus to curve modulus
-  let err = mpz_set_str(p, Algebra(C).Mod.toHex(), 0)
-  doAssert err == 0, "Error on prime for curve " & $Algebra(C)
+  let err = mpz_set_str(p, Fp[Name].getmodulus().toHex(), 0)
+  doAssert err == 0, "Error on prime for curve " & $Name
 
   #########################################################
   # Conversion to GMP


### PR DESCRIPTION
This fixes compilation in 32-bit mode on 64-bit machines. And fixes the C definition of 32-bit add-carry intrinsics.
It also updates some test to use the new names following #402

Lastly we kept having "code after noReturn" section in the VM in the curve parser