### PR TITLE
feat(secp256k1): add endomorphism acceleration

### DIFF
--- a/benchmarks/bench_ec_g1.nim
+++ b/benchmarks/bench_ec_g1.nim
@@ -34,7 +34,7 @@ const AvailableCurves = [
   BN254_Snarks,
   # Edwards25519,
   # P256,
-  # Secp256k1,
+  Secp256k1,
   Pallas,
   Vesta,
   BLS12_377,

--- a/benchmarks/bench_ec_g1_scalar_mul.nim
+++ b/benchmarks/bench_ec_g1_scalar_mul.nim
@@ -31,7 +31,7 @@ const AvailableCurves = [
   BN254_Snarks,
   # Edwards25519,
   # P256,
-  # Secp256k1,
+  Secp256k1,
   Pallas,
   Vesta,
   BLS12_377,
@@ -67,7 +67,7 @@ proc main() =
     scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], bits, window = 4, MulIters)
     scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], bits, window = 5, MulIters)
     separator()
-    when bits >= EndomorphismThreshold: # All endomorphisms constants are below this threshold
+    when curve.hasEndomorphismAcceleration():
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp[curve], G1], bits, window = 2, MulIters)
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp[curve], G1], bits, window = 3, MulIters)
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp[curve], G1], bits, window = 4, MulIters)

--- a/benchmarks/bench_ec_g2_scalar_mul.nim
+++ b/benchmarks/bench_ec_g2_scalar_mul.nim
@@ -66,7 +66,7 @@ proc main() =
     scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp2[curve], G2], bits, window = 4, MulIters)
     scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp2[curve], G2], bits, window = 5, MulIters)
     separator()
-    when bits >= EndomorphismThreshold: # All endomorphisms constants are below this threshold
+    when curve.hasEndomorphismAcceleration():
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp2[curve], G2], bits, window = 2, MulIters)
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp2[curve], G2], bits, window = 3, MulIters)
       scalarMulVartimeEndoWNAFBench(EC_ShortW_Prj[Fp2[curve], G2], bits, window = 4, MulIters)

--- a/benchmarks/bench_elliptic_parallel_template.nim
+++ b/benchmarks/bench_elliptic_parallel_template.nim
@@ -56,14 +56,14 @@ proc multiAddParallelBench*(EC: typedesc, numInputs: int, iters: int) =
 type BenchMsmContext*[EC] = object
   tp: Threadpool
   numInputs: int
-  coefs: seq[getBigInt(EC.getName(), kScalarField)]
+  coefs: seq[BigInt[64]] # seq[getBigInt(EC.getName(), kScalarField)]
   points: seq[affine(EC)]
 
 proc createBenchMsmContext*(EC: typedesc, inputSizes: openArray[int]): BenchMsmContext[EC] =
   result.tp = Threadpool.new()
   let maxNumInputs = inputSizes.max()
 
-  const bits = EC.getScalarField().bits()
+  const bits = 64 # EC.getScalarField().bits()
   type ECaff = affine(EC)
 
   result.numInputs = maxNumInputs
@@ -104,7 +104,7 @@ proc createBenchMsmContext*(EC: typedesc, inputSizes: openArray[int]): BenchMsmC
   stdout.write &"in {float64(inNanoSeconds(stop-start)) / 1e6:6.3f} ms\n"
 
 proc msmParallelBench*[EC](ctx: var BenchMsmContext[EC], numInputs: int, iters: int) =
-  const bits = EC.getScalarField().bits()
+  const bits = 64 # EC.getScalarField().bits()
   type ECaff = affine(EC)
 
   template coefs: untyped = ctx.coefs.toOpenArray(0, numInputs-1)

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -529,6 +529,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/math_elliptic_curves/t_ec_sage_bls12_381.nim", false),
   ("tests/math_elliptic_curves/t_ec_sage_pallas.nim", false),
   ("tests/math_elliptic_curves/t_ec_sage_vesta.nim", false),
+  ("tests/math_elliptic_curves/t_ec_sage_secp256k1.nim", false),
 
   # Edge cases highlighted by past bugs
   # ----------------------------------------------------------

--- a/constantine/math/arithmetic/finite_fields.nim
+++ b/constantine/math/arithmetic/finite_fields.nim
@@ -472,6 +472,15 @@ func `*=`*(a: var FF, b: static int) =
     a.double(t)  # 6
     a.double()   # 12
     a += t       # 15
+  elif b == 21:
+    var t {.noInit.}: typeof(a)
+    t.double(a)
+    t.double()   # 4
+    t += a       # 5
+    t.double()   # 10
+    t.double()   # 20
+    a += t       # 21
+
   else:
     {.error: "Multiplication by this small int not implemented".}
 

--- a/constantine/math/elliptic/ec_multi_scalar_mul_parallel.nim
+++ b/constantine/math/elliptic/ec_multi_scalar_mul_parallel.nim
@@ -520,7 +520,13 @@ template withEndo[coefsBits: static int, EC, ECaff](
            coefs: ptr UncheckedArray[BigInt[coefsBits]],
            points: ptr UncheckedArray[ECaff],
            N: int, c: static int, useParallelBuckets: static bool) =
-  when coefsBits <= EC.getScalarField().bits() and hasEndomorphismAcceleration(EC.getName()):
+  when hasEndomorphismAcceleration(EC.getName()) and
+        EndomorphismThreshold <= coefsBits and
+        coefsBits <= EC.getScalarField().bits() and
+        # computeEndomorphism assumes they can be applied to affine repr
+        # but this is not the case for Bandersnatch/wagon
+        # instead Twisted Edwards MSM should be overloaded for Projective/ProjectiveExtended
+        EC.getName() notin {Bandersnatch, Banderwagon}:
     let (endoCoefs, endoPoints, endoN) = applyEndomorphism_parallel(tp, coefs, points, N)
     # Given that bits and N changed, we are able to use a bigger `c`
     # but it has no significant impact on performance

--- a/constantine/named/constants/secp256k1_endomorphisms.nim
+++ b/constantine/named/constants/secp256k1_endomorphisms.nim
@@ -1,0 +1,31 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  constantine/named/algebras,
+  constantine/math/io/[io_bigints, io_fields]
+
+# Secp256k1 G1
+# ------------------------------------------------------------
+
+const Secp256k1_cubicRootOfUnity_mod_p* =
+  Fp[Secp256k1].fromHex"0x851695d49a83f8ef919bb86153cbcb16630fb68aed0a766a3ec693d68e6afa40"
+
+const Secp256k1_Lattice_G1* = (
+  # (BigInt, isNeg)
+  ((BigInt[128].fromHex"0xe4437ed6010e88286f547fa90abfe4c3", false),
+   (BigInt[126].fromHex"0x3086d221a7d46bcde86c90e49284eb15", true)),
+  ((BigInt[126].fromHex"0x3086d221a7d46bcde86c90e49284eb15", false),
+   (BigInt[129].fromHex"0x114ca50f7a8e2f3f657c1108d9d44cfd8", false))
+)
+
+const Secp256k1_Babai_G1* = (
+  # (BigInt, isNeg)
+  (BigInt[129].fromHex"0x114ca50f7a8e2f3f657c1108d9d44cfd9", false),
+  (BigInt[126].fromHex"0x3086d221a7d46bcde86c90e49284eb15", false)
+)

--- a/constantine/named/zoo_endomorphisms.nim
+++ b/constantine/named/zoo_endomorphisms.nim
@@ -27,6 +27,7 @@ import
   ./constants/bw6_761_endomorphisms,
   ./constants/pallas_endomorphisms,
   ./constants/vesta_endomorphisms,
+  ./constants/secp256k1_endomorphisms,
   ./constants/bandersnatch_endomorphisms,
   ./constants/banderwagon_endomorphisms
 
@@ -112,6 +113,7 @@ func hasEndomorphismAcceleration*(Name: static Algebra): bool {.compileTime.} =
     Banderwagon,
     BN254_Nogami,
     BN254_Snarks,
+    Secp256k1,
     BLS12_377,
     BLS12_381,
     BW6_761,

--- a/sage/curves.sage
+++ b/sage/curves.sage
@@ -174,5 +174,16 @@ Curves = {
       'a': 0,
       'b': 5
     }
-  }
+  },
+  'Secp256k1': {
+    'field': {
+      'modulus':  Integer('0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f'),
+      'order': Integer('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141'),
+    },
+    'curve': {
+      'form': 'short_weierstrass',
+      'a': 0,
+      'b': 7
+    }
+  },
 }

--- a/sage/derive_endomorphisms.sage
+++ b/sage/derive_endomorphisms.sage
@@ -258,16 +258,20 @@ if __name__ == "__main__":
     print('\nPrecomputing G1 - 𝜑 (phi) cubic root endomorphism')
     print('----------------------------------------------------\n')
     cubeRootModP, g1lat, g1babai = genCubicRootEndo(curve, Curves)
-    print('\n\nPrecomputing 𝔾₂ - ψ (Psi) - untwist-Frobenius-twist endomorphism')
-    print('----------------------------------------------------\n')
-    g2lat, g2babai = genPsiEndo(curve, Curves)
+
+    hasG2 = 'tower' in Curves[curve]
+
+    if hasG2:
+        print('\n\nPrecomputing 𝔾₂ - ψ (Psi) - untwist-Frobenius-twist endomorphism')
+        print('----------------------------------------------------\n')
+        g2lat, g2babai = genPsiEndo(curve, Curves)
 
     with open(f'{curve.lower()}_endomorphisms.nim', 'w') as f:
       f.write(copyright())
       f.write('\n\n')
       f.write(inspect.cleandoc(f"""
         import
-          constantine/named/algebra,
+          constantine/named/algebras,
           constantine/math/io/[io_bigints, io_fields]
 
         # {curve} G1
@@ -288,18 +292,21 @@ if __name__ == "__main__":
         f'{curve}_Babai_G1',
         dumpBabai(g1babai)
       ))
-      f.write('\n\n')
-      f.write(inspect.cleandoc(f"""
-        # {curve} 𝔾₂
-        # ------------------------------------------------------------
-      """))
-      f.write('\n\n')
-      f.write(dumpConst(
-        f'{curve}_Lattice_G2',
-        dumpLattice(g2lat)
-      ))
       f.write('\n')
-      f.write(dumpConst(
-        f'{curve}_Babai_G2',
-        dumpBabai(g2babai)
-      ))
+      if hasG2:
+        f.write('\n')
+        f.write(inspect.cleandoc(f"""
+            # {curve} 𝔾₂
+            # ------------------------------------------------------------
+        """))
+        f.write('\n\n')
+        f.write(dumpConst(
+            f'{curve}_Lattice_G2',
+            dumpLattice(g2lat)
+        ))
+        f.write('\n')
+        f.write(dumpConst(
+            f'{curve}_Babai_G2',
+            dumpBabai(g2babai)
+        ))
+        f.write('\n')

--- a/sage/testgen_scalar_mul.sage
+++ b/sage/testgen_scalar_mul.sage
@@ -263,5 +263,5 @@ if __name__ == "__main__":
     elif group == 'G2':
       out = genScalarMulG2(curve, Curves, count, seed, scalarBits)
 
-    with open(f'tv_{curve}_scalar_mul_{group}_{bits}bits.json', 'w') as f:
+    with open(f'tv_{curve}_scalar_mul_{group}_{bits}bit.json', 'w') as f:
       json.dump(out, f, indent=2)

--- a/tests/math_elliptic_curves/t_ec_sage_secp256k1.nim
+++ b/tests/math_elliptic_curves/t_ec_sage_secp256k1.nim
@@ -1,0 +1,26 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  constantine/named/algebras,
+  constantine/math/extension_fields,
+  constantine/math/ec_shortweierstrass,
+  # Test utilities
+  ./t_ec_sage_template
+
+staticFor(bits, [32, 64, 128, Fr[Secp256k1].bits()]):
+  run_scalar_mul_test_vs_sage(
+    EC_ShortW_Prj[Fp[Secp256k1], G1], bits,
+    "t_ec_sage_secp256k1_g1_projective"
+  )
+
+  run_scalar_mul_test_vs_sage(
+    EC_ShortW_Jac[Fp[Secp256k1], G1], bits,
+    "t_ec_sage_secp256k1_g1_jacobian"
+  )

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g1_add_double.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g1_add_double.nim
@@ -23,6 +23,12 @@ run_EC_addition_tests(
   )
 
 run_EC_addition_tests(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $Secp256k1
+  )
+
+run_EC_addition_tests(
     ec = EC_ShortW_Jac[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_" & $BLS12_381
@@ -56,6 +62,12 @@ run_EC_addition_vartime_tests(
     ec = EC_ShortW_Jac[Fp[BN254_Snarks], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_vartime_" & $BN254_Snarks
+  )
+
+run_EC_addition_vartime_tests(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_add_double_vartime_" & $Secp256k1
   )
 
 run_EC_addition_vartime_tests(

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mixed_add.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mixed_add.nim
@@ -24,6 +24,12 @@ run_EC_mixed_add_impl(
   )
 
 run_EC_mixed_add_impl(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $Secp256k1
+  )
+
+run_EC_mixed_add_impl(
     ec = EC_ShortW_Jac[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_mixed_add_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_distri.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_distri.nim
@@ -24,6 +24,12 @@ run_EC_mul_distributive_tests(
   )
 
 run_EC_mul_distributive_tests(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $Secp256k1
+  )
+
+run_EC_mul_distributive_tests(
     ec = EC_ShortW_Jac[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_distributive_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_sanity.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_sanity.nim
@@ -69,6 +69,12 @@ suite "Order checks on BN254_Snarks":
       bool not ay.sqrt_if_square()
 
 run_EC_mul_sanity_tests(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_sanity_" & $Secp256k1
+  )
+
+run_EC_mul_sanity_tests(
     ec = EC_ShortW_Jac[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_sanity_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_vs_ref.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_vs_ref.nim
@@ -24,6 +24,12 @@ run_EC_mul_vs_ref_impl(
   )
 
 run_EC_mul_vs_ref_impl(
+    ec = EC_ShortW_Jac[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $Secp256k1
+  )
+
+run_EC_mul_vs_ref_impl(
     ec = EC_ShortW_Jac[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_jacobian_g1_mul_vs_ref_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_jacext_g1_add_double.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jacext_g1_add_double.nim
@@ -23,6 +23,12 @@ run_EC_addition_tests(
   )
 
 run_EC_addition_tests(
+    ec = EC_ShortW_JacExt[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_extended_g1_add_double_" & $Secp256k1
+  )
+
+run_EC_addition_tests(
     ec = EC_ShortW_JacExt[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_extended_g1_add_double_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_jacext_g1_mixed_add.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_jacext_g1_mixed_add.nim
@@ -24,6 +24,12 @@ run_EC_mixed_add_impl(
   )
 
 run_EC_mixed_add_impl(
+    ec = EC_ShortW_JacExt[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_jacobian_extendedmixed_add_" & $Secp256k1
+  )
+
+run_EC_mixed_add_impl(
     ec = EC_ShortW_JacExt[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_jacobian_extendedmixed_add_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_prj_g1_add_double.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_prj_g1_add_double.nim
@@ -23,6 +23,12 @@ run_EC_addition_tests(
   )
 
 run_EC_addition_tests(
+    ec = EC_ShortW_Prj[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_g1_add_double_" & $Secp256k1
+  )
+
+run_EC_addition_tests(
     ec = EC_ShortW_Prj[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_projective_g1_add_double_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mixed_add.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mixed_add.nim
@@ -24,6 +24,12 @@ run_EC_mixed_add_impl(
   )
 
 run_EC_mixed_add_impl(
+    ec = EC_ShortW_Prj[Fp[Secp256k1], G1],
+    Iters = Iters,
+    moduleName = "test_ec_shortweierstrass_projective_mixed_add_" & $Secp256k1
+  )
+
+run_EC_mixed_add_impl(
     ec = EC_ShortW_Prj[Fp[BLS12_381], G1],
     Iters = Iters,
     moduleName = "test_ec_shortweierstrass_projective_mixed_add_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_distri.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_distri.nim
@@ -24,6 +24,12 @@ run_EC_mul_distributive_tests(
   )
 
 run_EC_mul_distributive_tests(
+    ec = EC_ShortW_Prj[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_distributive_" & $Secp256k1
+  )
+
+run_EC_mul_distributive_tests(
     ec = EC_ShortW_Prj[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_distributive_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_sanity.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_sanity.nim
@@ -68,6 +68,12 @@ suite "Order checks on BN254_Snarks":
       bool not ay.sqrt_if_square()
 
 run_EC_mul_sanity_tests(
+    ec = EC_ShortW_Prj[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_sanity_" & $Secp256k1
+  )
+
+run_EC_mul_sanity_tests(
     ec = EC_ShortW_Prj[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_sanity_" & $BLS12_381

--- a/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_vs_ref.nim
+++ b/tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_vs_ref.nim
@@ -24,6 +24,12 @@ run_EC_mul_vs_ref_impl(
   )
 
 run_EC_mul_vs_ref_impl(
+    ec = EC_ShortW_Prj[Fp[Secp256k1], G1],
+    ItersMul = ItersMul,
+    moduleName = "test_ec_shortweierstrass_projective_g1_mul_vs_ref_" & $BN254_Snarks
+  )
+
+run_EC_mul_vs_ref_impl(
     ec = EC_ShortW_Prj[Fp[BLS12_381], G1],
     ItersMul = ItersMul,
     moduleName = "test_ec_shortweierstrass_projective_g1_mul_vs_ref_" & $BLS12_381

--- a/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_128bit.json
+++ b/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_128bit.json
@@ -1,0 +1,532 @@
+{
+  "curve": "Secp256k1",
+  "group": "G1",
+  "modulus": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+  "order": "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x7",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0xd4a05a97c36d8b4ce9a5ad4d45ec4ff8b139ec36833621862eb006f00144eb7",
+        "y": "0xcf3df54add33d3997033004bc98df7409587a36e0a45ca7cdb198288363c4460"
+      },
+      "scalarBits": 128,
+      "scalar": "0x82adaa188435901316b419bddfca2da2",
+      "Q": {
+        "x": "0x72cbbbf056d05a6ec64e5024d5cf79843902bc5442c6cacd5a97aee64adfd8c5",
+        "y": "0x4985583704d276b3080e9625cd37e5a0c7d53a56461fbb4e02e3026f557d5bf"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0x571a82c998879c9d2309354e9bfcf0833604580c7cc491bb104fe2b281893431",
+        "y": "0x9f87d828687c5c0399d16c426feba662c5cf5d3381e0ae30a9b4f78901ee5da9"
+      },
+      "scalarBits": 128,
+      "scalar": "0xe7adcfdd58bd8d84d9dbe065fa274e7",
+      "Q": {
+        "x": "0x64bab93ceec6759e1dc10e3becaca25176065e46c5642eae8b4f8c5daec6f574",
+        "y": "0xaeec6b64cee951bc95d8a1178311b4dc496542f2c530478aa65b500f94da6f5c"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0x405143845ee59da5e889ec76afb264aed5b49793106cdc71d746e0de501d4185",
+        "y": "0x2524aa607e5b0387fba35a6da2ef9dd77b918261a4187e00ee40522b1f16fce4"
+      },
+      "scalarBits": 128,
+      "scalar": "0xb215633497a03d7af3930214b65be136",
+      "Q": {
+        "x": "0xe840c7b6c61baf9da8c095b861f4727de6fcef7cb7d310362af0b2cddd4f2841",
+        "y": "0x488377155dfa2865e6adba0f81465c031fc8c1fc6d6ce7c6dc44807eddb1b24d"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0x28436cf74b570d48db2f9cd3fe1156fe38229975976c1fbfc66983b6b81e46fb",
+        "y": "0x9c0efc64d1096a47915ddf9529817e691a86237eb42d6f4fc2ec29d746fe2c65"
+      },
+      "scalarBits": 128,
+      "scalar": "0x1e19a84981e94a0dcfbc67b6b0f7b5f7",
+      "Q": {
+        "x": "0x5211e549ba5968f23a7a8d3191e576d4abfc207537812c06c3791995be40288b",
+        "y": "0x986ecb7b760d9dee15a2c301c23d624e270f609940ebcdaba7dab508132fdb05"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0x52d09155ac17bf1a820af9c1020d23a7295ccc3f0196fe12a0b729880c03ba10",
+        "y": "0xf8c7a2e9ee0148650703077b809ad3378a9258e9aafa91d587feaae58c771bb8"
+      },
+      "scalarBits": 128,
+      "scalar": "0x63ebaa058ec4e330a71d5b52cd1a2ae9",
+      "Q": {
+        "x": "0x9341b0d4feece01dba0364a924610f1b5b7ba727345b25fb2637adde7525fbe0",
+        "y": "0x9d4c0f47344ffcd71abffb741f9cb347deb31c5e6b2e8286c229991473122cf0"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x9bd9e789948f948a0a018273bc87fc7661d96c88fb50d2f22f5f7c1ca9271eb8",
+        "y": "0x24e44234bca3acf0f0218d7769a1d97b05fb0902ff5e7b20ce00625146ee3cd4"
+      },
+      "scalarBits": 128,
+      "scalar": "0xffbc1514835df813adfe9f4c705fae9e",
+      "Q": {
+        "x": "0xad6542d9c77a9c686d0188d0145f73e80682fbeae3d76e50bbc08bf6bd227a26",
+        "y": "0xdf8d1a7842382f47c969e4ba765b3d2049fa524dd669711cd21c24fc8e677931"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0xe2686b6902305cf7fdc6eb9dc5304214acfbe8f14224fc17c04ed6a6ed87962e",
+        "y": "0xd760b45dea8e69dd2b3d437ff24fc25d83357d9db6a292352c5faec5e14600c9"
+      },
+      "scalarBits": 128,
+      "scalar": "0x672f1d8fba138cc77be22d11f916c075",
+      "Q": {
+        "x": "0x3d592fb4adefb80dd2863cdd1119f1684d102b4684c7ce42c03238c6c51b80b0",
+        "y": "0xaba36450feede0ce272353a02017d83a21092caa6bedd3db9357ab7454deec1f"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0x5b33477f99992141bec786a18b84354ba1523094cd315c3c376f1679059de6f9",
+        "y": "0xad66aa2766a8e40437b70d5e313c9e0ab38ba6c0ea1ac6458a9ba66ee97ead47"
+      },
+      "scalarBits": 128,
+      "scalar": "0x274ab406889b81481c106499d83bd560",
+      "Q": {
+        "x": "0x6e486153e4f9d1c71086168e4817fb2addc22bb82a202330f85416dd1a77ba4c",
+        "y": "0x25a469d6032b10088b154897248c753d13a66baabaec37557b69ca6692f0349c"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0x196a343a6d2a5519451b4fddcbab41dfb8e3fe94ffb5ed4e3b1d9411fa686ac2",
+        "y": "0xe664a4cb0689c3875d1ba92490d545e4dd9e00dcae6f0cd788ee518cb33d1a30"
+      },
+      "scalarBits": 128,
+      "scalar": "0x8f82c939d1736e49e1c5c3a9af95e210",
+      "Q": {
+        "x": "0x674d0fef3ce414b1cb7b615970218ff9e54f0123909643f562e83c94f8cc088f",
+        "y": "0x8b95640258f84118148b5448762590b30c2dbc44d79fb44d00d0f730e1edda2a"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0x92a4a51acbd4b05a8a783d5deb8383549e471419d1758a13d96f3bc7416b35d1",
+        "y": "0x1c3d6d9134e1ff3ba8313568e0f31c547eef5de2167b1bdc6147e6025963f07f"
+      },
+      "scalarBits": 128,
+      "scalar": "0x87c2d6bdcb3a204131ad3b1171526a15",
+      "Q": {
+        "x": "0x1483af71dec419c2b623de179448cbb1a1c11d30702bc54f515d8128c86a9fb5",
+        "y": "0xaca497186897a258e0e702917a53bae87aed868b6db804aa094c6ccb89c2d66f"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0x2fa686baae6df653778b83420e8134bb994599e2e7805215242ab50fd1f81f82",
+        "y": "0xb225e5fb629e15737db492d2f1fbd63fb041d06befbe0a6d7741d2348ba95e33"
+      },
+      "scalarBits": 128,
+      "scalar": "0x7a85019857022b9901cb6c587344485e",
+      "Q": {
+        "x": "0x5d6936a307e9afc1bdb250cdd34df9d7f2604cefe318b11d3fc9c557d9bbb302",
+        "y": "0x4dcbd192d6fa27470202baeb8859c50319431df24e61da3b94f6eba3f59b9334"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0x1c9f2276ecd2dfc229b3f26b42279d5830c00679e5f7bcb1e51ead13ae64cecf",
+        "y": "0x6784fab2fcd579fa8935c8e5d464aad893e269dd23824d9197aa57f78d2e7478"
+      },
+      "scalarBits": 128,
+      "scalar": "0xb29aacb99e0f82fbc872922f7cd4b5c3",
+      "Q": {
+        "x": "0x3e8c035cf672a782768e18ac8c92c12d69e36ba17b8fbfa92c39f7cd9afcab86",
+        "y": "0xd4922ddda3fc418f959487b3780774a20e54f9ae9c5fa558ddb33f9215224362"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0xbc026a5d3647876c380c50d2f0c5aa9cc5a6bb5b0543435eb0dfb379152dec99",
+        "y": "0xbbf834732f9de72d8a8e2bce08c42f0c9d0b31461aabb6e093fee15e8e0c1138"
+      },
+      "scalarBits": 128,
+      "scalar": "0x3151dca7f4dac73289c70feae8ae20d3",
+      "Q": {
+        "x": "0xe6108609dfae606d94de63e03d95473ecfafc72c14cc1bce438885816a5b75d3",
+        "y": "0xae1bb0c0d033fb4b94aef6e099c6618a463e3daccd1ecf61ca4459d8cfc0dbb3"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0x2530f8779eb95d4fe0bad43fd76c587de940fe9f2b7cee72b1830ee56f5b1c85",
+        "y": "0x5ac27069a187fbb7c3aee169f81454016bd3770c2c37320d456b5521584dd64f"
+      },
+      "scalarBits": 128,
+      "scalar": "0x869129d8a544c9c178c34dfd95ebf43f",
+      "Q": {
+        "x": "0x566b0e22dd334a9ff26a5652ef94fc4ce4848f166e82fb2fff5c320958be9de4",
+        "y": "0xa57872c4eb09a64ba3ad8414bbe999568c2510bf83008adc1e771fc1da17d546"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0xa4532410f05650388190765a7aeea3d4604c794e0899049e25e26cef13ea2a4e",
+        "y": "0xd656906935237a9a0583b8a3e42531a4a00267ffb627e2888bec37d615eeb403"
+      },
+      "scalarBits": 128,
+      "scalar": "0xc78fc2008019a213c7ffa7a41903915a",
+      "Q": {
+        "x": "0x338f964b1b94de9897780a3d89d6403942fc77ebb34890e054f6b58f02feebb0",
+        "y": "0xc02440702ace6826c8c0b04d4e4c731d781fdc1da9ba8856094b1dc197793c1e"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0xf2066bf230a96de4a1e003006538a8bd43d073b0535b9672e0cad595e0d66e73",
+        "y": "0x7fa3257842d6c35dd48496e3f4ad590c7d4e38a469a8b6b1844ef55b8e959c0b"
+      },
+      "scalarBits": 128,
+      "scalar": "0xaa9da6dd9782436bf75373b0255bf262",
+      "Q": {
+        "x": "0x368798efb79c59617571770e76b8d42405f5507006397533fe83dac5428283dd",
+        "y": "0x8e53642b24759f3e4352694e1e7e7259f25bb73169b3e3989c5752cd36b3e7bd"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0xbb16ae01f9d34681c078ed6c19b5362c1597a144b93d0870959b519bf18061ee",
+        "y": "0xa501dcee08ad804e7b93bae1d9593926dc02a59e8c9e77264980790f5f3b65c2"
+      },
+      "scalarBits": 128,
+      "scalar": "0xe1ce8045c9eaf6faeb3bffacd3ce02f5",
+      "Q": {
+        "x": "0xbbc257ce017b72f61691bdf50e15cebebb5079beb6b5084627257436f5f6daad",
+        "y": "0x46f2d5f93038747dc2dd3b6c0687cfd8f21e896ca48c680e368320f36da05a6"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0xa72a34ab16c64a0c0cdcf9ba4c19b5d4a51c52cba72ebe3b75f3532417172234",
+        "y": "0x56999635355d2412bbff2641385bd3ba203a985a9843fd3871b6e6d875eae8e0"
+      },
+      "scalarBits": 128,
+      "scalar": "0xd3d34f9d65aad0107a9ca8baf4167da0",
+      "Q": {
+        "x": "0xc1b04b96dd76e20987b5877920bb1eef288636e6907bb7fb5f2294e79ed8d21e",
+        "y": "0xbd2c0c0bc4c99427d6d6bf1f1ad0f7cbab1d2066b35858ca4a1e6ffa83ad41e2"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0xfb19c121793e24435624b841b5f28c38bc8c2e37025254cfe28aebf640ab3b3",
+        "y": "0x69bb48d48edf6c0fa4119173c222c683402fb83af3662e7ee16372d5f57b3027"
+      },
+      "scalarBits": 128,
+      "scalar": "0xdd465b183343852dc4652c48ba45adb1",
+      "Q": {
+        "x": "0x40d54d2487865c79e0058a5915dcf30c8200d5eb3ed457de03f89b2449f2e34a",
+        "y": "0xd40198aef59c29b9809ff094de2657058db4c3317f80757b21ad7afb7af588d9"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0x827877fd8ad8015c62c08a6bedae673e249b75abb6a50635aa6cd38963bdb414",
+        "y": "0xbffef4629801ab762de3d1346051ae1d315d6497d3fdf64a4dca5798fefe699"
+      },
+      "scalarBits": 128,
+      "scalar": "0x813916a9aa529b45fb40a9c7fc70fd19",
+      "Q": {
+        "x": "0x5549cec7d7d7e27f1b6e704a0c33605bfc43f569a3bd9cb855d14f6a5240ca37",
+        "y": "0xd564cb7e300e15b0b4998c2ea83f0846d7333508547881b64bac7b66d8bbc66f"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0x790623ef7b8a51b4eb33f9df533c53aaeddcb63c21ce6c063f60f6b50cfa6a9a",
+        "y": "0x493aebd3536a7d71b61bf2515288efa7358e7c5c252614cb5a64b7f459f3e8b0"
+      },
+      "scalarBits": 128,
+      "scalar": "0x23b2b6796239e200e8f861664c4d9f81",
+      "Q": {
+        "x": "0xf4b67f661c0a644f30d08155620a8e71225c5fd09994e426839a9ffebf72cf8c",
+        "y": "0x8d631706f99b7a3c21cb4453a68413ebd82cd7262a0da1dc9e2a9d38a0be3698"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0xdc8b895bf967c86d22875b175d9133145e327e006a13f3b700850229e7ccecca",
+        "y": "0x3cdd7c18411948eecb47d4e54755e98e98adf4be25dc7507b54018011dfc5555"
+      },
+      "scalarBits": 128,
+      "scalar": "0x64ab3324e2476b57fb726b7593f1974c",
+      "Q": {
+        "x": "0xaa62153a1bf106283224417a8add2fd25d09a5e828d849cab83c010528c7ed0e",
+        "y": "0xa9b590ede519d40abe9a3c359aa8e20d83b6fa6a8e946651f528ac2ba2539291"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x37d7a64a2c875784435aaec1400b97a948abec6038848f943c241f3604becc68",
+        "y": "0x4f8f434ead7ed49450722c9fbe972bc18f336fe776ba4d9348d368f8d730c7a7"
+      },
+      "scalarBits": 128,
+      "scalar": "0xef35bee206383e5ad87209bbcc91b1f7",
+      "Q": {
+        "x": "0xbdf30ea591415a303415e225fb4bef25f31c7b3b8b69d137e0f2738a0212c40f",
+        "y": "0x9569231ef2f7d32254049b6b709abe940f68efae8a348ef48d610631ec9faf1"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0x784451f5dca896588b1900e0fbd1398258e97149cc55677c294272b0e185d600",
+        "y": "0x5e4a83ee5b963924351445de647b31154908e0fb39e51a0a244671a0cb6f8a16"
+      },
+      "scalarBits": 128,
+      "scalar": "0x60c35a36d2a94117ce0b2b4b0eb158f2",
+      "Q": {
+        "x": "0xbf87f7fa6a30592d47379771dae6f306cf82bd0b525f5ff21ac36e138273d421",
+        "y": "0x5095e694e4918b9137e2b613bc4cbc26dc436501ace2ae118c894d082d92c73"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0xa3335ceb9883604ff044e399dd7fc55e53b40956c31b6e9e3aa347caa39ec3ba",
+        "y": "0x157971ac3ce356f086906c9de2fa947eedcf53a8d735f6e1850612861c6447df"
+      },
+      "scalarBits": 128,
+      "scalar": "0x60c3f4c4bc277566425fd17b9393a7ec",
+      "Q": {
+        "x": "0x3112d6f5dc8f5a6ff688c3a1ee78ffd5e1197d5c7d8c91723778e84b943a783a",
+        "y": "0x8f62a88304c6016be98ae310fc0f32f41eb9db93a7f42411f73b1e45704b66dd"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0xd3bf3ee214476a6f1d4cc936ad37e3e7300cc629c86705b18b470e2db61b9183",
+        "y": "0x2687da190f503fa93b8c785ccb6ddf3a9ad80d4cb1271c7a1cfc0f2f59c3c308"
+      },
+      "scalarBits": 128,
+      "scalar": "0xe4acc748369882d87814942b1b87ffb9",
+      "Q": {
+        "x": "0xcb4176e46f1101a773321836381ee138c7eb85798872ee282f37ecba38dbf2e3",
+        "y": "0x452b294551948dc53f510a5eb0e62e58bdb7ec484ec582afe273220d95482b8b"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0x245d3251d06f520e2afd573fbab11ce412fb5212b47f9bcdb0ff927eec98312d",
+        "y": "0xb3524674f45bd0bcf0fe5664ba4990870cf08620da19fe72c6652310a8745ec2"
+      },
+      "scalarBits": 128,
+      "scalar": "0x9dffd98a70d222d8a0c33237011c985f",
+      "Q": {
+        "x": "0x18ce8c440ec2b51b4a8067dc1397f4f27070f4b6325a9c44487f7a15d4640065",
+        "y": "0xdd2a318f54f07ac23712dc20f10fff87601b36e35a8d60307200eec59bd918cf"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0xd397541fa473b1aac84c8d65bd372bda615b3d49631233b95e5e1d74e5c4e9b9",
+        "y": "0xe232a70a8e360c4a5939fd2ea0862688889b9cda3a98d8ae13669eb5c6fc0589"
+      },
+      "scalarBits": 128,
+      "scalar": "0x68227d28e47455244a6d9606ef8955f2",
+      "Q": {
+        "x": "0x49aab2d6d06ef9f072b35f028a1fc9a9dac365819a7b79de94b490c63d0b1682",
+        "y": "0xa0b6a6e10dc478a96bd7dd371c03e033545b383ed184a711b8d700adf7c2b9e"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0x9e1663e9f787f83d011fe816166b5cd6640037b56d158cc97f9a8749a4fa08bf",
+        "y": "0x3f382f5f38eb5d954180950af5e34e15a5fae36130382f8fc563ea2eaccd1f07"
+      },
+      "scalarBits": 128,
+      "scalar": "0xab2e3e76e3d9b5dba4aeb47a5dda90cf",
+      "Q": {
+        "x": "0x4d641cfb78d66103cfb0305d1e0e6db9fe8963c04a411ed61472fccf07df1c7d",
+        "y": "0x79d73ab6dea88ee14692658f47be826e8c097204821430f3e15249de8bab3f98"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0x9776c9be7c054333f5469678fa3f16168ed4cad1fc66a9879c6746386da08452",
+        "y": "0xc977bae7f4579c206244251811a11c978777709622b26c904a09dadb867de1ea"
+      },
+      "scalarBits": 128,
+      "scalar": "0x720436fb4abaffed5e9cd7d24521468e",
+      "Q": {
+        "x": "0x8efb2a620194ca3539639c27b745f5343c57432fbddcb44b4df9c3232028ca1d",
+        "y": "0xd9932d4323a16255e5d909c44b1a1307581ed69e45c1429211c450faa81db296"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0x6ac284025cef183f8508e6e5444c0e5838f2732408bd230cc63cc49e1083797f",
+        "y": "0x15477b0fc3b38f2cf17774160b0262679292f99ffa0fc7a4d4c360f2063b4e4"
+      },
+      "scalarBits": 128,
+      "scalar": "0x668cb5d671e88bb8c9bca31cf07af881",
+      "Q": {
+        "x": "0xde9e31a003cc14c12798cccfc03c11a90086ef1a34ecf811223c65c7b870fcee",
+        "y": "0x505b9d3c8fc86cfebe429b6a4c71dcabf7733ff9a31c036c6d1cc43c3c434e5"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0x6095bffea8bcb9e7376cb73d8876b7586c10fdb677bc92612ea8764ece5a89c6",
+        "y": "0xa5ecb02d41ae6b05960f935b7f8dbd1b1f21b81d5dc755459b10533d2364292f"
+      },
+      "scalarBits": 128,
+      "scalar": "0x88eba2919dfa3680902f34e5b8723dec",
+      "Q": {
+        "x": "0x893bb4d301c5a1686a84d6a9661a0687a98a582ec6719efb76d7484df7c091b9",
+        "y": "0x99291bfd547b32ee0178a8574b1b367c39c3a26d30105ae7ce47b5a78d8f21a5"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0xe50a0ebd93716da2c6a9bf343ac3cb483d6aa0612a2c4bea749aaa6b7a0ebc41",
+        "y": "0xea43772ff0ec0bf6e3259b74477a4986401dd64f2f42d9b85a36bcc171b81826"
+      },
+      "scalarBits": 128,
+      "scalar": "0xb4d1a162fb149f5edf63a9768384db65",
+      "Q": {
+        "x": "0x13fbc60b27b96d5d8a2510ac1318b5f84e146232cdec70bbae7a64121973968f",
+        "y": "0xc4e7c7523c1017607779614350e0dd216b3979454f1d74bc84fa3e2ce0f86e45"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0x4362e8e403c240c9440a3f1b97a401cb9c7d799103eb07652561a0c07f6902f5",
+        "y": "0x965591f842263cac7b0a1512a58005c5bcb9142b4232c38ae869aab979f383f8"
+      },
+      "scalarBits": 128,
+      "scalar": "0x9b68f34764f7f373be6e046d5da880aa",
+      "Q": {
+        "x": "0x96846e5974b3856749b50f2e2ba588cbd35dc42e5b624816c19211e9a6df8d54",
+        "y": "0xd51446734055e713b163e5afcc611337ab464136bbd37b1c3805f615b4753939"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0xa2491f5c3a8952c439b2a6140cdd6e861190d18762166825c4cfcc18c62cae45",
+        "y": "0xb3fb5c5c00f1abd67e8930b944d281f9130bf760af71ae36dff90ca60ca98b9d"
+      },
+      "scalarBits": 128,
+      "scalar": "0xe3ff2362e93947cfd73059986aad3746",
+      "Q": {
+        "x": "0x1167830172077eda683a0f38c9a51375d071b188d08d18d61822b0cf8a2c4d8",
+        "y": "0xd6935452d6b021d6a3633ac54ea43a08a0131c1d6321c97a5d320bf7d4f005e4"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0xbbadb6264927337e0ceb600ccb82fea7ae7224424d62ae346973c76df4455df2",
+        "y": "0x78972029af5a755950fb68de365c4699eb668a6b50695fdbdb7ad9491a63265a"
+      },
+      "scalarBits": 128,
+      "scalar": "0x4b98ac8fa37cf3a1bcce8858cb987505",
+      "Q": {
+        "x": "0x3a7ac2c34a91fbcc7d00460250f8b93684f66b9d536973fdd11b269eff526953",
+        "y": "0x14d22148bd44b0cd3def7ab768cc6ce0063509de57dbf7391840d2ce6a7c4348"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0x3388620f54bc1a1c57bd3cd433dd3e3640d0ccf94b7b3a4138b64c8b469c021c",
+        "y": "0x2f6b2908ddd5634018f195f090492ec5bd22c55be46c955f0e9daf6abc7a7932"
+      },
+      "scalarBits": 128,
+      "scalar": "0x37667472c1489e944ea4782702af3efa",
+      "Q": {
+        "x": "0xe286dd314577fc05c3e1f05cbd6d268c8c8f8a811709a3e046bd3385ef3006c",
+        "y": "0x4da43e04fdb6aaab8c1d264cd3223a2d134d2b60202d4425d0d1ead9bc880b58"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0xf234cc80bbae235fb916a75a2824dded8d2ed341428dea7c990ed120be3f826e",
+        "y": "0x74db8bed12869db125d491dd1c90465f13a8260f2bb2a353fe50d83a72181781"
+      },
+      "scalarBits": 128,
+      "scalar": "0x902799b0fa28b16fa17287ada7bef96a",
+      "Q": {
+        "x": "0x54818f122806bffba4e63249b6c68d26d7a113a977de80bc6976ca5873fae29e",
+        "y": "0xf34791d317d6af583ef556ef5cae05f401d8e926aa49c596082a0e2b31790f13"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0xf43cf6215f24a54bffc2b7b20374e205ca2461d55d3c7a4f7acc3004e4f0e1af",
+        "y": "0x7b4893632a80392f81ab45f673598225df070a1a69095c52ba06078d417f690e"
+      },
+      "scalarBits": 128,
+      "scalar": "0x3ba68ade03a9e84d076d067733a6e4c8",
+      "Q": {
+        "x": "0xfb817a3ec419f02982cf1e07ca1690e4a78c5d8a757718bab0c697a3018ff2f6",
+        "y": "0x1815aeecd60126be74f7c5bce5bd13a1c7e133350d1b4d06c35e47b9c0215d92"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0xd5b3955ad4afb09946ef874b3853dcf3957573df4d7f31add7635e2c059a1bf6",
+        "y": "0x73301fd15d0167e4c5f6756f17827951a3da971d18e6df82caac9a6f6ca56276"
+      },
+      "scalarBits": 128,
+      "scalar": "0xba827fcf0ea632d82bc9f772092a67b7",
+      "Q": {
+        "x": "0x5dc5c42731431a02083f7ef58af01e21bc43c58ce9cbfd8bd4c215c538b66c44",
+        "y": "0x52a05ce136278031f514348bbbd2f0ebaa7dd7d13be69d6e4963d3ce61384a40"
+      }
+    }
+  ]
+}

--- a/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_256bit.json
+++ b/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_256bit.json
@@ -1,0 +1,532 @@
+{
+  "curve": "Secp256k1",
+  "group": "G1",
+  "modulus": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+  "order": "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x7",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0xd4a05a97c36d8b4ce9a5ad4d45ec4ff8b139ec36833621862eb006f00144eb7",
+        "y": "0xcf3df54add33d3997033004bc98df7409587a36e0a45ca7cdb198288363c4460"
+      },
+      "scalarBits": 256,
+      "scalar": "0xd0dc849eb6923fbda94c2f7340dcc4ec82adaa188435901316b419bddfca2da2",
+      "Q": {
+        "x": "0x4e77ae74d9b8159bd0d18f8926ba12f1ac8643bf02cf1451bee39c4d03dcecbe",
+        "y": "0x8fb1ea1c459660c880021e103362d97054d9703afb87dc1091da809c18f25d91"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0xfade45437be5b5ae403a15b2055b4dfb95369e38727d92ecfa0ed473fa1d539d",
+        "y": "0x14db45f04ebb0b23709a611d5bb0ef147472c2c584c8e50af87edb02aa3eeb2b"
+      },
+      "scalarBits": 256,
+      "scalar": "0x7cc491bb104fe2b28189343154d109b5d28221e73970485f20d6e49b7cc629c2",
+      "Q": {
+        "x": "0xf483080c820b9af0e4cf91c81f2dae28b14fc9c7f4d5b72b1d42260cd62998b0",
+        "y": "0x91f5cb4c0deae66c278929ec5fa9a80092a11d916bf97f096d585d6150f06886"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0x4b2fe8b885c869394de42481571a82c998879c9d2309354e9bfcf0833604580c",
+        "y": "0xdf191ef2bfe83059282914f624d2573c6289aadcd3ccd0413f58fbb1a0cb7ee3"
+      },
+      "scalarBits": 256,
+      "scalar": "0x501d418553d246a60e7adcfdd58bd8d84d9dbe065fa274e7fa275e9269f1bffe",
+      "Q": {
+        "x": "0xf711487f18203b5e28640c7f56c28bda1a949379f2e9108d11815c36637d845",
+        "y": "0x8a167c504d1ca2832870daad3d5b7fdaed36c25d73c90a8df3f8a9bdf093bea4"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0xb65be136405143845ee59da5e889ec76afb264aed5b49793106cdc71d746e0de",
+        "y": "0xff017c67b6d16dbef69e09986d534d63c59c1f8ed1fed27e9dcdd6d2325a089f"
+      },
+      "scalarBits": 256,
+      "scalar": "0x38a658a6bd99b7ed8f795e34932df26a13f2c0a5b215633497a03d7af3930214",
+      "Q": {
+        "x": "0xefa5f6e2d348597d03e5c6abced466fe933e3c83b9bc027d791e022569b2bc",
+        "y": "0xcdab5850a939f03539321f5b95402e3a78ca0d6ea7f2f59e446a568f3238b791"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0xec025d82d87021caa0db9856050bd2423f24791ec7039d66cdc031191012fffc",
+        "y": "0x1e8cd6a6b8eca175201331a3ad1783e9c20fb6bd3b1773f19c965b61ff2109d8"
+      },
+      "scalarBits": 256,
+      "scalar": "0x30542bf7fa44626722b70b870ffff15f75214b3e3c351cac9e68906d54e16893",
+      "Q": {
+        "x": "0xc4f8ed4b76afde54e99c34c6f4ed39b01edef90134b602f38e5144901fc76a97",
+        "y": "0xf6a826c4040297db39c740f1255cf360c398387c73e6c36dff699fdc95c31dba"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x12352692ee044cea15d486ff27134c1ea4325c7fc15917b679d8f74779eec5f3",
+        "y": "0x6a10d834330ee8ae678af660bb76b6a35240f3c871bd370daf7017ddb541c489"
+      },
+      "scalarBits": 256,
+      "scalar": "0x38229975976c1fbfc66983b6b81e46fbe8aaddb0627466d44c58f3826f117c44",
+      "Q": {
+        "x": "0x7ccb88013febdbf4043c02e4588a5f02c01017f822f2c4cd886e1dfb264b1a40",
+        "y": "0xe267fd9d90144601cafdbe9e908708d8c3c5fc083fcd747e2a97c7b126390174"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0x1e19a84981e94a0dcfbc67b6b0f7b5f728436cf74b570d48db2f9cd3fe1156fe",
+        "y": "0x57d80d5e3f4677f43a57bc27faaf4b9224879dfdfec38f1065d378047d97c3ca"
+      },
+      "scalarBits": 256,
+      "scalar": "0x9d93a6aece363facbb5530f5c2678c02bf658b481e59c6dec31445ad11c3a38d",
+      "Q": {
+        "x": "0x4d0090d0b5d9d5e40d5eb23a2a084de3fd202ba973bf67da6072c3499e03a93b",
+        "y": "0xf85acafd18c3d406f0617c8ca8c53f4b087efab0b54e0178b294294355f4afd5"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0x76dac66869ac1f9fff15542603e1cf0009606205fc5711e415f80d0e3d26e11f",
+        "y": "0xc46281abb1ba02008399c98f498208f53d181a83732f5c39bd231e6c7e387405"
+      },
+      "scalarBits": 256,
+      "scalar": "0xe37b0856d18ec52485fb8cfc6f1980d41576dd69f72ff3d82c9a25a1da1bb787",
+      "Q": {
+        "x": "0xddb3313a37a6734475b6e702c4bf84da36507a407ce1c2dc4b25d67b84ed346",
+        "y": "0x69d10f3dea191aafe35cea53533ea8cdaad34d3161cfbb16d3f9a8881a6133ad"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0xa71d5b52cd1a2ae9b5c15ab651fcfbf4c30a9373a5c28ded53a7716c52d09155",
+        "y": "0xef373674ba4f0a3b47a66872934f773847f71f17ac0999f47abe5dde1ac8ddb4"
+      },
+      "scalarBits": 256,
+      "scalar": "0xbc87fc7661d96c88fb50d2f22f5f7c1ca9271eb8730ea09963ebaa058ec4e330",
+      "Q": {
+        "x": "0x499e4c5b0e9a8df6d23c46cd3f57876e08a966ab811078604966eccce861abea",
+        "y": "0x6a3c5e7e001fcfae559e01bde00c071a8efaeb61af64b84d8c24401c3a72de47"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0xd33948d2f5f54041c39bbc8b9b40a59d1ea5552b9bd9e789948f948a0a018273",
+        "y": "0xbb9a80daf5e0c7d64c9bf9816f7c6c40f4a5b9a8417ddda96a7aba7b39e11d8d"
+      },
+      "scalarBits": 256,
+      "scalar": "0x4224fc17c04ed6a6ed87962e1db43937ffbc1514835df813adfe9f4c705fae9e",
+      "Q": {
+        "x": "0x9234716b277cfb4484c8dde47dea85162fb031ff64fb57adc8ee7ad081b4260a",
+        "y": "0x15a651a494e16db2b3730e0cc1e10433220983d08fd60aa5c563c5269394377e"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0xa02e15e569e1e3a329302daf4795465c802dfa0c8eb78d27e7a804c720b6078e",
+        "y": "0x429acf0961958b223d86f95f1d8613192dc53d960f49298372f8701f1b70df60"
+      },
+      "scalarBits": 256,
+      "scalar": "0xbcd886a299762fff4e40fd6c50650737f72a47c8dff996ea9e5dee387b530c5a",
+      "Q": {
+        "x": "0x9d6a9f52702a3fdf6959e422e8473a0a24143db9dbb5994bc0f9a3dbcf632547",
+        "y": "0x34de752c07eedced5eea4fcffed456448e1a93a1226c5e08cd24a2e578c1e998"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0xc1ed4d82912a97e4cb00d612f20d72d4833f5ec5e2b9aa24aa6d59d5a9c781ba",
+        "y": "0xa537268ef5505704f55b462915b4f416f99dbcdb42a84d04e34285438cf2273e"
+      },
+      "scalarBits": 256,
+      "scalar": "0xa1523094cd315c3c376f1679059de6f9f1a282d01b3445e04aafddbef1ebb400",
+      "Q": {
+        "x": "0x640df1c03a0d8155905b48658f7e69163c901fe92aac6b663d172fbdf3622e6d",
+        "y": "0x46f8d64c8683df9202fe559075d8ae8541ac042456bc0fbc839a4a8859587dba"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0x2544a3a6b11fbc840e2426776ba778c35b33477f99992141bec786a18b84354b",
+        "y": "0x4ceef0df5822dbf6ffb07e44357985220271392b04390518d33a0669110b9c4a"
+      },
+      "scalarBits": 256,
+      "scalar": "0x3b1d9411fa686ac26f199392274ab406889b81481c106499d83bd560825e778b",
+      "Q": {
+        "x": "0x576a6ecff1dadceb011aceb95aff9f61d5e63e4b8a642f6b8b5c643d47311536",
+        "y": "0x588e7aa257d01ee58788b182047694bbacdea198317801c82c714d280b1cbef4"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0xeb8383549e471419d1758a13d96f3bc7416b35d179fd6bed8f82c939d1736e49",
+        "y": "0xcf48a96d36b08ac43ca798e0069f1fa1010ac0722afb0b8bdfac142de5de189c"
+      },
+      "scalarBits": 256,
+      "scalar": "0xf80ddb20955d693d8d1dac0f0a6aa32f703f190092a4a51acbd4b05a8a783d5d",
+      "Q": {
+        "x": "0xff44f02ea5b26a219b6750f9cbb2cc4e5a01f3e99142610104ae7c2d68683097",
+        "y": "0x6b64c0dd40d57e4fcfa1d923eb2b3b25917c72e706bd63a54c102c28de093115"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0x9a55145de19b6b19ca653b1d13de81514360dff97a85019857022b9901cb6c58",
+        "y": "0x32fb9dfbe889bf069cbe4266f0c903acda8f365d3e345b1eb92592b7109bd4c6"
+      },
+      "scalarBits": 256,
+      "scalar": "0x30c00679e5f7bcb1e51ead13ae64cecf570b00b70f0b022499ae6da069b5a052",
+      "Q": {
+        "x": "0xdb0dea6b35c0d11eeea6c967ce6a251b4483de98bb6e919cdd91c51f69d06c10",
+        "y": "0x18d4330b1a9f640d0869c9beb47e9d8273f0c9af784d656637b552bcd72ecad0"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0xdbf0cb1aaa14ade105f83df91f2e495c1c9f2276ecd2dfc229b3f26b42279d58",
+        "y": "0xe635d4866caaf4fb4078d2ad7a4dcf8c8ae4102f050217799205e8af7d52c998"
+      },
+      "scalarBits": 256,
+      "scalar": "0x8dccade2a7a55a2e30cfd506b29aacb99e0f82fbc872922f7cd4b5c3b56f9129",
+      "Q": {
+        "x": "0x5d08ca98cf3bd8de9a0cbd047b0559fd49c18c76e95693d4b8a5c39b5fb93ce1",
+        "y": "0x40a54d703905e5ec4fa3abaaf6868a4805b4851f0361f6238a296d94c512ccad"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0x89c70feae8ae20d3bc026a5d3647876c380c50d2f0c5aa9cc5a6bb5b0543435e",
+        "y": "0x56deaceec08e4f4c7226a52db6b07f15249ac62c861a92f9bd64c2c044f6b42a"
+      },
+      "scalarBits": 256,
+      "scalar": "0xdbfc10e230a841fab4fabf1c8776410b5c6b3e893bb1838d3151dca7f4dac732",
+      "Q": {
+        "x": "0xc2b9eed62378a299f2bc663bb8cb6469748d03f63c441653adf1804426917f15",
+        "y": "0x1a6cd630b4dc2e7704e0035660d19a483a3a60df340ad7eabfe62b5c083b9e4c"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0xd76c587de940fe9f2b7cee72b1830ee56f5b1c85edb6eb265a64221ca44add07",
+        "y": "0xc28bc93ab896951b157311a4cff227c1c00c909eeda310ccdf617aed0579a995"
+      },
+      "scalarBits": 256,
+      "scalar": "0xa8ad996a220c2f9adbc74d14befb6193f2adc37f2530f8779eb95d4fe0bad43f",
+      "Q": {
+        "x": "0x587391c027af5909d4f4117cb456c115fb40340860a7eb82f08f25ccc130d5af",
+        "y": "0x2301aeff645a70a9ef0445d32073be65118a4378adb5038cb7752d5349f3fa09"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0x255bf2628c8db762a43ea4e52d7026158cb6c90efd0e0923f2066bf230a96de4",
+        "y": "0xe85e8611fa4cfe71242fc3afbddfc665e9a6ae4f12fffd9705dea2852e4489de"
+      },
+      "scalarBits": 256,
+      "scalar": "0x1597a144b93d0870959b519bf18061ee0f431c4daa9da6dd9782436bf75373b0",
+      "Q": {
+        "x": "0x8f3c854ceabed499e605d95fb622ac1bd830be8e85cbcb7c33f091bd57507bf1",
+        "y": "0x4e55a2c9e5170350c0efd60120f7b91f5158570b1108230ebad409d4a8441905"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0xe1ce8045c9eaf6faeb3bffacd3ce02f5bb16ae01f9d34681c078ed6c19b5362c",
+        "y": "0x3c4c53d29b43593f6a566bdb3aff3ddffbe5fc9f33e7ba75cb7b9c41ccd8b223"
+      },
+      "scalarBits": 256,
+      "scalar": "0x5f0b47c75c55acf73d8354e3ddbc1d36a5fabf125c97cc6db332ce30752d00bc",
+      "Q": {
+        "x": "0x76341b4189c312fdb520fefc157e3cd6a279787a7cf73d660c965225f53ee8d6",
+        "y": "0x5757d7ff1c7a062c8a4dc1c3fe9735701ec87c2553e1e0df30ce7b0705ab643"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0x16c64a0c0cdcf9ba4c19b5d4a51c52cba72ebe3b75f35324171722345dda2253",
+        "y": "0xdd7143bc95d67b8bf2216838241528ced32df4d7437cdf1c4aa4364160bfba59"
+      },
+      "scalarBits": 256,
+      "scalar": "0x7a9ca8baf4167da080cf1dd08bd40616bdb02e96ae4738be6e8dd857a72a34ab",
+      "Q": {
+        "x": "0x520c9e05cd4f706383db350b777d9e5303db2d2652bb14cc3b96edb0adae1b8",
+        "y": "0x45f8e149eed50555e1713d95cfd91285bbfe8504512e072050535abded928a1f"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0x827877fd8ad8015c62c08a6bedae673e249b75abb6a50635aa6cd38963bdb414",
+        "y": "0xbffef4629801ab762de3d1346051ae1d315d6497d3fdf64a4dca5798fefe699"
+      },
+      "scalarBits": 256,
+      "scalar": "0x21ce6c063f60f6b50cfa6a9a0a5b3ee8813916a9aa529b45fb40a9c7fc70fd19",
+      "Q": {
+        "x": "0x73053a0eeedcf6614955d3c7660e388fe59cae2cdbda474ff43314a1d71bd7",
+        "y": "0x635f97be90e6c4593a20cf859218c812d02be2fe3a043035f8f57bcf896826b0"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x44b151156d4d2d8b23b2b6796239e200e8f861664c4d9f81df5ed728d86fb7e6",
+        "y": "0x544f14fa56dec58fdca16687099772cd422d26ed78fb830c1c451811000740e7"
+      },
+      "scalarBits": 256,
+      "scalar": "0xe7cceccaae467370e142b10ed5afb6c124eabe7a62b1032197f459be528f35fb",
+      "Q": {
+        "x": "0x9ba9000300de29ee99818328652023fdd5ce78e91626e585da642cb7f0618bc8",
+        "y": "0xa83767651b1ecaaa6e6645825fc03c6c31edd768de1a16e217912b64e604f016"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0x745321ca8880288126bffeeb5f592d117213dd6a64ab3324e2476b57fb726b75",
+        "y": "0x17ec4682f334c8989edaa02f6fd78cbf5c1aa81f712077b86c0252e857c36ff8"
+      },
+      "scalarBits": 256,
+      "scalar": "0x48abec6038848f943c241f3604becc68491e4b8b9df3b373d64eeddbb17c81fb",
+      "Q": {
+        "x": "0xf381d61c7cd2e8e70cd15330d3e88fb894f9635e29bf4fde88610574dddfe3d0",
+        "y": "0x4e3c3a48be4bc511726cc1b16ae20b3cac0bba1fd607277e623041526de657a8"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0xef35bee206383e5ad87209bbcc91b1f737d7a64a2c875784435aaec1400b97a9",
+        "y": "0xe931ee8ca3dae8d0949a709ee83c3badf7c034cc374eb163e116b011a13f6a13"
+      },
+      "scalarBits": 256,
+      "scalar": "0x2ef4ce17f265ebd2408a39e8ced589d70431ae23dc14bd180023459550bb6980",
+      "Q": {
+        "x": "0xd1e93f435aa5452747bbfb2dff4976e1f66556ceff38a3ce4c0745d9721407a7",
+        "y": "0x191721dfb2bba38954cdb56bf379240f071c53ab925c11ba691f7cc368313372"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0x11aa7f3825be0d8da40ce597e104ec8598a8ae624613699da7d63e156ecc586d",
+        "y": "0x3cf3338173c26ab9b60c06c00f55ac14673e9bca9ee20d27dd98f2f0e1090c79"
+      },
+      "scalarBits": 256,
+      "scalar": "0xdca896588b1900e0fbd1398258e97149cc55677c294272b0e185d6009680538c",
+      "Q": {
+        "x": "0x7b9d8626ae27ec2a2639ce0454e0570e65f6de2f9095a8163d12eb9b3c299f46",
+        "y": "0x26aa8d0ca3f303d2bc33b6dbfb5c0af5a5d6c8676d3172780863bd70362093c8"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0xdd7fc55e53b40956c31b6e9e3aa347caa39ec3ba1db4031960c35a36d2a94117",
+        "y": "0x4596f9b712a657126365c923cfa4cc9f3afe92830464edc900d56bc2dcc2f811"
+      },
+      "scalarBits": 256,
+      "scalar": "0x6a814ea860c3f4c4bc277566425fd17b9393a7eca3335ceb9883604ff044e399",
+      "Q": {
+        "x": "0xde28b6e557232fd1e3866e1bffdbe426ab8796f4e35fb3a71dc6501b39814efb",
+        "y": "0xb12b27c1c8864a0924d71bb5e0786d693b3819af0bd65ab0a584e7394a5a4e3"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0xd3bf3ee214476a6f1d4cc936ad37e3e7300cc629c86705b18b470e2db61b9183",
+        "y": "0x2687da190f503fa93b8c785ccb6ddf3a9ad80d4cb1271c7a1cfc0f2f59c3c308"
+      },
+      "scalarBits": 256,
+      "scalar": "0x369882d87814942b1b87ffb9febde3b36545f8230d77d893515aaea79bbfe27d",
+      "Q": {
+        "x": "0x4184c0cabcd019b3a3da4c460a2a39dbf2ddc06eeb291c24a84c36be2bf83e5c",
+        "y": "0x4dec89dd7e6ff78ae38207539a561ce7fefd93ad020bf4eed1fc3697fb8e0238"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0x2afd573fbab11ce412fb5212b47f9bcdb0ff927eec98312d25c52c8fe4acc748",
+        "y": "0x3b69b07dbb1aa2edf206491cb44ae4821cf8641a9cef72ec91a35e3cfc173bb4"
+      },
+      "scalarBits": 256,
+      "scalar": "0x11c985fd48362b5aaa6304d33fc89ffc5ced38af21274ec245d3251d06f520e",
+      "Q": {
+        "x": "0x76327594a20f0ad4d5ea40c8238e8c1e599b857b3a2f3e690f5dc4647c6db079",
+        "y": "0xb4b38d361c51280e7e48d94f42d85d036a8de5fcd0ace0e7d175c103f3016e19"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0xf787f83d011fe816166b5cd6640037b56d158cc97f9a8749a4fa08bf65cbf345",
+        "y": "0xbdcd7fb6f46ea76deb362498a519e46f49a24c2211602fb165ee38e504a48163"
+      },
+      "scalarBits": 256,
+      "scalar": "0x8a68a3b9596ed1e24c462c0aab2e3e76e3d9b5dba4aeb47a5dda90cf9e1663e9",
+      "Q": {
+        "x": "0x24bb1048a17616a8e3ecfbdeef51624b1c17712ece34d51448cb8a16e6c0becd",
+        "y": "0x2f6908e8769e418ab0d74cc7716adb3a0cac3a0b15baa288ba8362403b160180"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0x6ac284025cef183f8508e6e5444c0e5838f2732408bd230cc63cc49e1083797f",
+        "y": "0x15477b0fc3b38f2cf17774160b0262679292f99ffa0fc7a4d4c360f2063b4e4"
+      },
+      "scalarBits": 256,
+      "scalar": "0xdb78aa9175f8038822dd7d5a02143124668cb5d671e88bb8c9bca31cf07af881",
+      "Q": {
+        "x": "0x3381de2accdc38c01ee97284a65a4f41d49f4b7a3df0a40ab8d556747a6489dd",
+        "y": "0x1674c1460d23c5dfd534f759b6c8c6a60944cfbfd662d4ff081940b32d5c2667"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0xc6a9bf343ac3cb483d6aa0612a2c4bea749aaa6b7a0ebc411e051b4b88eba291",
+        "y": "0xc6a8f05deec625f0e3acc5d4ab78d4ca489124d32940da479a881e3ce1d2acaa"
+      },
+      "scalarBits": 256,
+      "scalar": "0x1deed877aa64d679d9311702d313d63e65b0ba26bd1a769de50a0ebd93716da2",
+      "Q": {
+        "x": "0x35760ca112d5fb448f23bc991af7c0f35b14c242d65220784fc51527600f767e",
+        "y": "0x55b68813d5f7fb50431da16d0d8e783bb269b2d03f39d8496d6efc14fc3db098"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0xb4d1a162fb149f5edf63a9768384db65a93315a231aadb3d140f813e130e40a5",
+        "y": "0xec022f490117a46e753d8cbcaeb21f793dce9cdb39b6478128f7d6b7059d3c06"
+      },
+      "scalarBits": 256,
+      "scalar": "0x3c240c9440a3f1b97a401cb9c7d799103eb07652561a0c07f6902f5222d345d",
+      "Q": {
+        "x": "0xc34fee0ffeb998293c6b4a182ced1e915824b22f0d7b7657767ce7fd346909f3",
+        "y": "0x872552ac4067a7252d32e22c0756c65898dfad876559fda3f37d38b9f3e511c"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0xd73059986aad3746a2491f5c3a8952c439b2a6140cdd6e861190d18762166825",
+        "y": "0x61f5d8ebcaead50b365d2bea19a7a117d3fd8200e2cb08951be8dab454b95f8b"
+      },
+      "scalarBits": 256,
+      "scalar": "0xcb82fea7ae7224424d62ae346973c76df4455df212d3f4b5e3ff2362e93947cf",
+      "Q": {
+        "x": "0x3eb382921ab0147303d70785018329be0e5a69ee8c8daf8ff37ad8f97327d1ae",
+        "y": "0x2e4a2c6fdc768b15ff99b24528aaddb0048d275c4d8c5e501946842a6e9634bf"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0xa37cf3a1bcce8858cb987505cce92c33719ad9e008c62565a1c7591ae9d7e2d0",
+        "y": "0x32d8396af1646f969f3f438463c953ad09e7cb9a8708089f1dfaee3fe2d9e104"
+      },
+      "scalarBits": 256,
+      "scalar": "0xc75c92dbb014616fc3686e7e431e1c894baccc4aeaab7d5b76d79c664b98ac8f",
+      "Q": {
+        "x": "0x7bcf3329740c93821d036d3dca520f0f12963d69fbd3f376530cb9bdc1334343",
+        "y": "0x81ba8d1bf6d623b37dab25ddd7594299bb5763eac3ea7bddfcfc617b007e5e93"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0x25d82bda0d27ba98f234cc80bbae235fb916a75a2824dded8d2ed341428dea7c",
+        "y": "0xf557e6decaabe0b5226f84869eb0e7a6856f4cc22f01f43ce1b552fe48a0662a"
+      },
+      "scalarBits": 256,
+      "scalar": "0xdfa281271a822963ca698dca815eecea018d88dffb5005012638effe3e1c7b5d",
+      "Q": {
+        "x": "0xc0277ab0b69b4cb46b9bea4a44ad7d91e429dad94f4623c66d314f63675c7bb5",
+        "y": "0xcbd58397d8c6482e469a2c8b0603673cafbd86dd12b01fe57bb7b651f32a1d7b"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0xdbade881a60f176b880dbb9a5f6c06d14dfdd21b902799b0fa28b16fa17287ad",
+        "y": "0xa710585ac249cb71471227e1c554fbb11ebd0cfed0cdedb40a71e79deb55a18b"
+      },
+      "scalarBits": 256,
+      "scalar": "0xca2461d55d3c7a4f7acc3004e4f0e1afd4ce833d4e00f4ef04fcc5544fd9ead6",
+      "Q": {
+        "x": "0x19f10d316d9584e6cb2306dd09f94946e8b285206bf1a89c6d06e1b6acf27c04",
+        "y": "0x4c9227d89045699e40addb3f375f7254bd57d93ffdecb8777e03aba7c4eb1763"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0x76d067733a6e4c8ca94f21f4c83aed7da49108a71c4f3ecd565d6baefbaa9f2",
+        "y": "0x4644223d5224bd88e458d89102e546d401c7f5578c97c24b3a7cf0f9bab7a62d"
+      },
+      "scalarBits": 256,
+      "scalar": "0x3853dcf3957573df4d7f31add7635e2c059a1bf6701077d53ba68ade03a9e84d",
+      "Q": {
+        "x": "0x433f0d62289e985446a49777f472aed6cd949537ea9d04444c533107a4fc590d",
+        "y": "0x7a5e8fcd15e7278d0d1e5ce195ca03ce9aec522bbee1741817aac315537de2ca"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0x41d6bd3cba827fcf0ea632d82bc9f772092a67b7d5b3955ad4afb09946ef874b",
+        "y": "0xcfa584178c90a3b793af48baeb7bfc5677b2ee2f2f3c5dbc20cc7258445ea1bf"
+      },
+      "scalarBits": 256,
+      "scalar": "0x779a7eaf13f7abe8e15c2808992751ff822f85eaffbc5e891139856fa5939395",
+      "Q": {
+        "x": "0xb263b69b5856505324dc4b0dbc9833040959cc64c78764ae4b41fed27143eace",
+        "y": "0xb100545593b7d0baea0984eb02a71d62b67082a91d38426086fd92d2c18f58d0"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0x9e94494ed36faee08492e40ebfbe2a44602cd97fad1965fd2e05ba753d63e90f",
+        "y": "0xb61786241dd8edb0be1636ff49fab8e3ef772ea40a1ae92d88c9fe801b61e75e"
+      },
+      "scalarBits": 256,
+      "scalar": "0xe33df322419cf8d15b961e23cc40a171f965abed50097f2467548a8f3a51b532",
+      "Q": {
+        "x": "0xdbfc1a9c7235735a38f8fc1117651099a84df9ab707734d20812d5f398779db5",
+        "y": "0x1fe143d96341357d13a854aff15a4bb0b2b91ec814e197d5ab95985346d79733"
+      }
+    }
+  ]
+}

--- a/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_32bit.json
+++ b/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_32bit.json
@@ -1,0 +1,532 @@
+{
+  "curve": "Secp256k1",
+  "group": "G1",
+  "modulus": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+  "order": "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x7",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0xd4a05a97c36d8b4ce9a5ad4d45ec4ff8b139ec36833621862eb006f00144eb7",
+        "y": "0xcf3df54add33d3997033004bc98df7409587a36e0a45ca7cdb198288363c4460"
+      },
+      "scalarBits": 32,
+      "scalar": "0xdfca2da2",
+      "Q": {
+        "x": "0xadb079e667c7d266c1ed1a33f8498729d90f17658fce18696e66b67b5accaf05",
+        "y": "0x37344c8f73a828d1e67858ae38bb3d6b8805f30873f7b5a08bf0af73dda8e"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0xfa0ed473fa1d539dd0dc849eb6923fbda94c2f7340dcc4ec82adaa1884359013",
+        "y": "0x5f5cff549a5d556b45a5cf27d88886bc830ed6edb90165db75f3d4ff29651327"
+      },
+      "scalarBits": 32,
+      "scalar": "0x55b4dfb",
+      "Q": {
+        "x": "0x1fd9d76f4284832b5a6ddebaa33e79a0d3e191a051b98c6635e23200662ac649",
+        "y": "0xd44b08058e82447c4b29f3d93a47126b812beb80c7db31cb53e14497b58aedf5"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0x8189343154d109b5d28221e73970485f20d6e49b7cc629c2fade45437be5b5ae",
+        "y": "0xf03d38fac6ad6340e1d53866d2ef7650d35eb369d7955a826d8ad0221a2469b8"
+      },
+      "scalarBits": 32,
+      "scalar": "0x104fe2b2",
+      "Q": {
+        "x": "0x70423746e33c93db46d15a35cb6df5ca133f561b20e05dc8a21c63f3a0c309b5",
+        "y": "0xed2ad366aea6f26d70559a9965ece01cb49e3294fb0182ee1152c5718468a8a0"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0x4b2fe8b885c869394de42481571a82c998879c9d2309354e9bfcf0833604580c",
+        "y": "0xdf191ef2bfe83059282914f624d2573c6289aadcd3ccd0413f58fbb1a0cb7ee3"
+      },
+      "scalarBits": 32,
+      "scalar": "0x5fa274e7",
+      "Q": {
+        "x": "0x33869112826c4e507e8aaa8e9cc580a3d8a881f381f712c9cf509137a77ed65b",
+        "y": "0x4290ad6bd98d99f6e519d1ce7fb42ed1b099d75d3c6bd18d0e7a330329869b1"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0xafb264aed5b49793106cdc71d746e0de501d418553d246a60e7adcfdd58bd8d8",
+        "y": "0x23cfb72f62617cc9856c6674d7dea0b5e8e499651872a99d52567d5d36482453"
+      },
+      "scalarBits": 32,
+      "scalar": "0xe889ec76",
+      "Q": {
+        "x": "0x8aae418045256cb0c0f9d8e0771dac629b30628a32ae1e58072aca7e71ee100e",
+        "y": "0x9f9ea5720ae6d1023c24e2f799282cd4d6a82f534c359a389218d434c3df37d4"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x8f795e34932df26a13f2c0a5b215633497a03d7af3930214b65be13640514384",
+        "y": "0x6156e0436af5523269e71b85e907a52b94c63ab59223fa8199232860ec8853bc"
+      },
+      "scalarBits": 32,
+      "scalar": "0xbd99b7ed",
+      "Q": {
+        "x": "0x60f7e6aa1531bbc8b58e0efde7de1621fcbf4db683d2c47019b98d2888234964",
+        "y": "0x68b0618ee860c9ed56bcac9cd8f637920554e45f86ee2af4b9f62703367b1c17"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0xec025d82d87021caa0db9856050bd2423f24791ec7039d66cdc031191012fffc",
+        "y": "0x1e8cd6a6b8eca175201331a3ad1783e9c20fb6bd3b1773f19c965b61ff2109d8"
+      },
+      "scalarBits": 32,
+      "scalar": "0x3c351cac",
+      "Q": {
+        "x": "0x582207f1964deb076513cd8ab42e7e0943a0ff45bf81e63eda9fe18a934e9c2b",
+        "y": "0xb04c946179b3cb39f72c53d7fac8c3ab6733362fbc70ace821996091be5a14c9"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0x28436cf74b570d48db2f9cd3fe1156fe38229975976c1fbfc66983b6b81e46fb",
+        "y": "0x9c0efc64d1096a47915ddf9529817e691a86237eb42d6f4fc2ec29d746fe2c65"
+      },
+      "scalarBits": 32,
+      "scalar": "0x81e94a0d",
+      "Q": {
+        "x": "0x6fd2fcf943e19e19211176e0f5dc561ba65737baca609563adc4d43b56bc219e",
+        "y": "0xe1567603104cc26b045d52005e2c378b366ce82ced2bc78d21bd02ac52502c9f"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0x76dac66869ac1f9fff15542603e1cf0009606205fc5711e415f80d0e3d26e11f",
+        "y": "0xc46281abb1ba02008399c98f498208f53d181a83732f5c39bd231e6c7e387405"
+      },
+      "scalarBits": 32,
+      "scalar": "0xda1bb787",
+      "Q": {
+        "x": "0xfb1a0560547f44488ee7a0349ca0750eb4990980717d904189acc583669a19ef",
+        "y": "0x9e147493468ca2142d2f29c59534c72e4a37fb6eb09d30d4a95cd5a1c8f860cb"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0x53a7716c52d09155ac17bf1a820af9c1020d23a7295ccc3f0196fe12a0b72988",
+        "y": "0x96c94e3dfde9061ca819b09f2b877803e871df9d739bdc690862e5b5826b5e9c"
+      },
+      "scalarBits": 32,
+      "scalar": "0x8ec4e330",
+      "Q": {
+        "x": "0x29e8ea019eca3be47a6e458821378587604627ac4aadafb4fc08de2b8ea533cd",
+        "y": "0xc77347b28755dcfdb1d2dfc39c4a4b6084a3e137fb931bd9873964ee9a80e01c"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0x948f948a0a018273bc87fc7661d96c88fb50d2f22f5f7c1ca9271eb8730ea099",
+        "y": "0x7ae923c9acd35e6400d65130175f70ac1f61a5fd256dbc0e3270cd33f5de682d"
+      },
+      "scalarBits": 32,
+      "scalar": "0x9bd9e789",
+      "Q": {
+        "x": "0xbc3edccd887075b15e6db666860c95846e26959f9f26fbcfe0946d0715c65161",
+        "y": "0x4d204fcef86d049d2f1f1f9c09c70c6f72a2a4dfa37608be8eb04bc13354d924"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0xffbc1514835df813adfe9f4c705fae9ed33948d2f5f54041c39bbc8b9b40a59d",
+        "y": "0xa5baebb27cb3a5524fdefa50e36ddbb0dd74b3bf23ed2a338cdfb7526fa225c5"
+      },
+      "scalarBits": 32,
+      "scalar": "0xc04ed6a6",
+      "Q": {
+        "x": "0xacb601bd15d62842f31976899c7182f04fa4642f5aa294851a2bedd2932fbea4",
+        "y": "0xca9ec9079cb815f09e89ea0e05c866953646e11f3d3b9d6e82585579f1ad06f4"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0xa02e15e569e1e3a329302daf4795465c802dfa0c8eb78d27e7a804c720b6078e",
+        "y": "0xbd6530f69e6a74ddc27906a0e279ece6d23ac269f0b6d67c8d078fdfe48f1ccf"
+      },
+      "scalarBits": 32,
+      "scalar": "0x50650737",
+      "Q": {
+        "x": "0xccd96b86c4441615adcda4413ba67c48d3a59f58508f02d11056fffbb3685bac",
+        "y": "0x8e8b6ee407e82ab6437695a135f21464ba6dc6d4adb1ebac6bd6f0508bf6d7e6"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0xcb00d612f20d72d4833f5ec5e2b9aa24aa6d59d5a9c781babcd886a299762fff",
+        "y": "0xdef1719b29f618db06fedfbd4df62499b57e0978ac79a9e8b4fe27e9b294660e"
+      },
+      "scalarBits": 32,
+      "scalar": "0xf1ebb400",
+      "Q": {
+        "x": "0xba56bbb3ce1abb165b13a15fb486761aa11ec086e5d64c78ab9309cca8eb720b",
+        "y": "0x783f1f0bc37c3659f2ec085ddec2e91a784fe7a4b34a5504378c122105f86252"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0xd83bd560825e778b2544a3a6b11fbc840e2426776ba778c35b33477f99992141",
+        "y": "0x307aa16a512b623803a9d919fcbd3d0397c2d0270cb978a15b1726cfebfabe76"
+      },
+      "scalarBits": 32,
+      "scalar": "0x274ab406",
+      "Q": {
+        "x": "0xb216d3354225aed054c1f36ddf1682f2c67ec4406e4025e472adf7638b7491e9",
+        "y": "0xd9b64215f10268865e8d0c829565a9a6c22f4d733588f4a9743308ace5fb75f4"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0x196a343a6d2a5519451b4fddcbab41dfb8e3fe94ffb5ed4e3b1d9411fa686ac2",
+        "y": "0x199b5b34f9763c78a2e456db6f2aba1b2261ff235190f3287711ae724cc2e1ff"
+      },
+      "scalarBits": 32,
+      "scalar": "0x79fd6bed",
+      "Q": {
+        "x": "0x32979e762a7219c716165dd20c59d9a14c937cdd13a58299eb9291ae9e2219b1",
+        "y": "0x5b3fe57e8c7fe045bc2f8d83bcc7a0c75f7ce2c6e580df45443be09a5e47a662"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0x31ad3b1171526a15ad69f64c5c05659b82700cd498dec346a03375afa44074b2",
+        "y": "0x659281c4440d9822e11f675d0de1a5bf48975b6bfa3470563dc737f86b0316b1"
+      },
+      "scalarBits": 32,
+      "scalar": "0x64688728",
+      "Q": {
+        "x": "0x608ae11d6e455de8c82fb8269ead06faa04012d641bf504c7e6795eb6528d57",
+        "y": "0xeeb8e13c0ad1aed41d80146433c4283f329474ca69efe014f1daa2653da0146d"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0x9a55145de19b6b19ca653b1d13de81514360dff97a85019857022b9901cb6c58",
+        "y": "0xcd046204177640f96341bd990f36fc532570c9a2c1cba4e146da6d47ef642769"
+      },
+      "scalarBits": 32,
+      "scalar": "0xf0b0224",
+      "Q": {
+        "x": "0x9ce2a282906603f3a58931883a88237036bdaee968acb9435440dfda36b58f3e",
+        "y": "0x8f6d5f02b3c3d5a416e33d7c833563e21ac3814c619cf29f81984e10acb17bdb"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0x1c9f2276ecd2dfc229b3f26b42279d5830c00679e5f7bcb1e51ead13ae64cecf",
+        "y": "0x987b054d032a860576ca371a2b9b55276c1d9622dc7db26e6855a80772d187b7"
+      },
+      "scalarBits": 32,
+      "scalar": "0x1f2e495c",
+      "Q": {
+        "x": "0x515919dbf7fa221ae22122deae3321ea65e45c527848e4ca0d85fc7f4bcb0bae",
+        "y": "0x74ce525743f46e180959e08f2dee3fe1f4ec76e91b0a11c9eaa2e807787cc371"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0x30cfd506b29aacb99e0f82fbc872922f7cd4b5c3b56f9129dbf0cb1aaa14ade1",
+        "y": "0x7a8aaf1692e06fe3eb33afe578fff6c2e9d3fb95ab2421d27931832f1b40d3be"
+      },
+      "scalarBits": 32,
+      "scalar": "0xe103f853",
+      "Q": {
+        "x": "0x50f44ee91b86acdda9657bcad4dfcc2875b6a2a2197e0abb26aaa5bc22bd9c7a",
+        "y": "0x37ee7e4ec76d32825335adcab988925112045699bcabff710bfeba3172afdcda"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0xbc026a5d3647876c380c50d2f0c5aa9cc5a6bb5b0543435eb0dfb379152dec99",
+        "y": "0xbbf834732f9de72d8a8e2bce08c42f0c9d0b31461aabb6e093fee15e8e0c1138"
+      },
+      "scalarBits": 32,
+      "scalar": "0xf4dac732",
+      "Q": {
+        "x": "0x7abc4eae87a7ab4b0dfbdec0d1f0fb0c6ad09f494703352ffe9d5764a010d1e3",
+        "y": "0x6a55d7f97791fe68273dec9d81fd0781e81185cf805d42aea7328d3c346c9837"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0x5a64221ca44add07dbfc10e230a841fab4fabf1c8776410b5c6b3e893bb1838d",
+        "y": "0x4f50d294a2725c38c12af7e956858b30abcebc334b0ed20b8969eacf5606c17d"
+      },
+      "scalarBits": 32,
+      "scalar": "0xedb6eb26",
+      "Q": {
+        "x": "0xc57f49b4f577d0b46c9b9ade472bf78e0e403b5c62a5780fb6afed9ff26843d5",
+        "y": "0x6118076a9c307b1898d6b501e2537b7ac7fc95e121879904748fdbd077e77fb6"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x8cb6c90efd0e0923f2066bf230a96de4a1e003006538a8bd43d073b0535b9672",
+        "y": "0x728457861c31a395bcf8f04ed37aac27fc8405f5edbe5e1d72f0ea2f93e06785"
+      },
+      "scalarBits": 32,
+      "scalar": "0x8c8db762",
+      "Q": {
+        "x": "0x7efd019d798693845618b26130c46e2b3887f338c738421825fb15966459f0e5",
+        "y": "0x602bbee210fbedd6fb2339e872779304d797306881bb85c25a5b6b0a2177e9bc"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0xe1ce8045c9eaf6faeb3bffacd3ce02f5bb16ae01f9d34681c078ed6c19b5362c",
+        "y": "0x3c4c53d29b43593f6a566bdb3aff3ddffbe5fc9f33e7ba75cb7b9c41ccd8b223"
+      },
+      "scalarBits": 32,
+      "scalar": "0xddbc1d36",
+      "Q": {
+        "x": "0xce095b89052e11f9fd526bf6d2e938d3d275b5d91f298052dcf694c9c6264085",
+        "y": "0x12787d5afcb8f0979585fb5a69d4de970cda499b4aa358c551bf1603c7bf9007"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0xf2b5c8230a80f50f6fe8e9e2907d132eaf6183c85c1632ad5f0b47c75c55acf7",
+        "y": "0x14439a013f5a806c6fa312df712212d40aa5c9c0bcaa7a4229ae5aa3adbd8332"
+      },
+      "scalarBits": 32,
+      "scalar": "0xa10657ac",
+      "Q": {
+        "x": "0x3447a8c5c1ee12322b1da7aa8f918379424843688e50791c30c13efcf2842676",
+        "y": "0x74b2f23cd6ccfc205d62db560c6a8ea9e96d23c4e5c3015a18e4b42ba876d28a"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0x16c64a0c0cdcf9ba4c19b5d4a51c52cba72ebe3b75f35324171722345dda2253",
+        "y": "0x228ebc436a2984740dde97c7dbead7312cd20b28bc8320e3b55bc9bd9f4041d6"
+      },
+      "scalarBits": 32,
+      "scalar": "0xa72a34ab",
+      "Q": {
+        "x": "0x15b0fa9663b9fb0be0ec87484b1170c3cc9573ecb58c8b139780b4bbdfc5fe00",
+        "y": "0x47cdb52939df448689242faf8ea39e31c7e7a5fa06c481d75ab98468e0056362"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0xd3d34f9d65aad0107a9ca8baf4167da080cf1dd08bd40616bdb02e96ae4738be",
+        "y": "0x98bcc834d7a850b72ab5f43af32730f8643452199bc89d11e6437f0f1eca95c6"
+      },
+      "scalarBits": 32,
+      "scalar": "0xe20f97e",
+      "Q": {
+        "x": "0x31063bae56874e4dc09af3f07ba72781833a1a4a3c2b9d9446fa09cdbac4d8bb",
+        "y": "0xcbeac3423c877a1c187f1548b04513fb08c6c2816e47c25020eb971c971d8d61"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0xe0b69e12b19b8541c59c049fe12bb6437eec11dadd465b183343852dc4652c48",
+        "y": "0x2a0ebf98c60edb74d4e65cbf35d7693355f793a877efa9b8cd9536dd8f553810"
+      },
+      "scalarBits": 32,
+      "scalar": "0xd881760e",
+      "Q": {
+        "x": "0xe970da8b95d1b868c4988958112ab29403588409ce50f859bc93026f74edacd1",
+        "y": "0x158438388d7b62b2b06120703f1b9b34045e169b9dae1a23d9f5524c2c33527a"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0x827877fd8ad8015c62c08a6bedae673e249b75abb6a50635aa6cd38963bdb414",
+        "y": "0xbffef4629801ab762de3d1346051ae1d315d6497d3fdf64a4dca5798fefe699"
+      },
+      "scalarBits": 32,
+      "scalar": "0xa5b3ee8",
+      "Q": {
+        "x": "0xe8ffdd9eb096f3c41938315bd1e2f31a7f69ee906df017621a417245c1c23fab",
+        "y": "0xaa88deecb9cafbd3dc4045319d7138eff0554ea15b6f3c32d9760c15283406a5"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0x23b2b6796239e200e8f861664c4d9f81df5ed728d86fb7e6e3c38c864cfefdf5",
+        "y": "0x1c2616a75987f7843ecd3611b503c496a4303cfcaf30f8e73a6c8e2d81f3f4ad"
+      },
+      "scalarBits": 32,
+      "scalar": "0x6d4d2d8b",
+      "Q": {
+        "x": "0x3dcc48b3f5a43650d1db43f52d693fa45ddfc020424532f1710a5a824de21e89",
+        "y": "0x7d682711288eaa08034ee67ec45a9a808f8e591705fc98596372dc98f2c1924"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0x745321ca8880288126bffeeb5f592d117213dd6a64ab3324e2476b57fb726b75",
+        "y": "0x17ec4682f334c8989edaa02f6fd78cbf5c1aa81f712077b86c0252e857c36ff8"
+      },
+      "scalarBits": 32,
+      "scalar": "0x9df3b373",
+      "Q": {
+        "x": "0xbfe372c2c615fcf236ca0b2b2f59e6442b9f0da336c35b8429035159f3f9705b",
+        "y": "0xa9f878beceb4358524eb535368be7619a16f186ef8cb64693ff60b62496a697b"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0x37d7a64a2c875784435aaec1400b97a948abec6038848f943c241f3604becc68",
+        "y": "0x4f8f434ead7ed49450722c9fbe972bc18f336fe776ba4d9348d368f8d730c7a7"
+      },
+      "scalarBits": 32,
+      "scalar": "0x50bb6980",
+      "Q": {
+        "x": "0xadd02cca3c987ef9638a7c74242711c9f2c4daeecd82e9e36975435665993151",
+        "y": "0xab2307aaee43fab00945d81c113724bc727fba77048ad88e79c84e3f7ee31009"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0x74b955c2dae4a9272ef4ce17f265ebd2408a39e8ced589d70431ae23dc14bd18",
+        "y": "0xb93578f73ec89e59be22e582eaea27fb04322cd846682f64363f6f346ef25a4d"
+      },
+      "scalarBits": 32,
+      "scalar": "0xb33ee601",
+      "Q": {
+        "x": "0x66f181df71c967ab683d8e04acd85dbc226c75547320c90c2ad6ea424b972955",
+        "y": "0x5d89a6f293ac47142eb58c2c50ebb9bb60a6c82c0f66b4f583a8dc83a0699816"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0xd344e4476968dec9c94978c8e6e7a65adc71204b784451f5dca896588b1900e0",
+        "y": "0xcf0b2d8c6a2c8ac2e115ca6faae9d19c1705a3ef5148bfdb02d29bf91020fc22"
+      },
+      "scalarBits": 32,
+      "scalar": "0xd2a94117",
+      "Q": {
+        "x": "0x3dc0798511b27a84ed745f679e5e41495e894a847ded68baaf41c8638f0803d3",
+        "y": "0xf8e84ea88f9fe09451df085e410ead87e2384ae5f3be6b85889817a05a59d35b"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0x4f3b3cdfe58ebfe36a814ea860c3f4c4bc277566425fd17b9393a7eca3335ceb",
+        "y": "0x73dfd356887dceb7750d1a633531e3d16ca3b875c24d0f7d009288fd9755a0a8"
+      },
+      "scalarBits": 32,
+      "scalar": "0x2c596674",
+      "Q": {
+        "x": "0xf920dfe8e3ac09e3b592b53a98ede52f56f37a77091b29a01ca77e6a10712f46",
+        "y": "0x234667e5b6f0f04c7230020dd5f0c2af78ad556b9fbdf305bfc8988ee32f32c"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0x1d4cc936ad37e3e7300cc629c86705b18b470e2db61b91832330934013142396",
+        "y": "0x105f9796db886ae77b46db67f42e3ebf0837e7becb5967ab4bbfd96eec6e5e05"
+      },
+      "scalarBits": 32,
+      "scalar": "0x9bbfe27d",
+      "Q": {
+        "x": "0xfcf27b3010bf951f9adea873607f964f8a5bcc5f3cd0577c23308203fc0d2640",
+        "y": "0xbfd21faa2e5959ba898f64a0a4d7ffb2a1d95fa8cc180c32f09856bed9b74d98"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0x245d3251d06f520e2afd573fbab11ce412fb5212b47f9bcdb0ff927eec98312d",
+        "y": "0x4cadb98b0ba42f430f01a99b45b66f78f30f79df25e6018d399adcee578b9d6d"
+      },
+      "scalarBits": 32,
+      "scalar": "0xd48362b5",
+      "Q": {
+        "x": "0xc7d1eb248002dcf84b4c6241428c2427ef2ab3d84d108a88070853b0d8851be7",
+        "y": "0x1646e5dcac7403c3a1ba67e0bf570a6c90d19863a90cbe37c9e179c9313365ed"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0xf787f83d011fe816166b5cd6640037b56d158cc97f9a8749a4fa08bf65cbf345",
+        "y": "0x423280490b91589214c9db675ae61b90b65db3ddee9fd04e9a11c719fb5b7acc"
+      },
+      "scalarBits": 32,
+      "scalar": "0x9e1663e9",
+      "Q": {
+        "x": "0x1034552268f6d6b93ac6730e493c398791ddec3503d365d28d769495e39686dd",
+        "y": "0xe4a2a63cf5e6addb145c837806052134c6ded230a4e9a744511ae1369fba0270"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0xc63cc49e1083797f9313abc393cdb28db939086fbc31f78b5f06d889647ea807",
+        "y": "0x371c35d555c73ac475ac8377a8f2422c69a54b387cf7e96dee2b0b44c06a180"
+      },
+      "scalarBits": 32,
+      "scalar": "0x8bd230c",
+      "Q": {
+        "x": "0x39204cc97235b7b02b54c996c0ef4f81f5ad3a22fbdb814a923b2056b88d5010",
+        "y": "0x4c2eddc066c871da5d65de7051ba86be43a56f161c80242043b6c4b115f0a602"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0x68d678998cf88d16bb7012e2b90d2bf5db78aa9175f8038822dd7d5a02143124",
+        "y": "0xf43164b5f7169600d5b0d5f90b64f9b19ab1bab486fc613b90f9614b234da6bd"
+      },
+      "scalarBits": 32,
+      "scalar": "0x2ea8764e",
+      "Q": {
+        "x": "0xc83a7f14d39bdcff49537ed620069d8add98e4e0637a6180fbb20d1fe55d06a8",
+        "y": "0xd067c94af096ffad4c2e346fe88d5f984559cfa7434eec09348957674e4f0276"
+      }
+    }
+  ]
+}

--- a/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_64bit.json
+++ b/tests/math_elliptic_curves/vectors/tv_Secp256k1_scalar_mul_G1_64bit.json
@@ -1,0 +1,532 @@
+{
+  "curve": "Secp256k1",
+  "group": "G1",
+  "modulus": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+  "order": "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+  "cofactor": "0x1",
+  "form": "short_weierstrass",
+  "a": "0x0",
+  "b": "0x7",
+  "vectors": [
+    {
+      "id": 0,
+      "P": {
+        "x": "0xd4a05a97c36d8b4ce9a5ad4d45ec4ff8b139ec36833621862eb006f00144eb7",
+        "y": "0xcf3df54add33d3997033004bc98df7409587a36e0a45ca7cdb198288363c4460"
+      },
+      "scalarBits": 64,
+      "scalar": "0x403a15b2055b4dfb",
+      "Q": {
+        "x": "0xeacd9c41c2fbbd2b2ff87616ffe29040fd7999f08f9f74171dd171ff088a45aa",
+        "y": "0xe17c5c81a9bb34b9a74265f833a93923641ce3cc83abaf47c3b4fff55f823892"
+      }
+    },
+    {
+      "id": 1,
+      "P": {
+        "x": "0x405143845ee59da5e889ec76afb264aed5b49793106cdc71d746e0de501d4185",
+        "y": "0x2524aa607e5b0387fba35a6da2ef9dd77b918261a4187e00ee40522b1f16fce4"
+      },
+      "scalarBits": 64,
+      "scalar": "0xbd99b7ed8f795e34",
+      "Q": {
+        "x": "0x59f7e2ce564c73d15e748031797ca428c39f8b2208d6fc1046eaee33efecf3d0",
+        "y": "0x11f50ec76c1f47d8a6fda47c5eb8d69cbcc91840d0deb374f56b25bdde8264eb"
+      }
+    },
+    {
+      "id": 2,
+      "P": {
+        "x": "0xec025d82d87021caa0db9856050bd2423f24791ec7039d66cdc031191012fffc",
+        "y": "0x1e8cd6a6b8eca175201331a3ad1783e9c20fb6bd3b1773f19c965b61ff2109d8"
+      },
+      "scalarBits": 64,
+      "scalar": "0x9e68906d54e16893",
+      "Q": {
+        "x": "0x6b33d6e71ad4815afa35063bd9a9a2bed098aee1180a296fb8bf0fdf51a67445",
+        "y": "0xcf0d76c67cf5c708911f8138d33ffaa76eb7fd418fa98906a55ba6fa218077b6"
+      }
+    },
+    {
+      "id": 3,
+      "P": {
+        "x": "0xf72ff3d82c9a25a1da1bb78776dac66869ac1f9fff15542603e1cf0009606205",
+        "y": "0xc47da6ebee61d8cdb37c2805b911387bcbb791ad84658aab3df7b7d0fa105e6c"
+      },
+      "scalarBits": 64,
+      "scalar": "0xe37b0856d18ec524",
+      "Q": {
+        "x": "0x8a57688238eae683c1bf0867e5bd445466a2988d5fac443046ac0ffb19897539",
+        "y": "0x4b163ee40b9a9ee03859d0960d361ed06222cdc1827cd2e35c48c09f4e0a55e8"
+      }
+    },
+    {
+      "id": 4,
+      "P": {
+        "x": "0x52d09155ac17bf1a820af9c1020d23a7295ccc3f0196fe12a0b729880c03ba10",
+        "y": "0xf8c7a2e9ee0148650703077b809ad3378a9258e9aafa91d587feaae58c771bb8"
+      },
+      "scalarBits": 64,
+      "scalar": "0x8ec4e330a71d5b52",
+      "Q": {
+        "x": "0xbb00f21718c38ce8bb8950873409a42cfebda983c6e5eaba4af714e02bd3ba2",
+        "y": "0xef3dd4bea240cf1d5f40e6c3f75cdf4acfa3d5fb74da58e76f932e5e8237099f"
+      }
+    },
+    {
+      "id": 5,
+      "P": {
+        "x": "0x948f948a0a018273bc87fc7661d96c88fb50d2f22f5f7c1ca9271eb8730ea099",
+        "y": "0x8516dc36532ca19bff29aecfe8a08f53e09e5a02da9243f1cd8f32cb0a219402"
+      },
+      "scalarBits": 64,
+      "scalar": "0xfdc6eb9dc5304214",
+      "Q": {
+        "x": "0xd9ced1806ac835267f7302e5a0420735423a654a69e3d8d22f6c103a2c69e46a",
+        "y": "0xb36141849baa2786270e95748ee49f46c7680714608e00899a938b4945b66ef0"
+      }
+    },
+    {
+      "id": 6,
+      "P": {
+        "x": "0xab0324fa4577f221d6ef35d8e0962d949fe646061889798d5b171815e2686b69",
+        "y": "0x11de0d62292a931028c8eeb5b33e74f2de240def9df7ca266e0a39110b1ac746"
+      },
+      "scalarBits": 64,
+      "scalar": "0x89beeb752401e56a",
+      "Q": {
+        "x": "0x6b6d719abb9cba5fb356905db0c4dd942fdd91126ac9b4c30dfcf0ac9ae13794",
+        "y": "0xd14da4b83f8af386ceb67374c3011a85e85625ff4bdda1a570fff5cc72493045"
+      }
+    },
+    {
+      "id": 7,
+      "P": {
+        "x": "0xa02e15e569e1e3a329302daf4795465c802dfa0c8eb78d27e7a804c720b6078e",
+        "y": "0xbd6530f69e6a74ddc27906a0e279ece6d23ac269f0b6d67c8d078fdfe48f1ccf"
+      },
+      "scalarBits": 64,
+      "scalar": "0x50650737f72a47c8",
+      "Q": {
+        "x": "0x1742f3623a860b21ca84a80cf5d1bbd9d4bfa68e9427cba591d6df9b6e9ccdde",
+        "y": "0x329c6a218fb2286883bdc9982a444b37405f17e897a31ee2999a2159608d2c32"
+      }
+    },
+    {
+      "id": 8,
+      "P": {
+        "x": "0xcb00d612f20d72d4833f5ec5e2b9aa24aa6d59d5a9c781babcd886a299762fff",
+        "y": "0x210e8e64d609e724f9012042b209db664a81f687538656174b01d8154d6b9621"
+      },
+      "scalarBits": 64,
+      "scalar": "0x5b33477f99992141",
+      "Q": {
+        "x": "0x516e2476975835a281037100de6421edd3005938b19fb89153de8309e89ab768",
+        "y": "0x6ee26fe92243099640399e421ee5b42383be2480211e7a6fb8f09591235b716b"
+      }
+    },
+    {
+      "id": 9,
+      "P": {
+        "x": "0x6d2a5519451b4fddcbab41dfb8e3fe94ffb5ed4e3b1d9411fa686ac26f199392",
+        "y": "0xdee6f1407a5b78fae9e81dd20622076ea84cd163e7777ec12bcf17628bc0c000"
+      },
+      "scalarBits": 64,
+      "scalar": "0x8f82c939d1736e49",
+      "Q": {
+        "x": "0x9137954e7520679e9be6d1c79d505b6412d5c70e4d8816e3f10bd34f2969c362",
+        "y": "0x987a23d57e945955947f9e968618d8be69629f7141ea1f6ec52ec5102386452"
+      }
+    },
+    {
+      "id": 10,
+      "P": {
+        "x": "0x92a4a51acbd4b05a8a783d5deb8383549e471419d1758a13d96f3bc7416b35d1",
+        "y": "0xe3c2926ecb1e00c457ceca971f0ce3ab8110a21de984e4239eb819fca69c0bb0"
+      },
+      "scalarBits": 64,
+      "scalar": "0xf80ddb20955d693d",
+      "Q": {
+        "x": "0xc7300d577fb4640bcb3354a94eb482da06ef918f8e846cd2e9ad8389d32f15e1",
+        "y": "0x369b8160e3d0cd2b2f652f94699d7457d35b59e27f1da39b289ed9a2c7d3260b"
+      }
+    },
+    {
+      "id": 11,
+      "P": {
+        "x": "0x5c05659b82700cd498dec346a03375afa44074b29ecf23d9bdb17bd3105e1c72",
+        "y": "0xfce3291f286c9e5da905b50e60cd734c6c8a3c51964748d23b6d5d2c7da37753"
+      },
+      "scalarBits": 64,
+      "scalar": "0x71526a15ad69f64c",
+      "Q": {
+        "x": "0x1f21879017da95473dc3ff48eda62a866537d0ed95a519f291b929d381ccc0e",
+        "y": "0x7e25295866fc15fee44c91308d694c2f3ddbd45613989c745480767e3839b993"
+      }
+    },
+    {
+      "id": 12,
+      "P": {
+        "x": "0xd2dd33d4313ec4c568b817d0f327cdba33dc6efd6468872887c2d6bdcb3a2041",
+        "y": "0xb0b46f348a971ebdcbad51fad871d115df106c948ced3a9584af7dd7a42195f6"
+      },
+      "scalarBits": 64,
+      "scalar": "0x1754a2ccfe9b0869",
+      "Q": {
+        "x": "0xccf14049365115ea4c451276fb07b04a2bf58b6c286aeb88e43239d4ec104418",
+        "y": "0x3e8e29d54ee96860370cf631be36a9d5b21947bbe727fc5d761932a6c635709f"
+      }
+    },
+    {
+      "id": 13,
+      "P": {
+        "x": "0x2fa686baae6df653778b83420e8134bb994599e2e7805215242ab50fd1f81f82",
+        "y": "0x4dda1a049d61ea8c824b6d2d0e0429c04fbe2f941041f59288be2dca74569dfc"
+      },
+      "scalarBits": 64,
+      "scalar": "0x1cb6c587344485e",
+      "Q": {
+        "x": "0x1d2cd80245e0889e627e8dbcd1a9fac5207eebe489ac1f28f360161b7284d978",
+        "y": "0x154231ffe621fba8038d2378258f3235b2e9d5cee817958e0ebdb57ab83710a4"
+      }
+    },
+    {
+      "id": 14,
+      "P": {
+        "x": "0x99ae6da069b5a0529a55145de19b6b19ca653b1d13de81514360dff97a850198",
+        "y": "0x6ebbbfe44b60863b4321cd53c16bb303b82e7accdf2511eebaea75ffed5345e8"
+      },
+      "scalarBits": 64,
+      "scalar": "0xe5f7bcb1e51ead13",
+      "Q": {
+        "x": "0x4450eed9f37d1118b0e84fd06f8e1b12881d6e4b6c2bd9686613df4d5cc1d860",
+        "y": "0x25bc2020cd2f89a8085e9aa7ec1048bd26388edfe0b39b1d56fca9716e2ae8dc"
+      }
+    },
+    {
+      "id": 15,
+      "P": {
+        "x": "0xdbf0cb1aaa14ade105f83df91f2e495c1c9f2276ecd2dfc229b3f26b42279d58",
+        "y": "0xe635d4866caaf4fb4078d2ad7a4dcf8c8ae4102f050217799205e8af7d52c998"
+      },
+      "scalarBits": 64,
+      "scalar": "0xb29aacb99e0f82fb",
+      "Q": {
+        "x": "0x15d9d9b841d22a5a683743ee4be65edf77d6fad873f062b57df1c5f5821ca2e1",
+        "y": "0xca969acc154ff21df4af9ba37d5757ae762a46b6639402fcd10e15bf9f2e59d5"
+      }
+    },
+    {
+      "id": 16,
+      "P": {
+        "x": "0xbc026a5d3647876c380c50d2f0c5aa9cc5a6bb5b0543435eb0dfb379152dec99",
+        "y": "0x4407cb8cd06218d27571d431f73bd0f362f4ceb9e554491f6c011ea071f3eaf7"
+      },
+      "scalarBits": 64,
+      "scalar": "0x3bb1838d3151dca7",
+      "Q": {
+        "x": "0x2c1b924776802b7b701909a102656f2d33643253006f73eee5513560b9560443",
+        "y": "0xd174e8a2701bbbbaacea4402fb1b5f6e0b4b9fe443246a25f067a436d98f311f"
+      }
+    },
+    {
+      "id": 17,
+      "P": {
+        "x": "0x8cb6c90efd0e0923f2066bf230a96de4a1e003006538a8bd43d073b0535b9672",
+        "y": "0x728457861c31a395bcf8f04ed37aac27fc8405f5edbe5e1d72f0ea2f93e06785"
+      },
+      "scalarBits": 64,
+      "scalar": "0xb93d0870959b519b",
+      "Q": {
+        "x": "0x2e0584874d9c48cd5603aa3ef2c68468cb7d00b0891e0ef77c7a0e0e9d550ff9",
+        "y": "0x52c120d01ed7c9a381c341147ededc6072123db9c420b683cd6a76e21641df5c"
+      }
+    },
+    {
+      "id": 18,
+      "P": {
+        "x": "0xe1ce8045c9eaf6faeb3bffacd3ce02f5bb16ae01f9d34681c078ed6c19b5362c",
+        "y": "0xc3b3ac2d64bca6c095a99424c500c220041a0360cc18458a348463bd33274a0c"
+      },
+      "scalarBits": 64,
+      "scalar": "0xb332ce30752d00bc",
+      "Q": {
+        "x": "0x574fcc286be56e80cfbdccc080d7b3ca31f2b5b8981cdb7a9214a6be881183b0",
+        "y": "0x20b5433ebdf4620f178cdb77cc9d51a43701dba23b22a0ef1838ec51d8e4b483"
+      }
+    },
+    {
+      "id": 19,
+      "P": {
+        "x": "0xae4738be6e8dd857a72a34ab16c64a0c0cdcf9ba4c19b5d4a51c52cba72ebe3b",
+        "y": "0x620f2a95e2bab721e85d3bd411802c38e50a6549b9c7f8f5dc7850edd1b603bf"
+      },
+      "scalarBits": 64,
+      "scalar": "0x7a9ca8baf4167da0",
+      "Q": {
+        "x": "0xed6c6f2c3bc188f78ceb3f892acdef60649e8b5f753288f8428742c205c67ac8",
+        "y": "0x49f5761c51ec86c77e1300c4c877cedf2a44ab579d8e3038ef2a5c7fab3f7c65"
+      }
+    },
+    {
+      "id": 20,
+      "P": {
+        "x": "0x35624b841b5f28c38bc8c2e37025254cfe28aebf640ab3b30e20f97ed3d34f9d",
+        "y": "0x312c314146a07b6d786ac8fcaed092a2ff3037eed6474284a289bbdb546355f4"
+      },
+      "scalarBits": 64,
+      "scalar": "0xe0b69e12b19b8541",
+      "Q": {
+        "x": "0x9a94342d263c5f8d3877c2b24d8ff16b3f476e8aa6ae227569abe5063b3eb2f1",
+        "y": "0xd13d5ac5e32ae9823f2f2ea5648e5f8621ffdd92a47aff721685ca9a2fc87412"
+      }
+    },
+    {
+      "id": 21,
+      "P": {
+        "x": "0xedae673e249b75abb6a50635aa6cd38963bdb41440e617c2d881760efbea575c",
+        "y": "0x70ac03a37cc22e10acf72502bface776cf19a785ca8f1b76dadc19d7ce20d3a"
+      },
+      "scalarBits": 64,
+      "scalar": "0xa5b3ee8813916a9",
+      "Q": {
+        "x": "0xbd1e20fdd30cc7475f3d34ed7a9bbc07cdd3994eafe6859e1cc8bedf12214ced",
+        "y": "0xd252b911a5ef50799510c1f8948cc121d8d1370a16d2cf7bc6db95340cd118"
+      }
+    },
+    {
+      "id": 22,
+      "P": {
+        "x": "0x23b2b6796239e200e8f861664c4d9f81df5ed728d86fb7e6e3c38c864cfefdf5",
+        "y": "0x1c2616a75987f7843ecd3611b503c496a4303cfcaf30f8e73a6c8e2d81f3f4ad"
+      },
+      "scalarBits": 64,
+      "scalar": "0x44b151156d4d2d8b",
+      "Q": {
+        "x": "0xcc2411e0d2b765b2f0cf2126710e13cffe74a060998215d75b77d518c233957",
+        "y": "0x44cdcb8ac049593537457afcdbbadf1aa53651eb117a9219db3439bdb53b6223"
+      }
+    },
+    {
+      "id": 23,
+      "P": {
+        "x": "0xfb726b7593f1974cdc8b895bf967c86d22875b175d9133145e327e006a13f3b7",
+        "y": "0x48c86f41b10698791ab65db72029854088e779092d668ea5da4bf1837375818f"
+      },
+      "scalarBits": 64,
+      "scalar": "0x64ab3324e2476b57",
+      "Q": {
+        "x": "0x413bd1291a316b8b826111d2495eb625e59fc90b3da0acac5b9bef31ce5da760",
+        "y": "0x217c86bd30b29d562d49becf1d2439956e2757752a2ed1738fb0aef1b3feb8e3"
+      }
+    },
+    {
+      "id": 24,
+      "P": {
+        "x": "0x37d7a64a2c875784435aaec1400b97a948abec6038848f943c241f3604becc68",
+        "y": "0x4f8f434ead7ed49450722c9fbe972bc18f336fe776ba4d9348d368f8d730c7a7"
+      },
+      "scalarBits": 64,
+      "scalar": "0xd87209bbcc91b1f7",
+      "Q": {
+        "x": "0xd4d353bfee99313644d6b73bc2929489fecaea7fe7c45d33af2be7f0a9115978",
+        "y": "0x3dade3dcdd3933d4fe4fb7a9bfb86967c8993183f6b92b5ea6f86148cf68a817"
+      }
+    },
+    {
+      "id": 25,
+      "P": {
+        "x": "0xf265ebd2408a39e8ced589d70431ae23dc14bd180023459550bb6980ef35bee2",
+        "y": "0x2e9a0df83dfade7b5ccf8245a0a9e2aa2606e5a02b231845323fa7930e0e151a"
+      },
+      "scalarBits": 64,
+      "scalar": "0xdae4a9272ef4ce17",
+      "Q": {
+        "x": "0xf1ee1d246141f45723f127e260ed8af1eb62689bdd965e49914b0a3d87641594",
+        "y": "0x1c9bf7d26eaf41995d99199536b799af72859054cfb10100c9cb4f9c469a6443"
+      }
+    },
+    {
+      "id": 26,
+      "P": {
+        "x": "0xdc71204b784451f5dca896588b1900e0fbd1398258e97149cc55677c294272b0",
+        "y": "0x5a8083bbf6b176730fce4490970031754baa2145d54b7d40d10a53203a4453f1"
+      },
+      "scalarBits": 64,
+      "scalar": "0xc94978c8e6e7a65a",
+      "Q": {
+        "x": "0xdbbb57da3a61ca606b14e908589ff4dba774619e4977ea54f550fb35ffbb5bb2",
+        "y": "0xa7c31a81d52099321a02974a8ed809375fa71f986691419735fbb0948730527b"
+      }
+    },
+    {
+      "id": 27,
+      "P": {
+        "x": "0x425fd17b9393a7eca3335ceb9883604ff044e399dd7fc55e53b40956c31b6e9e",
+        "y": "0xab9ffa5c30d7a29ed1f0c8b0b06904f28c16bd257a059f3f56474f7bdde3a4b"
+      },
+      "scalarBits": 64,
+      "scalar": "0x60c3f4c4bc277566",
+      "Q": {
+        "x": "0x1b16c634caea65d5a75d3cc8aae58dc73e8da6a4edf5ba6c3b18534cfc7e8144",
+        "y": "0xcd214afb0391851707a95522bafcbb2358cff9b101be2ab0b04de83936a5b2e8"
+      }
+    },
+    {
+      "id": 28,
+      "P": {
+        "x": "0xd3bf3ee214476a6f1d4cc936ad37e3e7300cc629c86705b18b470e2db61b9183",
+        "y": "0xd97825e6f0afc056c47387a3349220c56527f2b34ed8e385e303f0cfa63c3927"
+      },
+      "scalarBits": 64,
+      "scalar": "0x515aaea79bbfe27d",
+      "Q": {
+        "x": "0x2f3dce918d3adc8d93f62c9be45018ff8d573544439bd2e93f7200b0bb3bfa3a",
+        "y": "0xc2729b4baec8fabb544e4728da183bdaabbd606935053bcdafed094b15417c73"
+      }
+    },
+    {
+      "id": 29,
+      "P": {
+        "x": "0xf21274ec245d3251d06f520e2afd573fbab11ce412fb5212b47f9bcdb0ff927e",
+        "y": "0xda2162f21b2236f61f82c80f9f8cf2918a643fde792ac6f86c71ff1969adff5a"
+      },
+      "scalarBits": 64,
+      "scalar": "0x9dffd98a70d222d8",
+      "Q": {
+        "x": "0x8e616a041f1294a2c712c190ead14dcf7af0a3858ec17811e33ee3abc5be9f6d",
+        "y": "0x406a2a3744f12676d4911f8756b84c9cc26b42504bc6495ad22b37b452e0ffe8"
+      }
+    },
+    {
+      "id": 30,
+      "P": {
+        "x": "0xd397541fa473b1aac84c8d65bd372bda615b3d49631233b95e5e1d74e5c4e9b9",
+        "y": "0x1dcd58f571c9f3b5a6c602d15f79d97777646325c5672751ec9961493903f6a6"
+      },
+      "scalarBits": 64,
+      "scalar": "0x6d158cc97f9a8749",
+      "Q": {
+        "x": "0xb59405c32a11b790328e79d13ad03e7d961ab9f40a7a2bab006e9f11c26d1eaa",
+        "y": "0x12620514ee5834465dbe01c5393987dd28207a41969249c6ae6c5e2af1957173"
+      }
+    },
+    {
+      "id": 31,
+      "P": {
+        "x": "0x7c054333f5469678fa3f16168ed4cad1fc66a9879c6746386da08452ab180568",
+        "y": "0x7adf12f99a2297415fe984f53f4bed78d7071936fc1c2de435c8da34226f27f2"
+      },
+      "scalarBits": 64,
+      "scalar": "0xc2e955339776c9be",
+      "Q": {
+        "x": "0xd13400a5665839833478d48179a27ca2cfcefc3a4fe077b57a81c4856617cf72",
+        "y": "0xe31323336d0282cb916958e232f76f501787940fff2cfe665d0702b2464b7c33"
+      }
+    },
+    {
+      "id": 32,
+      "P": {
+        "x": "0x6ac284025cef183f8508e6e5444c0e5838f2732408bd230cc63cc49e1083797f",
+        "y": "0xfeab884f03c4c70d30e888be9f4fd9d986d6d066005f0385b2b3c9efdf9c474b"
+      },
+      "scalarBits": 64,
+      "scalar": "0xc9bca31cf07af881",
+      "Q": {
+        "x": "0xaff29bbedb1e78ad9de3029ffa3f535c0af787dc34623bb344c1569553b80d9a",
+        "y": "0x1556484d46e10f5d223787cad40abd02bec5a0dc200777e43b6cb6c1c32d694d"
+      }
+    },
+    {
+      "id": 33,
+      "P": {
+        "x": "0x8cf88d16bb7012e2b90d2bf5db78aa9175f8038822dd7d5a02143124668cb5d6",
+        "y": "0xb3af7144f19c308eb4447bceff80ac9e9d787afa6468e1ab92cdf37318af9fc0"
+      },
+      "scalarBits": 64,
+      "scalar": "0x77bc92612ea8764e",
+      "Q": {
+        "x": "0xac64912ff26a28092b0b0ffe7375067b08b77ec889cd55dc0e90fe68205db880",
+        "y": "0xb3ae2c0ddcb843c344ccc0f5f4888e241a5600d112f765612b123f304230cf18"
+      }
+    },
+    {
+      "id": 34,
+      "P": {
+        "x": "0x88eba2919dfa3680902f34e5b8723dec6095bffea8bcb9e7376cb73d8876b758",
+        "y": "0xf636e97fcd3d304dfdc0bed30fc7f878757989004834262ad2730e3425aee767"
+      },
+      "scalarBits": 64,
+      "scalar": "0x7a0ebc411e051b4b",
+      "Q": {
+        "x": "0x2a68abf0462cdf12feccdf82f40e16545830bf620e8ee06a6680d10c1a53ef94",
+        "y": "0x9fc342212b3c034f02ce71db3112b5ed6df3ec4067b043a6dbd5d44ae3d14fb1"
+      }
+    },
+    {
+      "id": 35,
+      "P": {
+        "x": "0xa93315a231aadb3d140f813e130e40a51deed877aa64d679d9311702d313d63e",
+        "y": "0xf76f733676db3f18bddfd4ecde6cddd5303fe99272a09bf8673ef4d004753bd3"
+      },
+      "scalarBits": 64,
+      "scalar": "0x222d345db4d1a162",
+      "Q": {
+        "x": "0x4c5d15ae72587806cb941db880aa3d1de0a512b31a880b7776623afbb0c920f4",
+        "y": "0xeeda92eb936d92dace9166f5e8d3119d305c7d414ccf09b72966e90053ada149"
+      }
+    },
+    {
+      "id": 36,
+      "P": {
+        "x": "0xe3ff2362e93947cfd73059986aad3746a2491f5c3a8952c439b2a6140cdd6e86",
+        "y": "0x414b7df2faf5c8bc38d39ba472b7b34822fa1a80d963f975c89ea5dbb9726816"
+      },
+      "scalarBits": 64,
+      "scalar": "0xf4455df212d3f4b5",
+      "Q": {
+        "x": "0xd722b914c8c6dec707ccfea0e830d07df9e5a1749fc01329b0cb8d37caa41981",
+        "y": "0x92636886cd179bcec2e3bbea5ecd7a025838fcd8893ae59f11ebaf83da309b1e"
+      }
+    },
+    {
+      "id": 37,
+      "P": {
+        "x": "0x1e14ecdc973bed2a875aa9e4bf867b86e04f752e69149b5ada3e8b58cc358430",
+        "y": "0xd1f097b6cb23f6ac06ba549796615ddacae29b09850df424b1e7541d94481968"
+      },
+      "scalarBits": 64,
+      "scalar": "0x2af3efacfc7f883",
+      "Q": {
+        "x": "0x32828a212e83444eb3d751dcda00a79d8d2846ce8fb5f7f05a2213793f2b6602",
+        "y": "0x2ed6dab4ea60cb5c2f52b0ede86bfc676100df59029c772457c83e35c69aa12a"
+      }
+    },
+    {
+      "id": 38,
+      "P": {
+        "x": "0x2824dded8d2ed341428dea7c990ed120be3f826e31e6faa437667472c1489e94",
+        "y": "0xbfad95638b393114f142317fcd9ee8c4599048b3163f03bfdd58f872cdd638e5"
+      },
+      "scalarBits": 64,
+      "scalar": "0x25d82bda0d27ba98",
+      "Q": {
+        "x": "0x98dab304a401c0b250410b01ff30f1931084d5731fc315f9f3af80eec6ee8d3f",
+        "y": "0xc409e69a5653cc77762d8850dc36a5e921a6262e29792046b9b8eb15c9b5fc43"
+      }
+    },
+    {
+      "id": 39,
+      "P": {
+        "x": "0x6fd4e31adfa281271a822963ca698dca815eecea018d88dffb5005012638effe",
+        "y": "0x45c0efd7f5426062c499a647b641bce74e70cb30f4dbb806c2a0294862e809eb"
+      },
+      "scalarBits": 64,
+      "scalar": "0x5160f79ff1d0336f",
+      "Q": {
+        "x": "0xf76b5be43060742616f9df2cc7547b9c13b8226da905a97797a2a97d2e9e21c0",
+        "y": "0xf15ac743783231e1a3629c07637392214115799b41c8d0d12efc94ca3867b7f5"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is the first of a series of PR to bring secp256k1 performance to state-of-the-art and then beyond.

See overall steps in #285.

## Benchmarks

Unfortunately the most important primitive field multiplication does not use assembly for secp256k1 (256-bit) at the moment. Hence the huge gap (~30%) with the Pallas curve (255-bit) for example.

![image](https://github.com/user-attachments/assets/463da532-aaf2-4f28-b4ba-df378792dcaa)
![image](https://github.com/user-attachments/assets/a8c74ba7-6e6c-48c0-8bcb-6d3b517b7535)

![image](https://github.com/user-attachments/assets/76a8f617-bc46-4d94-98d7-0f8ded180dd2)
![image](https://github.com/user-attachments/assets/c2b39e61-5365-4227-850b-c2532ebb3633)
