### PR TITLE
Verkle ipa multiproof is now internally consistent

### DIFF
--- a/constantine/commitments/eth_verkle_ipa.nim
+++ b/constantine/commitments/eth_verkle_ipa.nim
@@ -938,6 +938,7 @@ func ipa_multi_verify*[N, logN: static int, EcAff, F](
   #   g₂(t) disagrees with <a, b> inner product in ipa_multi_prove
   # Compute g₂(t) = ∑rⁱ.yᵢ/(t-zᵢ)
   var g2t {.noInit.}: F
+  g2t.setZero()
 
   for i in 0 ..< num_distinct_challenges:
     var tmp {.noInit.}: Fr[Banderwagon]

--- a/constantine/commitments/protocol_quotient_check.nim
+++ b/constantine/commitments/protocol_quotient_check.nim
@@ -220,4 +220,5 @@ func getQuotientPolyInDomain*[N: static int, Field](
       lindom.dom.vanishing_deriv_poly_eval.evals[zIndex],
       lindom.dom.vanishing_deriv_poly_eval_inv.evals[i]
     )
+    ri *= r.evals[i]
     r.evals[zIndex] -= ri


### PR DESCRIPTION
This is a followup to the Verkle refactoring from
- https://github.com/mratsim/constantine/pull/397

While simple proof generation / verification had an off-by-one found right away https://github.com/mratsim/constantine/pull/403,
multiproofs had:
- a multiplication missing in polynomial division that was not tested by the multiproof consistency check https://github.com/mratsim/constantine/pull/424
- a zero init missing

The current code is self-consistent, but we need more assurance that the outputs are the same as the other libraries.
Hence we keep https://github.com/mratsim/constantine/issues/396 open to make sure test coverage is improved and corner cases are hardened.