### PR TITLE
Nvidia remastered

### DIFF
--- a/constantine/math_compiler/impl_fields_dispatch.nim
+++ b/constantine/math_compiler/impl_fields_dispatch.nim
@@ -1,0 +1,34 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  constantine/platforms/llvm/llvm,
+  ./ir,
+  ./impl_fields_sat {.all.},
+  ./impl_fields_nvidia {.all.}
+
+proc modadd*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) =
+  case asy.backend
+  of {bkX86_64_Linux, bkAmdGpu}:
+    asy.modadd_sat(fd, r, a, b, M)
+  of bkNvidiaPTX:
+    asy.modadd_nvidia(fd, r, a, b, M)
+
+proc modsub*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) =
+  case asy.backend
+  of bkNvidiaPTX:
+    asy.modsub_nvidia(fd, r, a, b, M)
+  else:
+    doAssert false, "Unimplemented"
+
+proc mtymul*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) =
+  case asy.backend
+  of bkNvidiaPTX:
+    asy.mtymul_nvidia(fd, r, a, b, M)
+  else:
+    doAssert false, "Unimplemented"

--- a/constantine/math_compiler/impl_fields_globals.nim
+++ b/constantine/math_compiler/impl_fields_globals.nim
@@ -157,8 +157,7 @@ proc getM0ninv*(asy: Assembler_LLVM, fd: FieldDescriptor): ValueRef =
         fd.wordTy
       )
 
-
-  return m0ninv
+  return asy.load2(fd.wordTy, m0ninv, "m0ninv")
 
 when isMainModule:
   let asy = Assembler_LLVM.new("test_module", bkX86_64_Linux)

--- a/constantine/math_compiler/impl_fields_nvidia.nim
+++ b/constantine/math_compiler/impl_fields_nvidia.nim
@@ -8,7 +8,8 @@
 
 import
   constantine/platforms/llvm/[llvm, asm_nvidia],
-  ./ir
+  ./ir,
+  ./impl_fields_globals
 
 # ############################################################
 #
@@ -46,7 +47,9 @@ import
 #
 # We cannot use i256 on Nvidia target: https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp#L244-L276
 
-proc finalSubMayOverflow(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, r, a: Array) =
+const SectionName = "ctt.fields"
+
+proc finalSubMayOverflow(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, M: Array) =
   ## If a >= Modulus: r <- a-M
   ## else:            r <- a
   ##
@@ -55,31 +58,27 @@ proc finalSubMayOverflow(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, r
   ##
   ## To be used when the final substraction can
   ## also overflow the limbs (a 2^256 order of magnitude modulus stored in n words of total max size 2^256)
-
-  let bld = asy.builder
-  let fieldTy = cm.getFieldType(field)
-  let scratch = bld.makeArray(fieldTy)
-  let M = cm.getModulus(field)
-  let N = M.len
+  let N = fd.numWords
+  let scratch = asy.makeArray(fd.fieldTy)
 
   # Contains 0x0001 (if overflowed limbs) or 0x0000
-  let overflowedLimbs = bld.add_ci(0'u32, 0'u32)
+  let overflowedLimbs = asy.br.add_ci(0'u32, 0'u32)
 
   # Now substract the modulus, and test a < M with the last borrow
-  scratch[0] = bld.sub_bo(a[0], M[0])
+  scratch[0] = asy.br.sub_bo(a[0], M[0])
   for i in 1 ..< N:
-    scratch[i] = bld.sub_bio(a[i], M[i])
+    scratch[i] = asy.br.sub_bio(a[i], M[i])
 
   # 1. if `overflowedLimbs`, underflowedModulus >= 0
   # 2. if a >= M, underflowedModulus >= 0
   # if underflowedModulus >= 0: a-M else: a
   # TODO: predicated mov instead?
-  let underflowedModulus = bld.sub_bi(overflowedLimbs, 0'u32)
+  let underflowedModulus = asy.br.sub_bi(overflowedLimbs, 0'u32)
 
   for i in 0 ..< N:
-    r[i] = bld.slct(scratch[i], a[i], underflowedModulus)
+    r[i] = asy.br.slct(scratch[i], a[i], underflowedModulus)
 
-proc finalSubNoOverflow(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, r, a: Array) =
+proc finalSubNoOverflow(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, M: Array) =
   ## If a >= Modulus: r <- a-M
   ## else:            r <- a
   ##
@@ -88,275 +87,260 @@ proc finalSubNoOverflow(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, r,
   ##
   ## To be used when the modulus does not use the full bitwidth of the storing words
   ## (say using 255 bits for the modulus out of 256 available in words)
-
-  let bld = asy.builder
-  let fieldTy = cm.getFieldType(field)
-  let scratch = bld.makeArray(fieldTy)
-  let M = cm.getModulus(field)
-  let N = M.len
+  let N = fd.numWords
+  let scratch = asy.makeArray(fd.fieldTy)
 
   # Now substract the modulus, and test a < M with the last borrow
-  scratch[0] = bld.sub_bo(a[0], M[0])
+  scratch[0] = asy.br.sub_bo(a[0], M[0])
   for i in 1 ..< N:
-    scratch[i] = bld.sub_bio(a[i], M[i])
+    scratch[i] = asy.br.sub_bio(a[i], M[i])
 
   # If it underflows here a was smaller than the modulus, which is what we want
-  let underflowedModulus = bld.sub_bi(0'u32, 0'u32)
+  let underflowedModulus = asy.br.sub_bi(0'u32, 0'u32)
 
   for i in 0 ..< N:
-    r[i] = bld.slct(scratch[i], a[i], underflowedModulus)
+    r[i] = asy.br.slct(scratch[i], a[i], underflowedModulus)
 
-proc field_add_gen*(asy: Assembler_LLVM, cm: CurveMetadata, field: Field): FnDef =
+proc modadd_nvidia(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) {.used.} =
   ## Generate an optimized modular addition kernel
   ## with parameters `a, b, modulus: Limbs -> Limbs`
+  let red = if fd.spareBits >= 1: "noo"
+            else: "mayo"
+  let name = "_modadd_" & red & ".u" & $fd.w & "x" & $fd.numWords
 
-  let procName = cm.genSymbol(block:
-    case field
-    of fp: opFpAdd
-    of fr: opFrAdd)
-  let fieldTy = cm.getFieldType(field)
-  let pFieldTy = pointer_t(fieldTy)
+  asy.llvmInternalFnDef(
+          name, SectionName,
+          asy.void_t, toTypes([r, a, b, M]),
+          {kHot}):
 
-  let addModTy = function_t(asy.void_t, [pFieldTy, pFieldTy, pFieldTy])
-  let addModKernel = asy.module.addFunction(cstring procName, addModTy)
-  let blck = asy.ctx.appendBasicBlock(addModKernel, "addModBody")
-  asy.builder.positionAtEnd(blck)
+    tagParameter(1, "sret")
 
-  let bld = asy.builder
+    let (rr, aa, bb, MM) = llvmParams
 
-  let r = bld.asArray(addModKernel.getParam(0), fieldTy)
-  let a = bld.asArray(addModKernel.getParam(1), fieldTy)
-  let b = bld.asArray(addModKernel.getParam(2), fieldTy)
+    # Pointers are opaque in LLVM now
+    let r = asy.asArray(rr, fd.fieldTy)
+    let a = asy.asArray(aa, fd.fieldTy)
+    let b = asy.asArray(bb, fd.fieldTy)
+    let M = asy.asArray(MM, fd.fieldTy)
 
-  let t = bld.makeArray(fieldTy)
-  let N = cm.getNumWords(field)
+    let t = asy.makeArray(fd.fieldTy)
+    let N = fd.numWords
 
-  t[0] = bld.add_co(a[0], b[0])
-  for i in 1 ..< N:
-    t[i] = bld.add_cio(a[i], b[i])
+    t[0] = asy.br.add_co(a[0], b[0])
+    for i in 1 ..< N:
+      t[i] = asy.br.add_cio(a[i], b[i])
 
-  if cm.getSpareBits(field) >= 1:
-    asy.finalSubNoOverflow(cm, field, t, t)
-  else:
-    asy.finalSubMayOverflow(cm, field, t, t)
+    if fd.spareBits >= 1:
+      asy.finalSubNoOverflow(fd, t, t, M)
+    else:
+      asy.finalSubMayOverflow(fd, t, t, M)
 
-  bld.store(r, t)
-  bld.retVoid()
+    asy.store(r, t)
+    asy.br.retVoid()
 
-  return (addModTy, addModKernel)
+  asy.callFn(name, [r, a, b, M])
 
-proc field_sub_gen*(asy: Assembler_LLVM, cm: CurveMetadata, field: Field): FnDef =
+proc modsub_nvidia(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) {.used.} =
   ## Generate an optimized modular substraction kernel
   ## with parameters `a, b, modulus: Limbs -> Limbs`
+  let name = "_modsub.u" & $fd.w & "x" & $fd.numWords
 
-  let procName = cm.genSymbol(block:
-    case field
-    of fp: opFpSub
-    of fr: opFrSub)
-  let fieldTy = cm.getFieldType(field)
-  let pFieldTy = pointer_t(fieldTy)
+  asy.llvmInternalFnDef(
+          name, SectionName,
+          asy.void_t, toTypes([r, a, b, M]),
+          {kHot}):
 
-  let subModTy = function_t(asy.void_t, [pFieldTy, pFieldTy, pFieldTy])
-  let subModKernel = asy.module.addFunction(cstring procName, subModTy)
-  let blck = asy.ctx.appendBasicBlock(subModKernel, "subModBody")
-  asy.builder.positionAtEnd(blck)
+    tagParameter(1, "sret")
 
-  let bld = asy.builder
+    let (rr, aa, bb, MM) = llvmParams
 
-  let r = bld.asArray(subModKernel.getParam(0), fieldTy)
-  let a = bld.asArray(subModKernel.getParam(1), fieldTy)
-  let b = bld.asArray(subModKernel.getParam(2), fieldTy)
+    # Pointers are opaque in LLVM now
+    let r = asy.asArray(rr, fd.fieldTy)
+    let a = asy.asArray(aa, fd.fieldTy)
+    let b = asy.asArray(bb, fd.fieldTy)
+    let M = asy.asArray(MM, fd.fieldTy)
 
-  let t = bld.makeArray(fieldTy)
-  let N = cm.getNumWords(field)
-  let zero = case cm.wordSize
-             of w32: constInt(asy.i32_t, 0)
-             of w64: constInt(asy.i64_t, 0)
+    let t = asy.makeArray(fd.fieldTy)
+    let N = fd.numWords
 
-  t[0] = bld.sub_bo(a[0], b[0])
-  for i in 1 ..< N:
-    t[i] = bld.sub_bio(a[i], b[i])
+    t[0] = asy.br.sub_bo(a[0], b[0])
+    for i in 1 ..< N:
+      t[i] = asy.br.sub_bio(a[i], b[i])
 
-  let underflowMask = bld.sub_bi(zero, zero)
+    let underflowMask = asy.br.sub_bi(fd.zero, fd.zero)
 
-  # If underflow
-  # TODO: predicated mov instead?
-  let M = (seq[ValueRef])(cm.getModulus(field))
-  let maskedM = bld.makeArray(fieldTy)
-  for i in 0 ..< N:
-    maskedM[i] = bld.`and`(M[i], underflowMask)
+    # If underflow
+    # TODO: predicated mov instead?
+    let maskedM = asy.makeArray(fd.fieldTy)
+    for i in 0 ..< N:
+      maskedM[i] = asy.br.`and`(M[i], underflowMask)
 
-  block:
-    t[0] = bld.add_co(t[0], maskedM[0])
-  for i in 1 ..< N-1:
-    t[i] = bld.add_cio(t[i], maskedM[i])
-  if N > 1:
-    t[N-1] = bld.add_ci(t[N-1], maskedM[N-1])
+    block:
+      t[0] = asy.br.add_co(t[0], maskedM[0])
+    for i in 1 ..< N-1:
+      t[i] = asy.br.add_cio(t[i], maskedM[i])
+    if N > 1:
+      t[N-1] = asy.br.add_ci(t[N-1], maskedM[N-1])
 
-  bld.store(r, t)
-  bld.retVoid()
+    asy.store(r, t)
+    asy.br.retVoid()
 
-  return (subModTy, subModKernel)
+  asy.callFn(name, [r, a, b, M])
 
-proc field_mul_CIOS_sparebit_gen(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, skipFinalSub: bool): FnDef =
+proc mtymul_CIOS_sparebit(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef, finalReduce: bool) =
   ## Generate an optimized modular multiplication kernel
   ## with parameters `a, b, modulus: Limbs -> Limbs`
 
-  let procName = cm.genSymbol(block:
-    if skipFinalSub:
-      case field
-      of fp: opFpMulSkipFinalSub
-      of fr: opFrMulSkipFinalSub
+  let name =
+    if finalReduce and fd.spareBits >= 2:
+      "_mty_mulur.u" & $fd.w & "x" & $fd.numWords & "b2"
     else:
-      case field
-      of fp: opFpMul
-      of fr: opFrMul)
-  let fieldTy = cm.getFieldType(field)
-  let pFieldTy = pointer_t(fieldTy)
+      doAssert fd.spareBits >= 1
+      "_mty_mul.u" & $fd.w & "x" & $fd.numWords & "b1"
 
-  let mulModTy = function_t(asy.void_t, [pFieldTy, pFieldTy, pFieldTy])
-  let mulModKernel = asy.module.addFunction(cstring procName, mulModTy)
-  let blck = asy.ctx.appendBasicBlock(mulModKernel, "mulModBody")
-  asy.builder.positionAtEnd(blck)
+  asy.llvmInternalFnDef(
+          name, SectionName,
+          asy.void_t, toTypes([r, a, b, M]),
+          {kHot}):
 
-  let bld = asy.builder
+    tagParameter(1, "sret")
 
-  let r = bld.asArray(mulModKernel.getParam(0), fieldTy)
-  let a = bld.asArray(mulModKernel.getParam(1), fieldTy)
-  let b = bld.asArray(mulModKernel.getParam(2), fieldTy)
+    let (rr, aa, bb, MM) = llvmParams
 
-  # Algorithm
-  # -----------------------------------------
-  #
-  # On x86, with a single carry chain and a spare bit:
-  #
-  # for i=0 to N-1
-  #   (A, t[0]) <- a[0] * b[i] + t[0]
-  #    m        <- (t[0] * m0ninv) mod 2ʷ
-  #   (C, _)    <- m * M[0] + t[0]
-  #   for j=1 to N-1
-  #     (A, t[j])   <- a[j] * b[i] + A + t[j]
-  #     (C, t[j-1]) <- m * M[j] + C + t[j]
-  #
-  #   t[N-1] = C + A
-  #
-  # with MULX, ADCX, ADOX dual carry chains
-  #
-  # for i=0 to N-1
-  #   for j=0 to N-1
-  # 		(A,t[j])  := t[j] + a[j]*b[i] + A
-  #   m := t[0]*m0ninv mod W
-  # 	C,_ := t[0] + m*M[0]
-  # 	for j=1 to N-1
-  # 		(C,t[j-1]) := t[j] + m*M[j] + C
-  #   t[N-1] = C + A
-  #
-  # In our case, we only have a single carry flag
-  # but we have a lot of registers
-  # and a multiply-accumulate instruction
-  #
-  # Hence we can use the dual carry chain approach
-  # one chain after the other instead of interleaved like on x86.
+    # Pointers are opaque in LLVM now
+    let r = asy.asArray(rr, fd.fieldTy)
+    let a = asy.asArray(aa, fd.fieldTy)
+    let b = asy.asArray(bb, fd.fieldTy)
+    let M = asy.asArray(MM, fd.fieldTy)
 
-  let t = bld.makeArray(fieldTy)
-  let N = cm.getNumWords(field)
-  let m0ninv = ValueRef cm.getMontgomeryNegInverse0(field)
-  let M = (seq[ValueRef])(cm.getModulus(field))
-  let zero = case cm.wordSize
-             of w32: constInt(asy.i32_t, 0)
-             of w64: constInt(asy.i64_t, 0)
+    let t = asy.makeArray(fd.fieldTy)
+    let N = fd.numWords
+    let m0ninv = asy.getM0ninv(fd)
 
-  for i in 0 ..< N:
-    # Multiplication
-    # -------------------------------
+    # Algorithm
+    # -----------------------------------------
+    #
+    # On x86, with a single carry chain and a spare bit:
+    #
+    # for i=0 to N-1
+    #   (A, t[0]) <- a[0] * b[i] + t[0]
+    #    m        <- (t[0] * m0ninv) mod 2ʷ
+    #   (C, _)    <- m * M[0] + t[0]
+    #   for j=1 to N-1
+    #     (A, t[j])   <- a[j] * b[i] + A + t[j]
+    #     (C, t[j-1]) <- m * M[j] + C + t[j]
+    #
+    #   t[N-1] = C + A
+    #
+    # with MULX, ADCX, ADOX dual carry chains
+    #
+    # for i=0 to N-1
     #   for j=0 to N-1
     # 		(A,t[j])  := t[j] + a[j]*b[i] + A
-    #
-    # for 4 limbs, implicit column-wise carries
-    #
-    # t[0]     = t[0] + (a[0]*b[i]).lo
-    # t[1]     = t[1] + (a[1]*b[i]).lo + (a[0]*b[i]).hi
-    # t[2]     = t[2] + (a[2]*b[i]).lo + (a[1]*b[i]).hi
-    # t[3]     = t[3] + (a[3]*b[i]).lo + (a[2]*b[i]).hi
-    # overflow =                         (a[3]*b[i]).hi
-    #
-    # or
-    #
-    # t[0]     = t[0] + (a[0]*b[i]).lo
-    # t[1]     = t[1] + (a[0]*b[i]).hi + (a[1]*b[i]).lo
-    # t[2]     = t[2] + (a[2]*b[i]).lo + (a[1]*b[i]).hi
-    # t[3]     = t[3] + (a[2]*b[i]).hi + (a[3]*b[i]).lo
-    # overflow =    carry              + (a[3]*b[i]).hi
-    #
-    # Depending if we chain lo/hi or even/odd
-    # The even/odd carry chain is more likely to be optimized via μops-fusion
-    # as it's common to compute the full product. That said:
-    # - it's annoying if the number of limbs is odd with edge conditions.
-    # - GPUs are RISC architectures and unlikely to have clever instruction rescheduling logic
-    let bi = b[i]
-    var A = ValueRef zero
-
-    if i == 0:
-      for j in 0 ..< N:
-        t[j] = bld.mul(a[j], bi)
-    else:
-      t[0] = bld.mulloadd_co(a[0], bi, t[0])
-      for j in 1 ..< N:
-        t[j] = bld.mulloadd_cio(a[j], bi, t[j])
-      if N > 1:
-        A = bld.add_ci(zero, zero)
-    if N > 1:
-      t[1] = bld.mulhiadd_co(a[0], bi, t[1])
-    for j in 2 ..< N:
-      t[j] = bld.mulhiadd_cio(a[j-1], bi, t[j])
-    A = bld.mulhiadd_ci(a[N-1], bi, A)
-
-    # Reduction
-    # -------------------------------
     #   m := t[0]*m0ninv mod W
-    #
     # 	C,_ := t[0] + m*M[0]
     # 	for j=1 to N-1
     # 		(C,t[j-1]) := t[j] + m*M[j] + C
     #   t[N-1] = C + A
     #
-    # for 4 limbs, implicit column-wise carries
-    #    _  = t[0] + (m*M[0]).lo
-    #  t[0] = t[1] + (m*M[1]).lo + (m*M[0]).hi
-    #  t[1] = t[2] + (m*M[2]).lo + (m*M[1]).hi
-    #  t[2] = t[3] + (m*M[3]).lo + (m*M[2]).hi
-    #  t[3] = A + carry          + (m*M[3]).hi
+    # In our case, we only have a single carry flag
+    # but we have a lot of registers
+    # and a multiply-accumulate instruction
     #
-    # or
-    #
-    #    _  = t[0] + (m*M[0]).lo
-    #  t[0] = t[1] + (m*M[0]).hi + (m*M[1]).lo
-    #  t[1] = t[2] + (m*M[2]).lo + (m*M[1]).hi
-    #  t[2] = t[3] + (m*M[2]).hi + (m*M[3]).lo
-    #  t[3] = A + carry          + (m*M[3]).hi
+    # Hence we can use the dual carry chain approach
+    # one chain after the other instead of interleaved like on x86.
 
-    let m = bld.mul(t[0], m0ninv)
-    let _ = bld.mulloadd_co(m, M[0], t[0])
-    for j in 1 ..< N:
-      t[j-1] = bld.mulloadd_cio(m, M[j], t[j])
-    t[N-1] = bld.add_ci(A, 0)
-    if N > 1:
-      t[0] = bld.mulhiadd_co(m, M[0], t[0])
-      for j in 1 ..< N-1:
-        t[j] = bld.mulhiadd_cio(m, M[j], t[j])
-      t[N-1] = bld.mulhiadd_ci(m, M[N-1], t[N-1])
-    else:
-      t[0] = bld.mulhiadd(m, M[0], t[0])
+    for i in 0 ..< N:
+      # Multiplication
+      # -------------------------------
+      #   for j=0 to N-1
+      # 		(A,t[j])  := t[j] + a[j]*b[i] + A
+      #
+      # for 4 limbs, implicit column-wise carries
+      #
+      # t[0]     = t[0] + (a[0]*b[i]).lo
+      # t[1]     = t[1] + (a[1]*b[i]).lo + (a[0]*b[i]).hi
+      # t[2]     = t[2] + (a[2]*b[i]).lo + (a[1]*b[i]).hi
+      # t[3]     = t[3] + (a[3]*b[i]).lo + (a[2]*b[i]).hi
+      # overflow =                         (a[3]*b[i]).hi
+      #
+      # or
+      #
+      # t[0]     = t[0] + (a[0]*b[i]).lo
+      # t[1]     = t[1] + (a[0]*b[i]).hi + (a[1]*b[i]).lo
+      # t[2]     = t[2] + (a[2]*b[i]).lo + (a[1]*b[i]).hi
+      # t[3]     = t[3] + (a[2]*b[i]).hi + (a[3]*b[i]).lo
+      # overflow =    carry              + (a[3]*b[i]).hi
+      #
+      # Depending if we chain lo/hi or even/odd
+      # The even/odd carry chain is more likely to be optimized via μops-fusion
+      # as it's common to compute the full product. That said:
+      # - it's annoying if the number of limbs is odd with edge conditions.
+      # - GPUs are RISC architectures and unlikely to have clever instruction rescheduling logic
+      let bi = b[i]
+      var A = fd.zero
 
-  if not skipFinalSub:
-    asy.finalSubNoOverflow(cm, field, t, t)
+      if i == 0:
+        for j in 0 ..< N:
+          t[j] = asy.br.mul(a[j], bi)
+      else:
+        t[0] = asy.br.mulloadd_co(a[0], bi, t[0])
+        for j in 1 ..< N:
+          t[j] = asy.br.mulloadd_cio(a[j], bi, t[j])
+        if N > 1:
+          A = asy.br.add_ci(fd.zero, fd.zero)
+      if N > 1:
+        t[1] = asy.br.mulhiadd_co(a[0], bi, t[1])
+      for j in 2 ..< N:
+        t[j] = asy.br.mulhiadd_cio(a[j-1], bi, t[j])
+      A = asy.br.mulhiadd_ci(a[N-1], bi, A)
 
-  bld.store(r, t)
-  bld.retVoid()
+      # Reduction
+      # -------------------------------
+      #   m := t[0]*m0ninv mod W
+      #
+      # 	C,_ := t[0] + m*M[0]
+      # 	for j=1 to N-1
+      # 		(C,t[j-1]) := t[j] + m*M[j] + C
+      #   t[N-1] = C + A
+      #
+      # for 4 limbs, implicit column-wise carries
+      #    _  = t[0] + (m*M[0]).lo
+      #  t[0] = t[1] + (m*M[1]).lo + (m*M[0]).hi
+      #  t[1] = t[2] + (m*M[2]).lo + (m*M[1]).hi
+      #  t[2] = t[3] + (m*M[3]).lo + (m*M[2]).hi
+      #  t[3] = A + carry          + (m*M[3]).hi
+      #
+      # or
+      #
+      #    _  = t[0] + (m*M[0]).lo
+      #  t[0] = t[1] + (m*M[0]).hi + (m*M[1]).lo
+      #  t[1] = t[2] + (m*M[2]).lo + (m*M[1]).hi
+      #  t[2] = t[3] + (m*M[2]).hi + (m*M[3]).lo
+      #  t[3] = A + carry          + (m*M[3]).hi
 
-  return (mulModTy, mulModKernel)
+      let m = asy.br.mul(t[0], m0ninv)
+      let _ = asy.br.mulloadd_co(m, M[0], t[0])
+      for j in 1 ..< N:
+        t[j-1] = asy.br.mulloadd_cio(m, M[j], t[j])
+      t[N-1] = asy.br.add_ci(A, 0)
+      if N > 1:
+        t[0] = asy.br.mulhiadd_co(m, M[0], t[0])
+        for j in 1 ..< N-1:
+          t[j] = asy.br.mulhiadd_cio(m, M[j], t[j])
+        t[N-1] = asy.br.mulhiadd_ci(m, M[N-1], t[N-1])
+      else:
+        t[0] = asy.br.mulhiadd(m, M[0], t[0])
 
-proc field_mul_gen*(asy: Assembler_LLVM, cm: CurveMetadata, field: Field, skipFinalSub = false): FnDef =
+    if finalReduce:
+      asy.finalSubNoOverflow(fd, t, t, M)
+
+    asy.store(r, t)
+    asy.br.retVoid()
+
+proc mtymul_nvidia(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef, finalReduce = true) {.used.} =
   ## Generate an optimized modular addition kernel
   ## with parameters `a, b, modulus: Limbs -> Limbs`
-  return asy.field_mul_CIOS_sparebit_gen(cm, field, skipFinalSub)
+
+  # TODO: spareBits == 0
+  asy.mtymul_CIOS_sparebit(fd, r, a, b, M, finalReduce)

--- a/constantine/math_compiler/impl_fields_nvidia.nim
+++ b/constantine/math_compiler/impl_fields_nvidia.nim
@@ -192,7 +192,7 @@ proc mtymul_CIOS_sparebit(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: 
   ## with parameters `a, b, modulus: Limbs -> Limbs`
 
   let name =
-    if finalReduce and fd.spareBits >= 2:
+    if not finalReduce and fd.spareBits >= 2:
       "_mty_mulur.u" & $fd.w & "x" & $fd.numWords & "b2"
     else:
       doAssert fd.spareBits >= 1
@@ -337,6 +337,8 @@ proc mtymul_CIOS_sparebit(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: 
 
     asy.store(r, t)
     asy.br.retVoid()
+
+  asy.callFn(name, [r, a, b, M])
 
 proc mtymul_nvidia(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef, finalReduce = true) {.used.} =
   ## Generate an optimized modular addition kernel

--- a/constantine/math_compiler/impl_fields_sat.nim
+++ b/constantine/math_compiler/impl_fields_sat.nim
@@ -121,7 +121,7 @@ proc finalSubNoOverflow*(asy: Assembler_LLVM, fd: FieldDescriptor, rr, a, M: Val
   let t = asy.br.select(borrow, a, a_minus_M)
   asy.store(rr, t)
 
-proc modadd*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) =
+proc modadd_sat(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, b, M: ValueRef) {.used.} =
   ## Generate an optimized modular addition kernel
   ## with parameters `a, b, modulus: Limbs -> Limbs`
 

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -259,11 +259,11 @@ proc makeArray*(asy: Assembler_LLVM, elemTy: TypeRef, len: uint32): Array =
 
 proc `[]`*(a: Array, index: SomeInteger): ValueRef {.inline.}=
   # First dereference the array pointer with 0, then access the `index`
-  let pelem = a.builder.getElementPtr2_InBounds(a.arrayTy, a.buf, [ValueRef constInt(a.int32_t, 0), ValueRef constInt(a.int32_t, uint64 index)])
+  let pelem = a.builder.getElementPtr2_InBounds(a.arrayTy, a.buf, [constInt(a.int32_t, 0), constInt(a.int32_t, uint64 index)])
   a.builder.load2(a.elemTy, pelem)
 
 proc `[]=`*(a: Array, index: SomeInteger, val: ValueRef) {.inline.}=
-  let pelem = a.builder.getElementPtr2_InBounds(a.arrayTy, a.buf, [ValueRef constInt(a.int32_t, 0), ValueRef constInt(a.int32_t, uint64 index)])
+  let pelem = a.builder.getElementPtr2_InBounds(a.arrayTy, a.buf, [constInt(a.int32_t, 0), constInt(a.int32_t, uint64 index)])
   a.builder.store(val, pelem)
 
 proc store*(asy: Assembler_LLVM, dst: Array, src: Array) {.inline.}=
@@ -345,9 +345,10 @@ proc defineGlobalConstant*(
 proc tagCudaKernel(asy: Assembler_LLVM, fn: ValueRef) =
   ## Tag a function as a Cuda Kernel, i.e. callable from host
 
-  let returnTy = fn.getTypeOf().getReturnType()
-  doAssert returnTy.isVoid(), block:
-    "Kernels must not return values but function returns " & $returnTy.getTypeKind()
+  # We cannot get the full function type from its impl so we cannot do this check.
+  # let returnTy = fn.getTypeOf().getReturnType()
+  # doAssert returnTy.isVoid(), block:
+  #   "Kernels must not return values but function returns " & $returnTy.getTypeKind()
 
   asy.module.addNamedMetadataOperand(
     "nvvm.annotations",
@@ -360,8 +361,11 @@ proc tagCudaKernel(asy: Assembler_LLVM, fn: ValueRef) =
 
 proc setPublic(asy: Assembler_LLVM, fn: ValueRef) =
   case asy.backend
-  of bkAmdGpu: fn.setFnCallConv(AMDGPU_KERNEL)
-  of bkNvidiaPtx: asy.tagCudaKernel(fn)
+  of bkAmdGpu:
+    fn.setFnCallConv(AMDGPU_KERNEL)
+  of bkNvidiaPtx:
+    # asy.tagCudaKernel(fn)
+    fn.setFnCallConv(PTX_Kernel)
   else: discard
 
 # ############################################################
@@ -474,7 +478,7 @@ template llvmFnDef[N: static int](
       savedLoc = blck
 
     let llvmParams {.inject.} = unpackParams(asy.br, paramsTys)
-    template tagParameter(idx: int, attr: string) {.inject.} =
+    template tagParameter(idx: int, attr: string) {.inject, used.} =
       let a = asy.ctx.createAttr(attr)
       fn.addAttribute(cint idx, a)
     body

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -484,7 +484,7 @@ template llvmFnDef[N: static int](
       fn.setLinkage(linkInternal)
     else:
       asy.setPublic(fn)
-    fn.setSection(sectionName)
+    fn.setSection(cstring sectionName)
     asy.addAttributes(fn, attrs)
 
     asy.br.positionAtEnd(savedLoc)

--- a/constantine/math_compiler/pub_fields.nim
+++ b/constantine/math_compiler/pub_fields.nim
@@ -10,13 +10,13 @@ import
   constantine/platforms/llvm/llvm,
   ./ir,
   ./impl_fields_globals,
-  ./impl_fields_sat
+  ./impl_fields_dispatch
 
 proc genFpAdd*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
   ## Generate a public field addition proc
   ## with signature
   ##   void name(FieldType r, FieldType a, FieldType b)
-  ## with r the result and a, b the operants
+  ## with r the result and a, b the operands
   ## and return the corresponding name to call it
 
   let name = fd.name & "_add"
@@ -25,6 +25,40 @@ proc genFpAdd*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
 
     let (r, a, b) = llvmParams
     asy.modadd(fd, r, a, b, M)
+    asy.br.retVoid()
+
+  return name
+
+proc genFpSub*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
+  ## Generate a public field substraction proc
+  ## with signature
+  ##   void name(FieldType r, FieldType a, FieldType b)
+  ## with r the result and a, b the operands
+  ## and return the corresponding name to call it
+
+  let name = fd.name & "_sub"
+  asy.llvmPublicFnDef(name, "ctt." & fd.name, asy.void_t, [fd.fieldTy, fd.fieldTy, fd.fieldTy]):
+    let M = asy.getModulusPtr(fd)
+
+    let (r, a, b) = llvmParams
+    asy.modsub(fd, r, a, b, M)
+    asy.br.retVoid()
+
+  return name
+
+proc genFpMul*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
+  ## Generate a public field substraction proc
+  ## with signature
+  ##   void name(FieldType r, FieldType a, FieldType b)
+  ## with r the result and a, b the operands
+  ## and return the corresponding name to call it
+
+  let name = fd.name & "_mul"
+  asy.llvmPublicFnDef(name, "ctt." & fd.name, asy.void_t, [fd.fieldTy, fd.fieldTy, fd.fieldTy]):
+    let M = asy.getModulusPtr(fd)
+
+    let (r, a, b) = llvmParams
+    asy.mtymul(fd, r, a, b, M) # TODO: for now we only suport Montgomery representation
     asy.br.retVoid()
 
   return name

--- a/tests/gpu/t_nvidia_fp.nim
+++ b/tests/gpu/t_nvidia_fp.nim
@@ -14,9 +14,9 @@ import
   constantine/platforms/llvm/llvm,
   constantine/platforms/static_for,
   constantine/named/algebras,
-  constantine/math/io/io_bigints,
   constantine/math/arithmetic,
-  constantine/math_compiler/[ir, impl_fields_nvidia, codegen_nvidia],
+  constantine/math/io/io_bigints,
+  constantine/math_compiler/[ir, pub_fields, codegen_nvidia],
   # Test utilities
   helpers/prng_unsafe
 
@@ -27,33 +27,6 @@ echo "\n------------------------------------------------------\n"
 echo "test_nvidia_fp xoshiro512** seed: ", seed
 
 const Iters = 10
-
-proc init(T: type CurveMetadata, asy: Assembler_LLVM, curve: static Algebra, wordSize: WordSize): T =
-  CurveMetadata.init(
-      asy.ctx,
-      $curve & "_", wordSize,
-      fpBits = uint32 Fp[curve].bits(),
-      fpMod = Fp[curve].getModulus().toHex(),
-      frBits = uint32 Fr[curve].bits(),
-      frMod = Fr[curve].getModulus().toHex())
-
-proc genFieldAddPTX(asy: Assembler_LLVM, cm: CurveMetadata) =
-  let fpAdd = asy.field_add_gen(cm, fp)
-  asy.module.wrapInCallableCudaKernel(fpAdd)
-  let frAdd = asy.field_add_gen(cm, fr)
-  asy.module.wrapInCallableCudaKernel(frAdd)
-
-proc genFieldSubPTX(asy: Assembler_LLVM, cm: CurveMetadata) =
-  let fpSub = asy.field_sub_gen(cm, fp)
-  asy.module.wrapInCallableCudaKernel(fpSub)
-  let frSub = asy.field_sub_gen(cm, fr)
-  asy.module.wrapInCallableCudaKernel(frSub)
-
-proc genFieldMulPTX(asy: Assembler_LLVM, cm: CurveMetadata) =
-  let fpMul = asy.field_mul_gen(cm, fp)
-  asy.module.wrapInCallableCudaKernel(fpMul)
-  let frMul = asy.field_mul_gen(cm, fr)
-  asy.module.wrapInCallableCudaKernel(frMul)
 
 # Init LLVM
 # -------------------------
@@ -66,173 +39,57 @@ var sm: tuple[major, minor: int32]
 check cuDeviceGetAttribute(sm.major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, cudaDevice)
 check cuDeviceGetAttribute(sm.minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, cudaDevice)
 
-proc t_field_add(curve: static Algebra) =
-  # Codegen
-  # -------------------------
-  let asy = Assembler_LLVM.new(bkNvidiaPTX, cstring("t_nvidia_" & $curve))
-  let cm32 = CurveMetadata.init(asy, curve, w32)
-  asy.genFieldAddPTX(cm32)
-  let cm64 = CurveMetadata.init(asy, curve, w64)
-  asy.genFieldAddPTX(cm64)
-
-  let ptx = asy.codegenNvidiaPTX(sm)
-
-  # GPU exec
-  # -------------------------
-  var cuCtx: CUcontext
-  var cuMod: CUmodule
-  check cuCtxCreate(cuCtx, 0, cudaDevice)
-  check cuModuleLoadData(cuMod, ptx)
-  defer:
-    check cuMod.cuModuleUnload()
-    check cuCtx.cuCtxDestroy()
-
-  let fpAdd32 = cuMod.getCudaKernel(cm32, opFpAdd)
-  let fpAdd64 = cuMod.getCudaKernel(cm64, opFpAdd)
-  let frAdd32 = cuMod.getCudaKernel(cm32, opFrAdd)
-  let frAdd64 = cuMod.getCudaKernel(cm64, opFrAdd)
-
-  # Fp
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fp[curve])
-    let b = rng.random_long01Seq(Fp[curve])
-
-    var rCPU, rGPU_32, rGPU_64: Fp[curve]
-
-    rCPU.sum(a, b)
-    fpAdd32.exec(rGPU_32, a, b)
-    fpAdd64.exec(rGPU_64, a, b)
-
-    doAssert bool(rCPU == rGPU_32)
-    doAssert bool(rCPU == rGPU_64)
-
-  # Fr
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fr[curve])
-    let b = rng.random_long01Seq(Fr[curve])
-
-    var rCPU, rGPU_32, rGPU_64: Fr[curve]
-
-    rCPU.sum(a, b)
-    frAdd32.exec(rGPU_32, a, b)
-    frAdd64.exec(rGPU_64, a, b)
-
-    doAssert bool(rCPU == rGPU_32)
-    doAssert bool(rCPU == rGPU_64)
-
-proc t_field_sub(curve: static Algebra) =
-  # Codegen
-  # -------------------------
-  let asy = Assembler_LLVM.new(bkNvidiaPTX, cstring("t_nvidia_" & $curve))
-  let cm32 = CurveMetadata.init(asy, curve, w32)
-  asy.genFieldSubPTX(cm32)
-  let cm64 = CurveMetadata.init(asy, curve, w64)
-  asy.genFieldSubPTX(cm64)
-
-  let ptx = asy.codegenNvidiaPTX(sm)
-
-  # GPU exec
-  # -------------------------
-  var cuCtx: CUcontext
-  var cuMod: CUmodule
-  check cuCtxCreate(cuCtx, 0, cudaDevice)
-  check cuModuleLoadData(cuMod, ptx)
-  defer:
-    check cuMod.cuModuleUnload()
-    check cuCtx.cuCtxDestroy()
-
-  let fpSub32 = cuMod.getCudaKernel(cm32, opFpSub)
-  let fpSub64 = cuMod.getCudaKernel(cm64, opFpSub)
-  let frSub32 = cuMod.getCudaKernel(cm32, opFrSub)
-  let frSub64 = cuMod.getCudaKernel(cm64, opFrSub)
-
-  # Fp
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fp[curve])
-    let b = rng.random_long01Seq(Fp[curve])
-
-    var rCPU, rGPU_32, rGPU_64: Fp[curve]
-
-    rCPU.diff(a, b)
-    fpSub32.exec(rGPU_32, a, b)
-    fpSub64.exec(rGPU_64, a, b)
-
-    doAssert bool(rCPU == rGPU_32)
-    doAssert bool(rCPU == rGPU_64)
-
-  # Fr
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fr[curve])
-    let b = rng.random_long01Seq(Fr[curve])
-
-    var rCPU, rGPU_32, rGPU_64: Fr[curve]
-
-    rCPU.diff(a, b)
-    frSub32.exec(rGPU_32, a, b)
-    frSub64.exec(rGPU_64, a, b)
-
-    doAssert bool(rCPU == rGPU_32)
-    doAssert bool(rCPU == rGPU_64)
-
-proc t_field_mul(curve: static Algebra) =
-  # Codegen
-  # -------------------------
-  let asy = Assembler_LLVM.new(bkNvidiaPTX, cstring("t_nvidia_" & $curve))
-  let cm32 = CurveMetadata.init(asy, curve, w32)
-  asy.genFieldMulPTX(cm32)
-
-  # 64-bit integer fused-multiply-add with carry is buggy:
-  # https://gist.github.com/mratsim/a34df1e091925df15c13208df7eda569#file-mul-py
-  # https://forums.developer.nvidia.com/t/incorrect-result-of-ptx-code/221067
-
-  # let cm64 = CurveMetadata.init(asy, curve, w64)
-  # asy.genFieldMulPTX(cm64)
-
-  let ptx = asy.codegenNvidiaPTX(sm)
-
-  # GPU exec
-  # -------------------------
-  var cuCtx: CUcontext
-  var cuMod: CUmodule
-  check cuCtxCreate(cuCtx, 0, cudaDevice)
-  check cuModuleLoadData(cuMod, ptx)
-  defer:
-    check cuMod.cuModuleUnload()
-    check cuCtx.cuCtxDestroy()
-
-  let fpMul32 = cuMod.getCudaKernel(cm32, opFpMul)
-  let frMul32 = cuMod.getCudaKernel(cm32, opFrMul)
-  # let fpMul64 = cuMod.getCudaKernel(cm64, opFpMul)
-  # let frMul64 = cuMod.getCudaKernel(cm64, opFrMul)
-
-  # Fp
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fp[curve])
-    let b = rng.random_long01Seq(Fp[curve])
+template gen_binop_test(
+      testName: untyped,
+      kernGenerator: untyped,
+      cpuFn: untyped) =
 
 
-    var rCPU, rGPU_32: Fp[curve] # rGPU_64
+  proc testName[Name: static Algebra](field: type FF[Name], wordSize: int) =
+    # Codegen
+    # -------------------------
+    static: debugEcho field
 
-    rCPU.prod(a, b)
-    fpMul32.exec(rGPU_32, a, b)
-    # fpMul64.exec(rGPU_64, a, b)
+    let name = if field is Fp: $Name & "_fp"
+              else: $Name & "_fr"
+    let asy = Assembler_LLVM.new(bkNvidiaPTX, cstring("t_nvidia_" & name & $wordSize))
+    let fd = asy.ctx.configureField(
+      name, field.bits(),
+      field.getModulus().toHex(),
+      v = 1, w = wordSize
+    )
 
-    doAssert bool(rCPU == rGPU_32)
-    # doAssert bool(rCPU == rGPU_64)
+    asy.definePrimitives(fd)
 
-  # Fr
-  for i in 0 ..< Iters:
-    let a = rng.random_long01Seq(Fr[curve])
-    let b = rng.random_long01Seq(Fr[curve])
+    let kernName = asy.kernGenerator(fd)
+    let ptx = asy.codegenNvidiaPTX(sm)
 
-    var rCPU, rGPU_32: Fr[curve] # rGPU_64
+    # GPU exec
+    # -------------------------
+    var cuCtx: CUcontext
+    var cuMod: CUmodule
+    check cuCtxCreate(cuCtx, 0, cudaDevice)
+    check cuModuleLoadData(cuMod, ptx)
+    defer:
+      check cuMod.cuModuleUnload()
+      check cuCtx.cuCtxDestroy()
 
-    rCPU.prod(a, b)
-    frMul32.exec(rGPU_32, a, b)
-    # frMul64.exec(rGPU_64, a, b)
+    let kernel = cuMod.getCudaKernel(kernName)
 
-    doAssert bool(rCPU == rGPU_32)
-    # doAssert bool(rCPU == rGPU_64)
+    for i in 0 ..< Iters:
+      let a = rng.random_long01Seq(field)
+      let b = rng.random_long01Seq(field)
+
+      var rCPU, rGPU: field
+
+      rCPU.cpuFn(a, b)
+      kernel.exec(rGPU, a, b)
+
+      doAssert bool(rCPU == rGPU)
+
+gen_binop_test(t_field_add, genFpAdd, sum)
+gen_binop_test(t_field_sub, genFpSub, diff)
+# gen_binop_test(t_field_mul, genFpMul, prod)
 
 proc main() =
   const curves = [
@@ -253,11 +110,25 @@ proc main() =
   suite "[Nvidia GPU] Field Arithmetic":
     staticFor i, 0, curves.len:
       const curve = curves[i]
-      test "Nvidia GPU field addition       (𝔽p, 𝔽r) for " & $curve:
-        t_field_add(curve)
-      test "Nvidia GPU field substraction   (𝔽p, 𝔽r) for " & $curve:
-        t_field_sub(curve)
-      test "Nvidia GPU field multiplication (𝔽p, 𝔽r) for " & $curve:
-        t_field_mul(curve)
+      for wordSize in [32, 64]:
+        test "Nvidia GPU field addition 𝔽p " & $wordSize & "-bit for " & $curve:
+          t_field_add(Fp[curve], wordSize)
+        test "Nvidia GPU field substraction 𝔽p " & $wordSize & "-bit for " & $curve:
+          t_field_sub(Fp[curve], wordSize)
+        # test "Nvidia GPU field multiplication 𝔽p " & $wordSize & "-bit for " & $curve:
+        #   # 64-bit integer fused-multiply-add with carry is buggy:
+        #   # https://gist.github.com/mratsim/a34df1e091925df15c13208df7eda569#file-mul-py
+        #   # https://forums.developer.nvidia.com/t/incorrect-result-of-ptx-code/221067
+        #   t_field_mul(Fp[curve], wordSize)
+
+        test "Nvidia GPU field addition 𝔽r " & $wordSize & "-bit for " & $curve:
+          t_field_add(Fr[curve], wordSize)
+        test "Nvidia GPU field substraction 𝔽r " & $wordSize & "-bit for " & $curve:
+          t_field_sub(Fr[curve], wordSize)
+        # test "Nvidia GPU field multiplication 𝔽r " & $wordSize & "-bit for " & $curve:
+        #   # 64-bit integer fused-multiply-add with carry is buggy:
+        #   # https://gist.github.com/mratsim/a34df1e091925df15c13208df7eda569#file-mul-py
+        #   # https://forums.developer.nvidia.com/t/incorrect-result-of-ptx-code/221067
+        #   t_field_mul(Fr[curve], wordSize)
 
 main()


### PR DESCRIPTION
This refactors the Nvidia backend in preparation for hardware accelerated elliptic curves and fields.
The Nvidia backend has been broken following AMDGPU and x86 experiments in:
- #453
- #456

This:
- refactors the hello_world_nvidia so that it uses only low-level cuda primitives (but it may use high-level LLVM ones)
- reimplement the add/sub/mul using the new framework which should significantly reduce boilerplate.