### PR TITLE
Halo2 0.4 and Halo2curves 0.7 compat + Rust warnings fixes

### DIFF
--- a/constantine-rust/constantine-ethereum-bls-sig/tests/t_ethereum_bls_sig_vectors.rs
+++ b/constantine-rust/constantine-ethereum-bls-sig/tests/t_ethereum_bls_sig_vectors.rs
@@ -28,11 +28,11 @@ macro_rules! test_dir {
 }
 
 const AGGREGATE_VERIFY_TESTS: &str = concat!(test_dir!(), "aggregate_verify/*");
-const AGGREGATE_TESTS: &str = concat!(test_dir!(), "aggregate/*");
+// const AGGREGATE_TESTS: &str = concat!(test_dir!(), "aggregate/*");
 const DESERIALIZATION_G1_TESTS: &str = concat!(test_dir!(), "deserialization_G1/*");
 const BATCH_VERIFY_TESTS: &str = concat!(test_dir!(), "batch_verify/*");
 const FAST_AGGREGATE_VERIFY_TESTS: &str = concat!(test_dir!(), "fast_aggregate_verify/*");
-const HASH_TO_G2_TESTS: &str = concat!(test_dir!(), "hash_to_G2/*");
+// const HASH_TO_G2_TESTS: &str = concat!(test_dir!(), "hash_to_G2/*");
 const DESERIALIZATION_G2_TESTS: &str = concat!(test_dir!(), "deserialization_G2/*");
 const VERIFY_TESTS: &str = concat!(test_dir!(), "verify/*");
 const SIGN_TESTS: &str = concat!(test_dir!(), "sign/*");
@@ -294,7 +294,7 @@ fn t_sign() {
         match skey {
             Err(_e) => {
                 // empty output due to `null` JSON value
-                let (Some(tout), Some(tmsg)) =
+                let (Some(tout), Some(_)) =
                     (test.output.opt_bytes.0, test.input.message.opt_bytes.0)
                 else {
                     assert!(false);

--- a/constantine-rust/constantine-ethereum-evm-precompiles/tests/t_ethereum_evm_precompiles.rs
+++ b/constantine-rust/constantine-ethereum-evm-precompiles/tests/t_ethereum_evm_precompiles.rs
@@ -59,6 +59,7 @@ const FAIL_MAP_FP2_TO_G2_BLS_TESTS: &str =
 
 type HexString = String;
 
+#[allow(dead_code, non_snake_case)]
 #[derive(Deserialize, Debug)]
 struct PrecompileTest {
     Input: HexString,
@@ -238,17 +239,17 @@ fn t_map_fp_to_g1_bls_tests() {
     t_generate(test_name, evm_bls12381_map_fp_to_g1);
 }
 #[test]
-fn t_fail_map_fp_to_G1_bls_tests() {
+fn t_fail_map_fp_to_g1_bls_tests() {
     let test_name = FAIL_MAP_FP_TO_G1_BLS_TESTS.to_string();
     t_generate(test_name, evm_bls12381_map_fp_to_g1);
 }
 #[test]
-fn t_map_fp2_to_G2_bls_tests() {
+fn t_map_fp2_to_g2_bls_tests() {
     let test_name = MAP_FP2_TO_G2_BLS_TESTS.to_string();
     t_generate(test_name, evm_bls12381_map_fp2_to_g2);
 }
 #[test]
-fn t_fail_map_fp2_to_G2_bls_tests() {
+fn t_fail_map_fp2_to_g2_bls_tests() {
     let test_name = FAIL_MAP_FP2_TO_G2_BLS_TESTS.to_string();
     t_generate(test_name, evm_bls12381_map_fp2_to_g2);
 }

--- a/constantine-rust/constantine-halo2-zal/benches/msm.rs
+++ b/constantine-rust/constantine-halo2-zal/benches/msm.rs
@@ -17,7 +17,7 @@ use constantine_halo2_zal::CttEngine;
 
 use halo2curves::bn256::{Fr as Scalar, G1Affine as Point};
 use halo2curves::ff::Field;
-use halo2curves::msm::best_multiexp;
+use halo2curves::msm::msm_best;
 use halo2curves::zal::MsmAccel;
 
 use rayon::current_thread_index;
@@ -94,7 +94,7 @@ fn msm(c: &mut Criterion) {
                 assert!(k < 64);
                 let n: usize = 1 << k;
                 b.iter(|| {
-                    best_multiexp(&coeffs[..n], &bases[..n]);
+                    msm_best(&coeffs[..n], &bases[..n]);
                 })
             })
             .sample_size(SAMPLE_SIZE);

--- a/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
+++ b/constantine-rust/constantine-halo2-zal/tests/t_zal_msm_accel.rs
@@ -16,7 +16,7 @@ use halo2_middleware::halo2curves::bn256;
 use halo2_middleware::halo2curves::ff::Field;
 use halo2_middleware::halo2curves::group::prime::PrimeCurveAffine;
 use halo2_middleware::halo2curves::group::{Curve, Group};
-use halo2_middleware::halo2curves::msm::best_multiexp;
+use halo2_middleware::halo2curves::msm::msm_best;
 use halo2_middleware::zal::traits::MsmAccel;
 
 #[test]
@@ -42,7 +42,7 @@ fn run_msm_zal(min_k: usize, max_k: usize) {
         let scalars = &scalars[..1 << k];
 
         let t0 = start_timer!(|| format!("freestanding msm k={}", k));
-        let e0 = best_multiexp(scalars, points);
+        let e0 = msm_best(scalars, points);
         end_timer!(t0);
 
         let engine = CttEngine::new(hardware::get_num_threads_os());

--- a/docs/zk_accel_layer.md
+++ b/docs/zk_accel_layer.md
@@ -155,7 +155,7 @@ mod tests {
     use halo2curves::ff::Field;
     use halo2curves::group::prime::PrimeCurveAffine;
     use halo2curves::group::{Curve, Group};
-    use halo2curves::msm::best_multiexp;
+    use halo2curves::msm::msm_best;
     use halo2curves::zal::MsmAccel;
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
             let scalars = &scalars[..1 << k];
 
             let t0 = start_timer!(|| format!("freestanding msm k={}", k));
-            let e0 = best_multiexp(scalars, points);
+            let e0 = msm_best(scalars, points);
             end_timer!(t0);
 
             let engine = CttEngine::new(num_cpus::get());


### PR DESCRIPTION
Halo2curves changed best_multiexp name to msm_best: https://github.com/privacy-scaling-explorations/halo2curves/pull/169