### PR TITLE
CI: replace apt-fast by apt-get + Nim v2.2.x in CI as Nim v2.0.10 is broken.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        nim_version: [version-1-6, version-2-0]
+        nim_version: [version-1-6, version-2-2] # version-2-0] is crashing due to https://github.com/mratsim/constantine/issues/471
         rust_toolchain: [stable] # [beta, nightly]
         go_toolchain: [stable]
         target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install test dependencies (Linux amd64)
         if: runner.os == 'Linux' && matrix.target.cpu == 'amd64'
         run: |
-          sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
             --no-install-recommends -yq \
             libgmp-dev \
             llvm
@@ -168,12 +168,12 @@ jobs:
         # We don't install LLVM as the Rust libraries that call Constantine are 64-bit only.
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt-fast update -qq
+          sudo apt-get update -qq
 
           # Try to fix "E: Unable to correct problems, you have held broken packages."
-          sudo apt-fast clean
+          sudo apt-get clean
 
-          sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
+          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
             --no-install-recommends -yq \
             gcc-multilib g++-multilib \
             libssl-dev:i386 libgmp-dev:i386

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ with a particular focus on cryptography used in blockchains and zero-knowledge p
 <!-- TOC -->
 
 - [Constantine](#constantine)
-    - [Public API: Curves & Protocols](#public-api-curves--protocols)
-        - [Protocols](#protocols)
-        - [Elliptic Curves](#elliptic-curves)
-        - [General cryptography](#general-cryptography)
-        - [Threadpool](#threadpool)
-    - [Installation](#installation)
-        - [From Rust](#from-rust)
-        - [From Go](#from-go)
-        - [From C](#from-c)
-        - [From Nim](#from-nim)
-    - [Dependencies & Requirements](#dependencies--requirements)
-    - [Performance](#performance)
-    - [Assembly & Hardware acceleration](#assembly--hardware-acceleration)
-    - [Security](#security)
-        - [Disclaimer](#disclaimer)
-        - [Security disclosure](#security-disclosure)
-    - [Why Nim](#why-nim)
-    - [License](#license)
+  - [Public API: Curves \& Protocols](#public-api-curves--protocols)
+    - [Protocols](#protocols)
+    - [Elliptic Curves](#elliptic-curves)
+    - [General cryptography](#general-cryptography)
+    - [Threadpool](#threadpool)
+  - [Installation](#installation)
+    - [From Rust](#from-rust)
+    - [From Go](#from-go)
+    - [From C](#from-c)
+    - [From Nim](#from-nim)
+  - [Dependencies \& Requirements](#dependencies--requirements)
+  - [Performance](#performance)
+  - [Assembly \& Hardware acceleration](#assembly--hardware-acceleration)
+  - [Security](#security)
+    - [Disclaimer](#disclaimer)
+    - [Security disclosure](#security-disclosure)
+  - [Why Nim](#why-nim)
+  - [License](#license)
 
 <!-- /TOC -->
 The library aims to be a fast, compact and hardened library for elliptic curve cryptography needs, in particular for blockchain protocols and zero-knowledge proofs system.
@@ -136,7 +136,10 @@ See the following documents on the threadpool performance details, design and re
 ## Installation
 
 > [!IMPORTANT]
-> Constantine can be compiled by Nim v1.6.x, v2.0.2 and v2.0.4 but not Nim v2.0.0 (due to a compile-time evaluation crash)
+> Constantine can be compiled with:
+> - Nim v1.6.x,
+> - Nim v2.0.2 to v2.0.8 but not Nim v2.0.0 and Nim 2.0.10 (due to compile-time evaluation crashes)
+> - Nim v2.2.0
 
 ### From Rust
 


### PR DESCRIPTION
This fixes #472. Github removed the apt-fast package from their Ubuntu 24.04 images in CI