### PR TITLE
Fixes for Nim v2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,12 +372,13 @@ jobs:
         # So "test_bindings" uses C and can find GMP
         # but nim-gmp cannot find GMP on Windows CI
         # Also need to workaround asynctools not being able to create pipes https://github.com/nim-lang/Nim/issues/23118
+        # And LTO impossible constraint in the deneb_kzg test (but not MSM for some reason)
         if: runner.os == 'Windows' && matrix.target.BACKEND == 'ASM'
         shell: msys2 {0}
         run: |
           cd constantine
           if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
-            nimble test_no_gmp --verbose
+            nimble CTT_LTO=false test_no_gmp --verbose
           else
             nimble test_parallel_no_gmp --verbose
           fi
@@ -390,7 +391,7 @@ jobs:
         run: |
           cd constantine
           if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
-            CTT_ASM=0 nimble test_no_gmp --verbose
+            CTT_ASM=0 CTT_LTO=false nimble test_no_gmp --verbose
           else
             CTT_ASM=0 nimble test_parallel_no_gmp --verbose
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
         run: |
           cd constantine
           if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
-            nimble CTT_LTO=false test_no_gmp --verbose
+            CTT_LTO=0 nimble test_no_gmp --verbose
           else
             nimble test_parallel_no_gmp --verbose
           fi
@@ -391,7 +391,7 @@ jobs:
         run: |
           cd constantine
           if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
-            CTT_ASM=0 CTT_LTO=false nimble test_no_gmp --verbose
+            CTT_ASM=0 CTT_LTO=0 nimble test_no_gmp --verbose
           else
             CTT_ASM=0 nimble test_parallel_no_gmp --verbose
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
         shell: msys2 {0}
         run: |
           cd constantine
-          if [[ '${{  matrix.nim_version }}' == 'version-2-0' ]]; then
+          if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
             nimble test_no_gmp --verbose
           else
             nimble test_parallel_no_gmp --verbose
@@ -389,7 +389,7 @@ jobs:
         shell: msys2 {0}
         run: |
           cd constantine
-          if [[ '${{  matrix.nim_version }}' == 'version-2-0' ]]; then
+          if [[ '${{  matrix.nim_version }}' != 'version-1-6' ]]; then
             CTT_ASM=0 nimble test_no_gmp --verbose
           else
             CTT_ASM=0 nimble test_parallel_no_gmp --verbose

--- a/helpers/pararun.nim
+++ b/helpers/pararun.nim
@@ -113,9 +113,6 @@ proc enqueuePendingCommands(wq: WorkQueue) {.async.} =
 
     await wq.sem.acquire()
     let cmd = wq.cmdQueue.popFirst()
-    echo '\n', '-'.repeat(80)
-    echo "|\n| Scheduling #", id, "/", total, ": ", cmd ,"\n|"
-    echo '-'.repeat(80)
     let p = cmd.startProcess(options = {poStdErrToStdOut, poUsePath, poEvalCommand})
 
     let bufOut = newAsyncQueue[string]()

--- a/helpers/pararun.nim
+++ b/helpers/pararun.nim
@@ -113,6 +113,9 @@ proc enqueuePendingCommands(wq: WorkQueue) {.async.} =
 
     await wq.sem.acquire()
     let cmd = wq.cmdQueue.popFirst()
+    echo '\n', '-'.repeat(80)
+    echo "|\n| Scheduling #", id, "/", total, ": ", cmd ,"\n|"
+    echo '-'.repeat(80)
     let p = cmd.startProcess(options = {poStdErrToStdOut, poUsePath, poEvalCommand})
 
     let bufOut = newAsyncQueue[string]()


### PR DESCRIPTION
Unfortunately Nim v2.0.x has a compiler regression that prevents compiling. It was introduced in some commit and Nim devel and Nim 2.2 branch has the subsequent commit that fixes the regression.

This PR fixes the remaining Windos issues with Nim v2.2 so it can be used in CI.