### PR TITLE
Nvidia MSM proof of concept (serial)

### DIFF
--- a/constantine/math_compiler/codegen_nvidia.nim
+++ b/constantine/math_compiler/codegen_nvidia.nim
@@ -448,6 +448,9 @@ proc execCudaImpl(jitFn, res, inputs: NimNode): NimNode =
         x[0]
       )
     )
+  result = quote do:
+    block:
+      `result`
 
 macro execCuda*(jitFn: CUfunction,
                 res: typed,

--- a/constantine/math_compiler/codegen_nvidia.nim
+++ b/constantine/math_compiler/codegen_nvidia.nim
@@ -586,7 +586,8 @@ proc initNvAsm*[Name: static Algebra](field: type EC_ShortW_Jac[Fp[Name], G1], w
     Fp[Name].getModulus().toHex(),
     v = 1, w = wordSize,
     coef_a = Fp[Name].Name.getCoefA(),
-    coef_B = Fp[Name].Name.getCoefB()
+    coef_B = Fp[Name].Name.getCoefB(),
+    curveOrderBitWidth = Fr[Name].bits()
   )
   result.fd = result.cd.fd
   result.asy.definePrimitives(result.cd)

--- a/constantine/math_compiler/codegen_nvidia.nim
+++ b/constantine/math_compiler/codegen_nvidia.nim
@@ -596,6 +596,19 @@ proc compile*(nv: NvidiaAssembler, kernName: string): CUfunction =
   ## Overload of `compile` below.
   ## Call this version if you have manually used the Assembler_LLVM object
   ## to build instructions and have a kernel name you wish to compile.
+  ##
+  ## Use this overload if your generator function does not match the `FieldFnGenerator` or
+  ## `CurveFnGenerator` signatures. This is useful if your function requires additional
+  ## arguments that are compile time values in the context of LLVM.
+  ##
+  ## Example:
+  ##
+  ## ```nim
+  ##  let nv = initNvAsm(EC, wordSize)
+  ##  let kernel = nv.compile(asy.genEcMSM(cd, 3, 1000) # window size, num. points
+  ## ```
+  ## where `genEcMSM` returns the name of the kernel.
+
   let ptx = nv.asy.codegenNvidiaPTX(nv.sm) # convert to PTX
 
   # GPU exec

--- a/constantine/math_compiler/codegen_nvidia.nim
+++ b/constantine/math_compiler/codegen_nvidia.nim
@@ -71,15 +71,17 @@ export
 # Cuda Driver API
 # ------------------------------------------------------------
 
-template check*(status: CUresult) =
+template check*(status: CUresult, quitOnFailure = true) =
   ## Check the status code of a CUDA operation
   ## Exit program with error if failure
 
   let code = status # ensure that the input expression is evaluated once only
+
   if code != CUDA_SUCCESS:
     writeStackTrace()
     stderr.write(astToStr(status) & " " & $instantiationInfo() & " exited with error: " & $code & '\n')
-    quit 1
+    if quitOnFailure:
+      quit 1 # NOTE: this hides exceptions if they are thrown!
 
 func cuModuleLoadData*(module: var CUmodule, sourceCode: openArray[char]): CUresult {.inline.}=
   cuModuleLoadData(module, sourceCode[0].unsafeAddr)
@@ -516,8 +518,18 @@ type
 
 proc `=destroy`*(nv: NvidiaAssemblerObj) =
   ## XXX: Need to also call the finalizer for `asy` in the future!
-  check nv.cuMod.cuModuleUnload()
-  check nv.cuCtx.cuCtxDestroy()
+  # NOTE: In the destructor we don't want to quit on a `check` failure.
+  # The reason is that if we throw an exception with an `NvidiaAssembler`
+  # in scope, it will trigger the destructor here (with a likely invalid
+  # state in the CUDA module / context). However, in this case
+  # we will crash anyway and would just end up hiding the actual cause of
+  # the error.
+  # In the unlikely case that all CUDA operations worked correctly up
+  # to this point, but then fail to unload, we currently ignore this
+  # as a failure mode.
+  # Hopefully we find a better solution in the future.
+  check nv.cuMod.cuModuleUnload(), quitOnFailure = false
+  check nv.cuCtx.cuCtxDestroy(), quitOnFailure = false
   `=destroy`(nv.asy)
 
 proc initNvAsm*[Name: static Algebra](field: type FF[Name], wordSize: int = 32, backend = bkNvidiaPTX): NvidiaAssembler =

--- a/constantine/math_compiler/impl_curves_ops_jacobian.nim
+++ b/constantine/math_compiler/impl_curves_ops_jacobian.nim
@@ -60,13 +60,25 @@ proc store*(dst: EcPointJac, src: EcPointJac) =
 template declEllipticJacOps*(asy: Assembler_LLVM, cd: CurveDescriptor): untyped =
   ## This template can be used to make operations on `Field` elements
   ## more convenient.
-  ## XXX: extend to include all ops
+  # Setters
+  template setNeutral(x: EcPointJac): untyped = asy.setNeutral(cd, x.buf)
+
   # Boolean checks
   template isNeutral(res, x: EcPointJac): untyped = asy.isNeutral(cd, res, x.buf)
   template isNeutral(x: EcPointJac): untyped =
     var res = asy.br.alloca(asy.ctx.int1_t())
     asy.isNeutral(cd, res, x.buf)
     res
+
+  # Mutating assignment ops
+  template sum(res, x, y: EcPointJac): untyped = asy.sum(cd, res.buf, x.buf, y.buf)
+  template `+=`(x, y: EcPointJac): untyped     = x.sum(x, y)
+  template mixedSum(res, x: EcPointJac, y: EcPointAff): untyped = asy.mixedSum(cd, res.buf, x.buf, y.buf)
+  template `+=`(x: EcPointJac, y: EcPointAff): untyped = x.mixedSum(x, y)
+
+  # Arithmetic mutations
+  template double(res, x: EcPointJac): untyped = asy.double(cd, res.buf, x.buf)
+  template double(x: EcPointJac): untyped      = x.double(x)
 
   # Conditional ops
   template ccopy(x, y: EcPointJac, c): untyped = asy.ccopy(cd, x.buf, y.buf, derefBool c)

--- a/constantine/math_compiler/impl_msm_nvidia.nim
+++ b/constantine/math_compiler/impl_msm_nvidia.nim
@@ -1,0 +1,96 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/[primitives],
+  ./ir,
+  ./impl_fields_globals,
+  ./impl_fields_dispatch,
+  ./impl_fields_ops,
+  ./impl_curves_ops_affine,
+  ./impl_curves_ops_jacobian,
+  std / typetraits # for distinctBase
+
+## Section name used for `llvmInternalFnDef`
+const SectionName = "ctt.msm_nvidia"
+
+proc msm*(asy: Assembler_LLVM, cd: CurveDescriptor, r, coefs, points: ValueRef,
+          c, N: int) {.used.} =
+  ## Inner implementation of MSM, for static dispatch over c, the bucket bit length
+  ## This is a straightforward simple translation of BDLO12, section 4
+  ##
+  ## Entirely serial implementation!
+  ##
+  ## Important note: The coefficients given to this procedure must be in canonical
+  ## representation instead of Montgomery representation! Thus, you cannot pass
+  ## values of type `Fr[Curve]` directly, as they are internally stored in Montgomery
+  ## rep. Convert to a `BigInt` using `fromField`.
+  let name = cd.name & "_msm_impl"
+  asy.llvmInternalFnDef(
+          name, SectionName,
+          asy.void_t, toTypes([r, coefs, points]),
+          {kHot}):
+    tagParameter(1, "sret")
+
+    # Inject templates for convenient access
+    declFieldOps(asy, cd.fd)
+    declEllipticJacOps(asy, cd)
+    declEllipticAffOps(asy, cd)
+    declNumberOps(asy, cd.fd)
+
+    let (ri, coefsIn, pointsIn) = llvmParams
+    let rA = asy.asEcPointJac(cd, ri)
+    let cs = asy.asFieldScalarArray(cd, coefsIn, N) # coefficients
+    let Ps = asy.asEcAffArray(cd, pointsIn, N) # EC points
+    # Prologue
+    # --------
+    let numBuckets = 1 shl c - 1 # bucket 0 is unused
+    let numWindows = cd.orderBitWidth.int.ceilDiv_vartime(c)
+
+    let miniMSMs = asy.initEcJacArray(cd, numWindows)
+    let buckets  = asy.initEcJacArray(cd, numBuckets)
+
+    # Algorithm
+    # ---------
+    var cNonZero = asy.initMutVal(cd.fd.wordTy)
+    asy.llvmFor w, 0, numWindows - 1, true:
+      # Place our points in a bucket corresponding to
+      # how many times their bit pattern in the current window of size c
+      asy.llvmFor i, 0, numBuckets - 1, true:
+        buckets[i].setNeutral()
+
+      # 1. Bucket accumulation.                            Cost: n - (2ᶜ-1) => n points in 2ᶜ-1 buckets, first point per bucket is just copied
+      asy.llvmFor j, 0, N-1, true:
+        var b = asy.initMutVal(cd.fd.wordTy)
+        let w0 = asy.initConstVal(0, cd.fd.wordTy)
+        asy.getWindowAt(cd, b.buf, cs[j].buf, asy.to(w, cd.fd.wordTy) * c, constInt(cd.fd.wordTy, c))
+        llvmIf(asy):
+          if b != w0:
+            buckets[b-1] += Ps[j]
+
+      var accumBuckets = asy.newEcPointJac(cd)
+      var miniMSM      = asy.newEcPointJac(cd)
+      accumBuckets = buckets[numBuckets-1]
+      miniMSM.store(buckets[numBuckets-1])
+
+      asy.llvmFor k, numBuckets-2, 0, false:
+        accumBuckets += buckets[k] # Stores S₈ then    S₈+S₇ then       S₈+S₇+S₆ then ...
+        miniMSM += accumBuckets    # Stores S₈ then [2]S₈+S₇ then [3]S₈+[2]S₇+S₆ then ...
+
+      miniMSMs[w].store(miniMSM)
+
+    rA.store(miniMSMs[numWindows-1])
+    asy.llvmFor w, numWindows-2, 0, false:
+      asy.llvmFor j, 0, c-1:
+        rA.double()
+      rA += miniMSMs[w]
+
+    asy.br.retVoid()
+
+  asy.callFn(name, [r, coefs, points])

--- a/constantine/math_compiler/impl_msm_nvidia.nim
+++ b/constantine/math_compiler/impl_msm_nvidia.nim
@@ -76,7 +76,7 @@ proc msm*(asy: Assembler_LLVM, cd: CurveDescriptor, r, coefs, points: ValueRef,
 
       var accumBuckets = asy.newEcPointJac(cd)
       var miniMSM      = asy.newEcPointJac(cd)
-      accumBuckets = buckets[numBuckets-1]
+      accumBuckets.store(buckets[numBuckets-1])
       miniMSM.store(buckets[numBuckets-1])
 
       asy.llvmFor k, numBuckets-2, 0, false:

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -304,8 +304,11 @@ type
     elemTy*: TypeRef
     int32_t: TypeRef
 
-proc `[]`*(a: Array, index: SomeInteger): ValueRef {.inline.}
-proc `[]=`*(a: Array, index: SomeInteger, val: ValueRef) {.inline.}
+proc `=copy`*(m: var Array, x: Array) {.error: "Copying an Array is not allowed. " &
+  "You likely want to copy the LLVM value. Use `dst.store(src)` instead.".}
+
+proc `[]`*(a: Array, index: SomeInteger | ValueRef): ValueRef {.inline.}
+proc `[]=`*(a: Array, index: SomeInteger | ValueRef, val: ValueRef) {.inline.}
 
 proc asArray*(br: BuilderRef, arrayPtr: ValueRef, arrayTy: TypeRef): Array =
   Array(

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -254,7 +254,8 @@ proc configureCurve*(ctx: ContextRef,
       name: string,
       modBits: int, modulus: string,
       v, w: int,
-      coefA, coefB: int): CurveDescriptor =
+      coefA, coefB: int,
+      curveOrderBitWidth: int): CurveDescriptor =
   ## Configure a curve descriptor with:
   ## - v: vector length
   ## - w: base word size in bits
@@ -276,6 +277,7 @@ proc configureCurve*(ctx: ContextRef,
   # Curve parameters
   result.coef_a = coef_a
   result.coef_b = coef_b # unused
+  result.orderBitWidth = curveOrderBitWidth.uint32
 
 proc definePrimitives*(asy: Assembler_LLVM, cd: CurveDescriptor) =
   asy.definePrimitives(cd.fd)

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -226,9 +226,13 @@ type
     fd*: FieldDescriptor # of the underlying field
     family*: CurveFamily
     modulus*: string # Modulus as Big-Endian uppercase hex, NOT prefixed with 0x
-    modulusBitWidth*: uint32
+    modulusBitWidth*: uint32 # bits required for elements of `Fp`
     order*: string
-    orderBitWidth*: uint32
+    orderBitWidth*: uint32 # bits required for scalar elements `Fr`
+
+    # type of the field Fr
+    fieldScalarTy*: TypeRef
+    numWordsScalar*: uint32 # num words required for it
 
     cofactor*: string
     eqForm*: CurveEquationForm
@@ -264,6 +268,10 @@ proc configureCurve*(ctx: ContextRef,
   result.curveTy = array_t(result.fd.fieldTy, 3)
   # Array of 2 arrays for affine coords
   result.curveTyAff = array_t(result.fd.fieldTy, 2)
+
+  # and the type for elements of Fr
+  result.numWordsScalar = uint32 wordsRequired(curveOrderBitWidth, w)
+  result.fieldScalarTy = array_t(result.fd.wordTy, result.numWordsScalar)
 
   # Curve parameters
   result.coef_a = coef_a

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -646,4 +646,19 @@ template load2*(asy: Assembler_LLVM, ty: TypeRef, `ptr`: ValueRef, name: cstring
   asy.br.load2(ty, `ptr`, name)
 
 template store*(asy: Assembler_LLVM, dst, src: ValueRef, name: cstring = "") =
+  if not dst.getTypeOf.isPointerType():
+    raise newException(ValueError, "The destination argument to `store` is not a pointer type.")
+  if src.getTypeOf.isPointerType():
+    raise newException(ValueError, "The source argument to `store` is a pointer type. " &
+      "You must `load2()` it before the store. Or use the `MutableValue` type, in which case " &
+      "we can load it automatically for you. If you really wish to store the pointer " &
+      "to the destination, use `storePtr` instead.")
+  asy.br.store(src, dst)
+
+template storePtr*(asy: Assembler_LLVM, dst, src: ValueRef, name: cstring = "") =
+  if not dst.getTypeOf.isPointerType():
+    raise newException(ValueError, "The destination argument to `storePtr` is not a pointer type.")
+  if not src.getTypeOf.isPointerType():
+    raise newException(ValueError, "The source argument to `storePtr` is not a pointer type. " &
+      "You likely want to call `store` instead.")
   asy.br.store(src, dst)

--- a/constantine/math_compiler/pub_fields.nim
+++ b/constantine/math_compiler/pub_fields.nim
@@ -330,7 +330,7 @@ proc genFpNsqrRT*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
     for i in 0 ..< fd.numWords:
       rA[i] = aA[i]
 
-    asy.genCountdownLoop(fn, count):
+    asy.llvmForCountdown i, count, 0: # countdown from count to 0
       # use `mtymul` to multiply `r·r` and store it again in `r`
       asy.mtymul(fd, r, r, r, M)
 

--- a/constantine/platforms/abis/llvm_abi.nim
+++ b/constantine/platforms/abis/llvm_abi.nim
@@ -277,6 +277,8 @@ type
 
 proc getContext*(ty: TypeRef): ContextRef {.importc: "LLVMGetTypeContext".}
 proc getTypeKind*(ty: TypeRef): TypeKind {.importc: "LLVMGetTypeKind".}
+proc isPointerType*(ty: TypeRef): bool = ty.getTypeKind == tkPointer
+
 proc dumpType*(ty: TypeRef) {.sideeffect, importc: "LLVMDumpType".}
 proc toLLVMstring(ty: TypeRef): LLVMstring {.used, importc: "LLVMPrintTypeToString".}
 

--- a/tests/gpu/t_msm.nim
+++ b/tests/gpu/t_msm.nim
@@ -1,0 +1,68 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internal
+  constantine/named/algebras,
+  constantine/math/io/[io_bigints, io_fields, io_ec],
+  constantine/math/arithmetic,
+  constantine/math/elliptic/[ec_shortweierstrass_affine, ec_shortweierstrass_jacobian, ec_multi_scalar_mul],
+  constantine/platforms/abstractions,
+  constantine/platforms/llvm/llvm,
+  constantine/math_compiler/[ir, pub_fields, pub_curves_jacobian, codegen_nvidia, impl_fields_globals],
+  # Test utilities
+  helpers/prng_unsafe
+
+type
+  EC = EC_ShortW_Jac[Fp[BN254_Snarks], G1]
+  ECAff = EC_ShortW_Aff[Fp[BN254_Snarks], G1]
+const wordSize = 32
+
+# 2 EC points
+let x = "0x2ef34a5db00ff691849861d49415d8081d9d0e10cba33b57b2dd1f37f13eeee0"
+let y = "0x2beb0d0d6115007676f30bcc462fe814bf81198848f139621a3e9fa454fe8e6a"
+let pt = ECAff.fromHex(x, y)
+echo pt.toHex()
+
+let x2 = "0x226c85cf65f4596a77da7d247310a81ac9aa9220e819e3ef23b6cbe0218ce272"
+let y2 = "0xf53265870f65aa18bded3ccb9c62a4d8b060a32a05a75d455710bce95a991df"
+let pt2 = ECAff.fromHex(x2, y2)
+
+# 2 coefficients
+let a = Fr[BN254_Snarks].fromUInt(1'u32)
+let b = Fr[BN254_Snarks].fromHex("0x2beb0d0d6115007676f30bcc462fe814bf81198848f139621a3e9fa454fe8e6a")
+
+proc fromField[BigInt](x: FF): BigInt =
+  result.fromField(x)
+
+type CB = Fr[BN254_Snarks].getBigInt()
+
+template toPOA(x): untyped = cast[ptr UncheckedArray[x[0].typeof]](x[0].addr)
+
+let bN = fromField[CB](b) # convert to BigInt to go from Montgomery rep to canonical rep
+let coefs = [bN, bN]
+
+let points = [pt, pt2]
+
+block MSM:
+  # Codegen
+  # -------------------------
+  let nv = initNvAsm(EC, wordSize)
+  let kernel = nv.compile(nv.asy.genEcMSM(nv.cd, 3, coefs.len))
+
+  # For CPU:
+  var rCPU: EC
+  rCPU.multiScalarMul_reference_vartime(@coefs, @points)
+
+  # For GPU:
+  var rGPU: EC
+  kernel.execCuda(res = rGPU, inputs = (coefs, points))
+  echo "CPU: ", rCPU.toHex()
+  echo "GPU: ", rGPU.toHex()
+  # Verify CPU and GPU agree
+  doAssert bool(rCPU == rGPU)


### PR DESCRIPTION
This implements the bucket method on the LLVM target. In principle it is just a direct port of the reference implementation. However, to make it look mostly identical, I added helper macros for for loops and if statements. 

In addition, due to the somewhat tricky nature of dealing with LLVM types (especially with respect to pointer types), I added `MutableValue` and `ConstantValue` helpers as well as multiple further array types to deal with the different data types part of the calculation.

While  I haven't run any benchmarks (or anything resembling a real MSM, only tested with 2 inputs), this is obviously not going to be fast given that it runs entirely in serial. 

This was a (to me at least) useful implementation to see how usable one can make the LLVM IR from Nim macros for more complicated code. At the very least it is noticeable that the more complicated the code becomes, the more helper boilerplate code one needs to write to keep it similar to the CPU implementations.