### PR TITLE
fix(MSM): properly handle edge condition in parallel MSM when bits is exactly divided by c

### DIFF
--- a/benchmarks/bench_eth_eip4844_kzg.nim
+++ b/benchmarks/bench_eth_eip4844_kzg.nim
@@ -74,6 +74,7 @@ proc benchBlobToKzgCommitment(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
 
   ## We require `tp` to be unintialized as even idle threads somehow reduce perf of serial benches
   let tp = Threadpool.new()
+  let numThreads = tp.numThreads
 
   let startParallel = getMonotime()
   block:
@@ -88,7 +89,7 @@ proc benchBlobToKzgCommitment(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
   let perfParallel = inNanoseconds((stopParallel-startParallel) div iters)
 
   let parallelSpeedup = float(perfSerial) / float(perfParallel)
-  echo &"Speedup ratio parallel {tp.numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
+  echo &"Speedup ratio parallel {numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
 
 proc benchComputeKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) =
 
@@ -102,6 +103,7 @@ proc benchComputeKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) 
 
   ## We require `tp` to be unintialized as even idle threads somehow reduce perf of serial benches
   let tp = Threadpool.new()
+  let numThreads = tp.numThreads
 
   let startParallel = getMonotime()
   block:
@@ -117,7 +119,7 @@ proc benchComputeKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) 
   let perfParallel = inNanoseconds((stopParallel-startParallel) div iters)
 
   let parallelSpeedup = float(perfSerial) / float(perfParallel)
-  echo &"Speedup ratio parallel {tp.numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
+  echo &"Speedup ratio parallel {numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
 
 proc benchComputeBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) =
 
@@ -130,6 +132,7 @@ proc benchComputeBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
 
   ## We require `tp` to be unintialized as even idle threads somehow reduce perf of serial benches
   let tp = Threadpool.new()
+  let numThreads = tp.numThreads
 
   let startParallel = getMonotime()
   block:
@@ -144,7 +147,7 @@ proc benchComputeBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: i
   let perfParallel = inNanoseconds((stopParallel-startParallel) div iters)
 
   let parallelSpeedup = float(perfSerial) / float(perfParallel)
-  echo &"Speedup ratio parallel {tp.numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
+  echo &"Speedup ratio parallel {numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
 
 proc benchVerifyKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) =
 
@@ -163,6 +166,7 @@ proc benchVerifyBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: in
 
   ## We require `tp` to be unintialized as even idle threads somehow reduce perf of serial benches
   let tp = Threadpool.new()
+  let numThreads = tp.numThreads
 
   let startParallel = getMonotime()
   block:
@@ -176,7 +180,7 @@ proc benchVerifyBlobKzgProof(b: BenchSet, ctx: ptr EthereumKZGContext, iters: in
   let perfParallel = inNanoseconds((stopParallel-startParallel) div iters)
 
   let parallelSpeedup = float(perfSerial) / float(perfParallel)
-  echo &"Speedup ratio parallel {tp.numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
+  echo &"Speedup ratio parallel {numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
 
 proc benchVerifyBlobKzgProofBatch(b: BenchSet, ctx: ptr EthereumKZGContext, iters: int) =
 
@@ -201,6 +205,7 @@ proc benchVerifyBlobKzgProofBatch(b: BenchSet, ctx: ptr EthereumKZGContext, iter
 
     ## We require `tp` to be unintialized as even idle threads somehow reduce perf of serial benches
     let tp = Threadpool.new()
+    let numTHreads = tp.numThreads
 
     let startParallel = getMonotime()
     block:
@@ -220,7 +225,7 @@ proc benchVerifyBlobKzgProofBatch(b: BenchSet, ctx: ptr EthereumKZGContext, iter
     let perfParallel = inNanoseconds((stopParallel-startParallel) div iters)
 
     let parallelSpeedup = float(perfSerial) / float(perfParallel)
-    echo &"Speedup ratio parallel {tp.numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
+    echo &"Speedup ratio parallel {numThreads} threads over serial: {parallelSpeedup:>6.3f}x"
     echo ""
 
     i *= 2
@@ -258,7 +263,7 @@ proc main() =
   echo ""
   benchVerifyBlobKzgProofBatch(b, ctx, Iters)
   separator()
-
+  ctx.trusted_setup_delete()
 
 when isMainModule:
   main()

--- a/tests/parallel/t_ec_shortw_jac_g1_msm_parallel.nim
+++ b/tests/parallel/t_ec_shortw_jac_g1_msm_parallel.nim
@@ -14,7 +14,7 @@ import
   # Test utilities
   ./t_ec_template_parallel
 
-const numPoints = [1, 2, 8, 16, 32, 64, 128, 1024, 2048, 16384] # 32768, 262144, 1048576]
+const numPoints = [1, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 1024, 2048, 16384] # 32768, 262144, 1048576]
 
 run_EC_multi_scalar_mul_parallel_impl(
     ec = EC_ShortW_Jac[Fp[BN254_Snarks], G1],

--- a/tests/parallel/t_ec_shortw_prj_g1_msm_parallel.nim
+++ b/tests/parallel/t_ec_shortw_prj_g1_msm_parallel.nim
@@ -14,7 +14,7 @@ import
   # Test utilities
   ./t_ec_template_parallel
 
-const numPoints = [1, 2, 8, 16, 128, 1024, 2048, 16384] # 32768, 262144, 1048576]
+const numPoints = [1, 2, 3, 4, 5, 6, 7, 8, 16, 128, 1024, 2048, 16384] # 32768, 262144, 1048576]
 
 run_EC_multi_scalar_mul_parallel_impl(
     ec = EC_ShortW_Prj[Fp[BN254_Snarks], G1],


### PR DESCRIPTION
The parallel MSM skips the top window if the number of bits is exactly divided by MSM parameter c.

This is easy to reproduce with 3 points and by removing the endomorphism acceleration (which multiply the number of points by 2x or 4x) here:

https://github.com/mratsim/constantine/blob/7c3d76d6d6e4de78f3d5a4d37fe39ed4b247c491/constantine/math/elliptic/ec_multi_scalar_mul_parallel.nim#L539-L557

This might help for #479, cc @Vindaar 