### PR TITLE
CI: drop old nim compiler versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        nim_version: [version-1-6, version-2-2] # version-2-0] is crashing due to https://github.com/mratsim/constantine/issues/471
+        # version-2-0 is crashing due to https://github.com/mratsim/constantine/issues/471
+        # version-1-6 and version-2-0 have issues with templates in typedef operating on a generic for Fp12 tower in https://github.com/mratsim/constantine/pull/485
+        # Hence we only test and officially sypport 2.2.0, though 99% of Constantine should work on older compilers
+        nim_version: [version-2-2]
         rust_toolchain: [stable] # [beta, nightly]
         go_toolchain: [stable]
         target:

--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ See the following documents on the threadpool performance details, design and re
 
 > [!IMPORTANT]
 > Constantine can be compiled with:
-> - Nim v1.6.x,
-> - Nim v2.0.2 to v2.0.8 but not Nim v2.0.0 and Nim 2.0.10 (due to compile-time evaluation crashes)
 > - Nim v2.2.0
 
 ### From Rust


### PR DESCRIPTION
We remove explicit support for Nim 1.6.x as its EOL and Nim 2.0.x as one version to the next works or does not work.

Furthermore neither 1.6.12 or 2.0.12 can compile #485

Closes #471 