### PR TITLE
Keccak optimizations

### DIFF
--- a/benchmarks/bench_h_keccak.nim
+++ b/benchmarks/bench_h_keccak.nim
@@ -84,5 +84,6 @@ when isMainModule:
       let iters = int(target_cycles div (s.int64 * worst_cycles_per_bytes))
       benchKeccak256_constantine(msg, $s & "B", iters)
       benchSHA3_256_openssl(msg, $s & "B", iters)
+      echo "----"
 
   main()

--- a/constantine/ciphers/chacha20.nim
+++ b/constantine/ciphers/chacha20.nim
@@ -80,12 +80,12 @@ func chacha20_block(
     state.inner_block()
 
   # uint32 are 4 bytes so multiply destination by 4
-  for i in 0'u ..< 4:
+  for i in 0 ..< 4:
     key_stream.dumpRawInt(state[i] + cccc[i], i shl 2, littleEndian)
-  for i in 4'u ..< 12:
+  for i in 4 ..< 12:
     key_stream.dumpRawInt(state[i] + key[i-4], i shl 2, littleEndian)
   key_stream.dumpRawInt(state[12] + block_counter, 12 shl 2, littleEndian)
-  for i in 13'u ..< 16:
+  for i in 13 ..< 16:
     key_stream.dumpRawInt(state[i] + nonce[i-13], i shl 2, littleEndian)
 
 func chacha20_cipher*(

--- a/constantine/hashes/h_keccak.nim
+++ b/constantine/hashes/h_keccak.nim
@@ -10,6 +10,9 @@ import
   constantine/platforms/[abstractions, views],
   ./keccak/keccak_generic
 
+when UseASM_X86_32:
+  import ./keccak/keccak_x86_bmi1
+
 # Keccak, the hash function underlying SHA3
 # --------------------------------------------------------------------------------
 #
@@ -125,8 +128,110 @@ func init*(ctx: var KeccakContext) {.inline.} =
   ## Initialize or reinitialize a Keccak context
   ctx.reset()
 
-# debug
-import constantine/serialization/codecs
+template genAbsorb(isaFeatures: untyped) =
+  func `absorb _ isaFeatures`*(ctx: var KeccakContext, message: openArray[byte]) =
+    ## Absorb a message in the Keccak sponge state
+    ##
+    ## Security note: the tail of your message might be stored
+    ## in an internal buffer.
+    ## if sensitive content is used, ensure that
+    ## `ctx.finish(...)` and `ctx.clear()` are called as soon as possible.
+    ## Additionally ensure that the message(s) passed were stored
+    ## in memory considered secure for your threat model.
+
+    var pos = int ctx.absorb_offset # offset in Keccak state
+    var cur = 0                     # offset in message
+    var bytesLeft = message.len
+
+    # We follow the "absorb-permute-squeeze" approach
+    # originally defined by the Keccak team.
+    # It is compatible with SHA-3 hash spec.
+    # See https://eprint.iacr.org/2022/1340.pdf
+    #
+    # There are no transition/permutation between squeezing -> absorbing
+    # And within this `absorb` function
+    #    the state pos == ctx.rate()
+    # is always followed by a permute and setting `pos = 0`
+
+    if (pos mod ctx.rate()) != 0 and pos+bytesLeft >= ctx.rate():
+      # Previous partial update, fill the state and do one permutation
+      let free = ctx.rate() - pos
+      ctx.H.`xorInPartial _ isaFeatures`(pos, message.toOpenArray(0, free-1))
+      ctx.H.`permute _ isaFeatures`(NumRounds = 24)
+      pos = 0
+      cur = free
+      bytesLeft -= free
+
+    if bytesLeft >= ctx.rate():
+      # Process multiple blocks
+      let numBlocks = bytesLeft div ctx.rate()
+      ctx.H.`hashMessageBlocks _ isaFeatures`(message.asUnchecked() +% cur, numBlocks)
+      cur += numBlocks * ctx.rate()
+      bytesLeft -= numBlocks * ctx.rate()
+
+    if bytesLeft != 0:
+      # Store the tail in buffer
+      ctx.H.`xorInPartial _ isaFeatures`(pos, message.toOpenArray(cur, cur+bytesLeft-1))
+
+    # Epilogue
+    ctx.absorb_offset = int32(pos+bytesLeft)
+    # Signal that the next squeeze transition needs a permute
+    ctx.squeeze_offset = int32 ctx.rate()
+
+genAbsorb(generic)
+when UseASM_X86_32:
+  genAbsorb(x86_bmi1)
+
+template genSqueeze(isaFeatures: untyped) =
+  func `squeeze _ isaFeatures`*(ctx: var KeccakContext, digest: var openArray[byte]) =
+    var pos = ctx.squeeze_offset # offset in Keccak state
+    var cur = 0                  # offset in message
+    var bytesLeft = digest.len
+
+    if pos == ctx.rate():
+      # Transition from absorbing to squeezing
+      #   This state can only come from `absorb` function
+      #   as within `squeeze`, pos == ctx.rate() is always followed
+      #   by a permute and pos = 0
+      ctx.H.pad(ctx.absorb_offset, ctx.delimiter, ctx.rate())
+      ctx.H.`permute _ isaFeatures`(NumRounds = 24)
+      pos = 0
+      ctx.absorb_offset = 0
+
+    if (pos mod ctx.rate()) != 0 and pos+bytesLeft >= ctx.rate():
+      # Previous partial squeeze, fill up to rate and do one permutation
+      let free = ctx.rate() - pos
+      ctx.H.`copyOutPartial _ isaFeatures`(hByteOffset = pos, digest.toOpenArray(0, free-1))
+      ctx.H.`permute _ isaFeatures`(NumRounds = 24)
+      pos = 0
+      ctx.absorb_offset = 0
+      cur = free
+      bytesLeft -= free
+
+    if bytesLeft >= ctx.rate():
+      # Process multiple blocks
+      let numBlocks = bytesLeft div ctx.rate()
+      ctx.H.`squeezeDigestBlocks _ isaFeatures`(digest.asUnchecked() +% cur, numBlocks)
+      ctx.absorb_offset = 0
+      cur += numBlocks * ctx.rate()
+      bytesLeft -= numBlocks * ctx.rate()
+
+    if bytesLeft != 0:
+      # Output the tail
+      ctx.H.`copyOutPartial _ isaFeatures`(hByteOffset = pos, digest.toOpenArray(cur, bytesLeft-1))
+
+    # Epilogue
+    ctx.squeeze_offset = int32 bytesLeft
+    # We don't signal absorb_offset to permute the state if called next
+    # as per
+    #   - original keccak spec that uses "absorb-permute-squeeze" protocol
+    #   - https://eprint.iacr.org/2022/1340.pdf
+    #   - https://eprint.iacr.org/2023/522.pdf
+    #     https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/ByIbpfX9c#2-SAFE-definition
+
+genSqueeze(generic)
+when UseASM_X86_32:
+  genSqueeze(x86_bmi1)
 
 func absorb*(ctx: var KeccakContext, message: openArray[byte]) =
   ## Absorb a message in the Keccak sponge state
@@ -137,91 +242,22 @@ func absorb*(ctx: var KeccakContext, message: openArray[byte]) =
   ## `ctx.finish(...)` and `ctx.clear()` are called as soon as possible.
   ## Additionally ensure that the message(s) passed were stored
   ## in memory considered secure for your threat model.
+  when UseASM_X86_32:
+    if ({.noSideEffect.}: hasBmi1()):
+      ctx.absorb_x86_bmi1(message)
+    else:
+      ctx.absorb_generic(message)
+  else:
+    ctx.absorb_generic(message)
 
-  var pos = int ctx.absorb_offset # offset in Keccak state
-  var cur = 0                     # offset in message
-  var bytesLeft = message.len
-
-  # We follow the "absorb-permute-squeeze" approach
-  # originally defined by the Keccak team.
-  # It is compatible with SHA-3 hash spec.
-  # See https://eprint.iacr.org/2022/1340.pdf
-  #
-  # There are no transition/permutation between squeezing -> absorbing
-  # And within this `absorb` function
-  #    the state pos == ctx.rate()
-  # is always followed by a permute and setting `pos = 0`
-
-  if (pos mod ctx.rate()) != 0 and pos+bytesLeft >= ctx.rate():
-    # Previous partial update, fill the state and do one permutation
-    let free = ctx.rate() - pos
-    ctx.H.xorInPartial(pos, message.toOpenArray(0, free-1))
-    ctx.H.permute_generic(NumRounds = 24)
-    pos = 0
-    cur = free
-    bytesLeft -= free
-
-  if bytesLeft >= ctx.rate():
-    # Process multiple blocks
-    let numBlocks = bytesLeft div ctx.rate()
-    ctx.H.hashMessageBlocks_generic(message.asUnchecked() +% cur, numBlocks)
-    cur += numBlocks * ctx.rate()
-    bytesLeft -= numBlocks * ctx.rate()
-
-  if bytesLeft != 0:
-    # Store the tail in buffer
-    ctx.H.xorInPartial(pos, message.toOpenArray(cur, cur+bytesLeft-1))
-
-  # Epilogue
-  ctx.absorb_offset = int32(pos+bytesLeft)
-  # Signal that the next squeeze transition needs a permute
-  ctx.squeeze_offset = int32 ctx.rate()
-
-func squeeze*(ctx: var KeccakContext, digest: var openArray[byte]) =
-  var pos = ctx.squeeze_offset # offset in Keccak state
-  var cur = 0                  # offset in message
-  var bytesLeft = digest.len
-
-  if pos == ctx.rate():
-    # Transition from absorbing to squeezing
-    #   This state can only come from `absorb` function
-    #   as within `squeeze`, pos == ctx.rate() is always followed
-    #   by a permute and pos = 0
-    ctx.H.pad(ctx.absorb_offset, ctx.delimiter, ctx.rate())
-    ctx.H.permute_generic(NumRounds = 24)
-    pos = 0
-    ctx.absorb_offset = 0
-
-  if (pos mod ctx.rate()) != 0 and pos+bytesLeft >= ctx.rate():
-    # Previous partial squeeze, fill up to rate and do one permutation
-    let free = ctx.rate() - pos
-    ctx.H.copyOutPartial(hByteOffset = pos, digest.toOpenArray(0, free-1))
-    ctx.H.permute_generic(NumRounds = 24)
-    pos = 0
-    ctx.absorb_offset = 0
-    cur = free
-    bytesLeft -= free
-
-  if bytesLeft >= ctx.rate():
-    # Process multiple blocks
-    let numBlocks = bytesLeft div ctx.rate()
-    ctx.H.squeezeDigestBlocks_generic(digest.asUnchecked() +% cur, numBlocks)
-    ctx.absorb_offset = 0
-    cur += numBlocks * ctx.rate()
-    bytesLeft -= numBlocks * ctx.rate()
-
-  if bytesLeft != 0:
-    # Output the tail
-    ctx.H.copyOutPartial(hByteOffset = pos, digest.toOpenArray(cur, bytesLeft-1))
-
-  # Epilogue
-  ctx.squeeze_offset = int32 bytesLeft
-  # We don't signal absorb_offset to permute the state if called next
-  # as per
-  #   - original keccak spec that uses "absorb-permute-squeeze" protocol
-  #   - https://eprint.iacr.org/2022/1340.pdf
-  #   - https://eprint.iacr.org/2023/522.pdf
-  #     https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/ByIbpfX9c#2-SAFE-definition
+func squeeze*(ctx: var KeccakContext, message: var openArray[byte]) =
+  when UseASM_X86_32:
+    if ({.noSideEffect.}: hasBmi1()):
+      ctx.squeeze_x86_bmi1(message)
+    else:
+      ctx.squeeze_generic(message)
+  else:
+    ctx.squeeze_generic(message)
 
 func update*(ctx: var KeccakContext, message: openArray[byte]) =
   ## Append a message to a Keccak context

--- a/constantine/hashes/h_sha256.nim
+++ b/constantine/hashes/h_sha256.nim
@@ -65,10 +65,10 @@ func dumpHash(
        digest: var array[DigestSize, byte],
        s: Sha256_state) {.inline.} =
   ## Convert the internal hash into a message digest
-  var dstIdx = 0'u
+  var dstIdx = 0
   for i in 0 ..< s.H.len:
     digest.dumpRawInt(s.H[i], dstIdx, bigEndian)
-    dstIdx += uint sizeof(uint32)
+    dstIdx += sizeof(uint32)
 
 func hashBuffer(ctx: var Sha256Context) {.inline.} =
   ctx.s.hashMessageBlocks(ctx.buf.asUnchecked(), numBlocks = 1)

--- a/constantine/hashes/keccak/keccak_generic.nim
+++ b/constantine/hashes/keccak/keccak_generic.nim
@@ -176,7 +176,12 @@ func genRho(): array[5*5, int] =
     y = Y
 
 func rotl(x: uint64, k: static int): uint64 {.inline.} =
-  return (x shl k) or (x shr (64 - k))
+  when k == 0 or k == 64:
+    # Rho[0, 0] = 0 and is miscompiled with Clang+optimizations
+    # https://github.com/mratsim/constantine/issues/499
+    x
+  else:
+    (x shl k) or (x shr (64 - k))
 
 func permute_impl*(A: var KeccakState, NumRounds: static int) {.inline.} =
   ## Implementation of Keccak permutation

--- a/constantine/hashes/keccak/keccak_generic.nim
+++ b/constantine/hashes/keccak/keccak_generic.nim
@@ -222,41 +222,24 @@ func permute_generic*(A: var KeccakState, NumRounds: static int) =
 template `^=`(accum: var SomeInteger, b: SomeInteger) =
   accum = accum xor b
 
-func xorInSingle(H: var KeccakState, val: byte, offset: int) {.inline.} =
+template `|=`(accum: var SomeInteger, b: SomeInteger) =
+  accum = accum or b
+
+func xorInSingle(H: var KeccakState, hByteOffset: int, val: byte) {.inline.} =
   ## Add a single byte in the Keccak state
+  ## at hByteOffset
 
   # Shift of 3    = log2(sizeof(byte) * 8) - Find the word to read/write
   # WordMask of 7 = sizeof(byte) * 8 - 1   - In the word, shift to the offset to read/write
-  let slot = (offset and 7) shl 3
+  let slot = (hByteOffset and 7) shl 3
   let lane = uint64(val) shl slot # All bits but the one set in `val` are 0, and 0 is neutral element of xor
-  H.state[offset shr 3] ^= lane
+  H.state[hByteOffset shr 3] ^= lane
 
 func xorInBlock_generic(H: var KeccakState, msg: array[200 - 2*32, byte]) {.inline.} =
   ## Add new data into the Keccak state
   # This can benefit from vectorized instructions
   for i in 0 ..< msg.len div 8:
     H.state[i] ^= uint64.fromBytes(msg, i*8, littleEndian)
-
-func xorInPartial*(H: var KeccakState, msg: openArray[byte]) =
-  ## Add multiple bytes to the state
-  ## The length MUST be less than the state length.
-  debug: doAssert msg.len <= sizeof(H.state)
-
-  # Implementation detail:
-  #   We could avoid an intermediate variable but
-  #   dealing with non-multiple of size(T) length
-  #   would be verbose, and require less than size(T)
-  #   endianness handling.
-  #   Furthermore 2 copies without the "multiple-of"
-  #   tracking overhead might be faster, especially
-  #   if the compiler vectorize the second one
-  #   or is able to fuse the 2 together.
-  #   Lastly, this is only called when transitioning
-  #   between absorbing and squeezing, for hashing
-  #   this means once, however long a message to hash is.
-  var blck: array[200 - 2*32, byte] # zero-init
-  rawCopy(blck, 0, msg, 0, msg.len)
-  H.xorInBlock_generic(blck)
 
 func copyOutWords[W: static int](
       H: KeccakState,
@@ -270,6 +253,70 @@ func copyOutWords[W: static int](
     for i in 0 ..< 8:
       dst[w*8+i] = toByte(word shr (i*8))
 
+func xorInPartialWord(
+        H: var KeccakState, hByteOffset: int,
+        msg: openArray[byte]) {.inline.} =
+  type T = uint64
+  const S = log2_vartime(uint sizeof(T))
+  let laneOffset = hByteOffset and (sizeof(T) - 1)
+  let slot = hByteOffset shr S
+  var lane = T(0)
+  for i in 0 ..< msg.len:
+    lane |= T(msg[i]) shl ((laneOffset+i)*sizeof(T))
+  H.state[slot] ^= lane
+
+func copyOutPartialWord(
+        H: KeccakState, hByteOffset: int,
+        dst: var openArray[byte]) {.inline.} =
+  type T = uint64
+  const S = log2_vartime(uint sizeof(T))
+  var lane = H.state[hByteOffset shr S] shr (hByteOffset*sizeof(T))
+  for i in 0 ..< dst.len:
+    dst[i] = toByte(lane)
+    lane = lane shr sizeof(T)
+
+func xorInPartial*(H: var KeccakState, hByteOffset: int, msg: openArray[byte]) =
+  ## Add multiple bytes to the state
+  ## The hByteOffset+length MUST be less than the state length.
+  debug: doAssert hByteOffset + msg.len <= sizeof(H.state)
+
+  # Implementation detail:
+  #   For small inputs, i.e. less than the rate (136 bytes)
+  #   copying data to/from the state to an intermediate buffer
+  #   has a very high cost.
+  #   This is problematic for tree hashing / Merkle tries
+  #   hence we directly write to the state.
+  type T = uint64
+  var pos = hByteOffset # offset in Keccak state (in bytes)
+  var cur = 0           # offset in message      (in bytes)
+  var bytesLeft = msg.len
+
+  # 1. Prologue - Loop peeling, offset landing in middle of uint64
+  let posMod = pos mod sizeof(T)
+  if posMod != 0 and posMod+bytesLeft >= sizeof(T):
+    # Previous partial word update
+    let free = sizeof(T) - posMod
+    H.xorInPartialWord(pos, msg.toOpenArray(0, free-1))
+    pos += free
+    cur = free
+    bytesLeft -= free
+
+  # 2. Steady state - copy whole uint64s
+  if bytesLeft >= sizeof(T):
+    let numWords = bytesLeft div sizeof(T)
+    let posW = pos div sizeof(T)
+    for w in 0 ..< numWords:
+      H.state[posW + w] ^= uint64.fromBytes(msg, cur + w*sizeof(T), littleEndian)
+    let adv = numWords * sizeof(T)
+    pos += adv
+    cur += adv
+    bytesLeft -= adv
+
+  # 3. Epilogue - partial uint64 update
+  if bytesLeft != 0:
+    # Store the tail in buffer
+    H.xorInPartialWord(pos, msg.toOpenArray(cur, cur+bytesLeft-1))
+
 func copyOutPartial*(
       H: KeccakState,
       hByteOffset: int,
@@ -280,17 +327,47 @@ func copyOutPartial*(
   ## hByteOffset + dst length MUST be less than the Keccak rate
   debug: doAssert dst.len + hByteOffset <= sizeof(H.state)
 
-  # Implementation details:
-  #   we could avoid a temporary block
-  #   see `xorInPartial` for rationale
-  var blck {.noInit.}: array[200 - 2*32, byte]
-  H.copyOutWords(blck)
-  rawCopy(dst, 0, blck, hByteOffset, dst.len)
+  # Implementation detail:
+  #   For small inputs, i.e. less than the rate (136 bytes)
+  #   copying data to/from the state to an intermediate buffer
+  #   has a very high cost.
+  #   Hashing outputs 32B, hence we incur 4x the cost
+  #   if we use an intermediate buffer of size the `rate`
+  type T = uint64
+  var pos = hByteOffset # offset in Keccak state (in bytes)
+  var cur = 0           # offset in dst digest   (in bytes)
+  var bytesLeft = dst.len
+
+  # 1. Prologue - Loop peeling, offset landing in middle of uint64
+  let posMod = pos mod sizeof(T)
+  if posMod != 0 and posMod+bytesLeft >= sizeof(T):
+    # previous partial word copy
+    let free = sizeof(T) - posMod
+    H.copyOutPartialWord(pos, dst.toOpenArray(0, free-1))
+    pos += free
+    cur = free
+    bytesLeft -= free
+
+  # 2. Steady state - copy whole uint64s
+  if bytesLeft >= sizeof(T):
+    let numWords = bytesLeft div sizeof(T)
+    let posW = pos div sizeof(T)
+    for w in 0 ..< numWords:
+      dst.dumpRawInt(H.state[posW + w], cur + w*sizeof(T), littleEndian)
+    let adv = numWords * sizeof(T)
+    pos += adv
+    cur += adv
+    bytesLeft -= adv
+
+  # 3. Epilogue - partial uint64 dump
+  if bytesLeft != 0:
+    # Store the tail in buffer
+    H.copyOutPartialWord(pos, dst.toOpenArray(cur, cur+bytesLeft-1))
 
 func pad*(H: var KeccakState, hByteOffset: int, delim: static byte, rate: static int) {.inline.} =
   debug: doAssert hByteOffset < rate
-  H.xorInSingle(delim, hByteOffset)
-  H.xorInSingle(0x80, rate-1)
+  H.xorInSingle(hByteOffset, delim)
+  H.xorInSingle(hByteOffset = rate-1, 0x80)
 
 func hashMessageBlocks_generic*(
       H: var KeccakState,

--- a/constantine/hashes/keccak/keccak_x86_bmi1.nim
+++ b/constantine/hashes/keccak/keccak_x86_bmi1.nim
@@ -1,0 +1,60 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./keccak_generic
+
+# Notes:
+# - AVX2 makes thing **slower**
+# - BMI2 makes the compiler use RORX everywhere
+#   but
+#   - hardware already has instruction-level parallelism (ILP)
+#     when modified flags are not consumed by next instructions
+#   - compiler generates RORX everywhere even when self-rotating a register
+#     and the instructions is 2x bigger than ROL/ROR so it hurts instruction cache.
+#   - benchmarks appear to be the same
+{.localpassC:"-mbmi".}
+
+func permute_x86_bmi1*(A: var KeccakState, NumRounds: static int) =
+  permute_impl(A, NumRounds)
+
+func xorInPartial_x86_bmi1*(H: var KeccakState, hByteOffset: int, msg: openArray[byte]) =
+  ## Add multiple bytes to the state
+  ## The hByteOffset+length MUST be less than the state length.
+  xorInPartial_impl(H, hByteOffset, msg)
+
+func copyOutPartial_x86_bmi1*(
+      H: KeccakState,
+      hByteOffset: int,
+      dst: var openArray[byte]) {.inline.} =
+  ## Read data from the Keccak state
+  ## and write it into `dst`
+  ## starting from the state byte offset `hByteOffset`
+  ## hByteOffset + dst length MUST be less than the Keccak rate
+  copyOutPartial_impl(H, hByteOffset, dst)
+
+func hashMessageBlocks_x86_bmi1*(
+      H: var KeccakState,
+      message: ptr UncheckedArray[byte],
+      numBlocks: int) =
+  ## Hash a message block by block
+  ## Keccak block size is the rate: 64
+  ## The state MUST be absorb ready
+  ## i.e. previous operation cannot be a squeeze
+  ##      a permutation is needed in-between
+  hashMessageBlocks_impl(H, message, numBlocks)
+
+func squeezeDigestBlocks_x86_bmi1*(
+      H: var KeccakState,
+      digest: ptr UncheckedArray[byte],
+      numBlocks: int) =
+  ## Squeeze a digest block by block
+  ## Keccak block digest is the rate: 64
+  ## The state MUST be squeeze ready
+  ## i.e. previous operation cannot be an absorb
+  ##      a permutation is needed in-between
+  squeezeDigestBlocks_impl(H, digest, numBlocks)

--- a/constantine/platforms/allocs.nim
+++ b/constantine/platforms/allocs.nim
@@ -90,7 +90,7 @@ proc allocHeapAligned*(T: typedesc, alignment: static Natural): ptr T {.inline.}
   # aligned_alloc requires allocating in multiple of the alignment.
   let # Cannot be static with bitfields. Workaround https://github.com/nim-lang/Nim/issues/19040
     size = sizeof(T)
-    requiredMem = size.roundround_step_up(alignment)
+    requiredMem = size.round_step_up(alignment)
 
   cast[ptr T](aligned_alloc(alignment, requiredMem))
 
@@ -98,7 +98,7 @@ proc allocHeapUncheckedAligned*(T: typedesc, size: int, alignment: static Natura
   ## Aligned heap allocation for types containing a variable-sized UncheckedArray field
   ## or an importc type with missing size information
   # aligned_alloc requires allocating in multiple of the alignment.
-  let requiredMem = size.roundround_step_up(alignment)
+  let requiredMem = size.round_step_up(alignment)
 
   cast[ptr T](aligned_alloc(alignment, requiredMem))
 
@@ -106,7 +106,7 @@ proc allocHeapArrayAligned*(T: typedesc, len: int, alignment: static Natural): p
   # aligned_alloc requires allocating in multiple of the alignment.
   let
     size = sizeof(T) * len
-    requiredMem = size.roundround_step_up(alignment)
+    requiredMem = size.round_step_up(alignment)
 
   cast[ptr UncheckedArray[T]](aligned_alloc(alignment, requiredMem))
 

--- a/constantine/platforms/allocs.nim
+++ b/constantine/platforms/allocs.nim
@@ -6,6 +6,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+import ./bithacks
+
 {.push raises:[].}  # No exceptions for crypto
 {.push checks:off.} # No int->size_t exceptions
 

--- a/constantine/serialization/endians.nim
+++ b/constantine/serialization/endians.nim
@@ -38,7 +38,7 @@ func blobFrom*(dst: var openArray[byte], src: SomeUnsignedInt, startIdx: int, en
 func dumpRawInt*(
            dst: var openArray[byte],
            src: SomeUnsignedInt,
-           cursor: uint, endian: static Endianness) {.inline.} =
+           cursor: int, endian: static Endianness) {.inline.} =
   ## Dump an integer into raw binary form
   ## The `cursor` represents the current index in the array
   ## The binary blob is interpreted as:
@@ -50,13 +50,13 @@ func dumpRawInt*(
       "cursor (" & $cursor & ") + sizeof(src) (" & $sizeof(src) &
       ") <= dst.len (" & $dst.len & ")"
 
-  const L = uint sizeof(src)
+  const L = sizeof(src)
 
   when endian == littleEndian:
-    for i in 0'u ..< L:
+    for i in 0 ..< L:
       dst[cursor+i] = toByte(src shr (i * 8))
   else:
-    for i in 0'u ..< L:
+    for i in 0 ..< L:
       dst[cursor+i] = toByte(src shr ((L-i-1) * 8))
 
 func toBytes*(num: SomeUnsignedInt, endianness: static Endianness): array[sizeof(num), byte] {.noInit, inline.}=

--- a/constantine/serialization/endians.nim
+++ b/constantine/serialization/endians.nim
@@ -45,8 +45,8 @@ func dumpRawInt*(
   ## - an array of words traversed from 0 ..< len (little-endian), via an incremented `cursor`
   ## - with each word being of `endian` ordering for deserialization purpose.
   debug:
-    doAssert 0 <= cursor and cursor < dst.len.uint
-    doAssert cursor + sizeof(src).uint <= dst.len.uint,
+    doAssert 0 <= cursor and cursor < dst.len
+    doAssert cursor + sizeof(src) <= dst.len,
       "cursor (" & $cursor & ") + sizeof(src) (" & $sizeof(src) &
       ") <= dst.len (" & $dst.len & ")"
 


### PR DESCRIPTION
This optimizes Keccak and fixes #495:
- remove the intermediate buffer and directly use Keccak state for chunked hashing.
- introduces BMI1 optimizations on x86. AVX2 and BMI2, at least naive were worst (AVX2) or unconvincing (BMI2, no change in perf, bigger code due to 2x bigger instruction)

It also addresses #499:
- rotate left by 0 gives wrong result with Clang + optimizations

Benchmarks done with Clang on Zen5

Before
![image](https://github.com/user-attachments/assets/382c6704-f4ce-4f51-9c6c-02c8fef1685c)

After
![image](https://github.com/user-attachments/assets/6bba9ae5-93df-49d7-a2db-0ed6c0a44d3f)

Small hashes like 32B, the size for Merkle Tree based keccak has been improved by 16%.

And for large input we're faster than OpenSSL! without assembly.

## Full comparison vs C and Rust
Rustcrypto from https://github.com/mratsim/constantine/issues/495#issuecomment-2561915443

![image](https://github.com/user-attachments/assets/cf0023f7-d6e1-472c-bee7-da783848ad7a)

22.8% perf advantage over the Rust implementation

vs C Keccak-tiny-unrolled from https://github.com/status-im/nim-keccak-tiny/blob/master/keccak_tiny/keccak-tiny-unrolled.c
![image](https://github.com/user-attachments/assets/6dd85ef3-32cc-4e20-ac36-cd8c95fb4b51)

