### PR TITLE
Add `ECRecover` EVM precompile

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -609,7 +609,8 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/t_ethereum_verkle_ipa_primitives.nim", false),
 
   # Signatures
-  ("tests/ecdsa/t_ecdsa_verify_openssl.nim", false),
+  # NOTE: Requires OpenSSL version >=v3.3 for to Keccak256 support
+  # ("tests/ecdsa/t_ecdsa_verify_openssl.nim", false),
 
   # Proof systems
   # ----------------------------------------------------------

--- a/constantine/ecdsa_secp256k1.nim
+++ b/constantine/ecdsa_secp256k1.nim
@@ -81,3 +81,21 @@ proc recoverPubkey*(
   ## `evenY == true` returns the public key corresponding to the
   ## even `y` coordinate of the `R` point.
   publicKey.raw.recoverPubkey(signature, message, evenY, H)
+
+proc recoverPubkey*(
+    publicKey: var PublicKey,
+    msgHash: Fr[Secp256k1],
+    signature: Signature,
+    evenY: bool
+) {.libPrefix: prefix_ffi.} =
+  ## Verify `signature` using `publicKey` for the given message digest
+  ## given as a scalar in the field `Fr[Secp256k1]`.
+  ##
+  ## `evenY == true` returns the public key corresponding to the
+  ## even `y` coordinate of the `R` point.
+  ##
+  ## As this overload works directly with a message hash as a scalar,
+  ## it requires no hash function. Internally, it also calls the
+  ## `verify` implementation, which already takes a scalar and thus
+  ## requires no hash function there either.
+  publicKey.raw.recoverPubkeyImpl_vartime(signature, msgHash, evenY)

--- a/constantine/ecdsa_secp256k1.nim
+++ b/constantine/ecdsa_secp256k1.nim
@@ -66,3 +66,12 @@ func derive_pubkey*(public_key: var PublicKey, secret_key: SecretKey) {.libPrefi
   ##
   ## The secret_key MUST be validated
   public_key.raw.derivePubkey(secret_key.raw)
+
+proc recoverPubkey*(
+    publicKey: var PublicKey,
+    message: openArray[byte],
+    signature: Signature,
+    evenY: bool
+) {.libPrefix: prefix_ffi, genCharAPI.} =
+  ## Verify `signature` using `publicKey` for `message`.
+  publicKey.raw.recoverPubkey(signature, message, evenY, sha256)

--- a/constantine/eth_ecdsa_signatures.nim
+++ b/constantine/eth_ecdsa_signatures.nim
@@ -79,7 +79,7 @@ proc recoverPubkey*(
   ## even `y` coordinate of the `R` point.
   publicKey.raw.recoverPubkey(signature, message, evenY, keccak256)
 
-proc recoverPubkey*(
+proc recoverPubkeyFromDigest*(
     publicKey: var PublicKey,
     msgHash: Fr[Secp256k1],
     signature: Signature,

--- a/constantine/eth_ecdsa_signatures.nim
+++ b/constantine/eth_ecdsa_signatures.nim
@@ -47,21 +47,19 @@ func signatures_are_equal*(a, b: Signature): bool {.libPrefix: prefix_ffi.} =
 proc sign*(sig: var Signature,
            secretKey: SecretKey,
            message: openArray[byte],
-           nonceSampler: NonceSampler = nsRandom,
-           H: type CryptoHash = sha256) {.libPrefix: prefix_ffi, genCharAPI.} =
+           nonceSampler: NonceSampler = nsRandom) {.libPrefix: prefix_ffi, genCharAPI.} =
   ## Sign `message` using `secretKey` and store the signature in `sig`. The nonce
   ## will either be randomly sampled `nsRandom` or deterministically calculated according
   ## to RFC6979 (`nsRfc6979`)
-  sig.coreSign(secretKey.raw, message, H, nonceSampler)
+  sig.coreSign(secretKey.raw, message, keccak256, nonceSampler)
 
 proc verify*(
     publicKey: PublicKey,
     message: openArray[byte],
-    signature: Signature,
-    H: type CryptoHash = sha256
+    signature: Signature
 ): bool {.libPrefix: prefix_ffi, genCharAPI.} =
   ## Verify `signature` using `publicKey` for `message`.
-  result = publicKey.raw.coreVerify(message, signature, H)
+  result = publicKey.raw.coreVerify(message, signature, keccak256)
 
 func derive_pubkey*(public_key: var PublicKey, secret_key: SecretKey) {.libPrefix: prefix_ffi.} =
   ## Derive the public key matching with a secret key
@@ -73,14 +71,13 @@ proc recoverPubkey*(
     publicKey: var PublicKey,
     message: openArray[byte],
     signature: Signature,
-    evenY: bool,
-    H: type CryptoHash = sha256
+    evenY: bool
 ) {.libPrefix: prefix_ffi, genCharAPI.} =
   ## Verify `signature` using `publicKey` for `message`.
   ##
   ## `evenY == true` returns the public key corresponding to the
   ## even `y` coordinate of the `R` point.
-  publicKey.raw.recoverPubkey(signature, message, evenY, H)
+  publicKey.raw.recoverPubkey(signature, message, evenY, keccak256)
 
 proc recoverPubkey*(
     publicKey: var PublicKey,

--- a/constantine/eth_ecdsa_signatures.nim
+++ b/constantine/eth_ecdsa_signatures.nim
@@ -17,7 +17,7 @@ import
 
 export NonceSampler
 
-const prefix_ffi = "ctt_ecdsa_secp256k1_"
+const prefix_ffi = "ctt_eth_ecdsa"
 type
   SecretKey* {.byref, exportc: prefix_ffi & "seckey".} = object
     ## A Secp256k1 secret key

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -1340,7 +1340,7 @@ func eth_evm_ecrecover*(r: var openArray[byte],
 
   # 4. perform pubkey recovery
   var pubKey {.noinit.}: PublicKey
-  pubKey.recoverPubkey(msgHash, signature, evenY) # , keccak256)
+  pubKey.recoverPubkeyFromDigest(msgHash, signature, evenY)
 
   # 4. now calculate the Ethereum address of the public key (keccak256)
   privateAccess(PublicKey)

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -24,7 +24,7 @@ import
   ./ethereum_eip4844_kzg,
   ./serialization/codecs_status_codes,
   # ECDSA for ECRecover
-  ./ecdsa_secp256k1
+  ./eth_ecdsa_signatures
 
 # For KZG point precompile
 export EthereumKZGContext, TrustedSetupFormat, TrustedSetupStatus, trusted_setup_load, trusted_setup_delete

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -50,8 +50,7 @@ type
     cttEVM_PointNotOnCurve
     cttEVM_PointNotInSubgroup
     cttEVM_VerificationFailure
-    cttEVM_InvalidSignature
-    cttEVM_InvalidV # `v` of signature `(r, s, v)` is invalid
+    cttEVM_MalformedSignature
 
 func eth_evm_sha256*(r: var openArray[byte], inputs: openArray[byte]): CttEVMStatus {.libPrefix: prefix_ffi, meter.} =
   ## SHA256
@@ -1323,10 +1322,10 @@ func eth_evm_ecrecover*(r: var openArray[byte],
   ## XXX: Or construct a `BigInt[256]` instead and compare? (or compare with uint64s?)
   for i in 32 ..< 63: # first 31 bytes must be zero for a valid `v`
     if input[i] != byte 0:
-      return cttEVM_InvalidV
+      return cttEVM_MalformedSignature
   let v = input[63]
   if v notin [byte 0, 1, 27, 28]:
-    return cttEVM_InvalidSignature
+    return cttEVM_MalformedSignature
   # 2a. determine if even or odd `y` coordinate
   let evenY = v in [byte 0, 27] # 0 / 27 indicates `y` to be even, 1 / 28 odd
 

--- a/constantine/serialization/codecs_ecdsa_secp256k1.nim
+++ b/constantine/serialization/codecs_ecdsa_secp256k1.nim
@@ -38,7 +38,7 @@ import
   constantine/math/arithmetic/finite_fields,
   constantine/math/elliptic/ec_shortweierstrass_affine,
   constantine/math/io/io_bigints,
-  constantine/ecdsa_secp256k1
+  constantine/eth_ecdsa_signatures
 
 import std / [strutils, base64, math, importutils]
 

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -340,7 +340,7 @@ proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
 
   # Due to the conversion of the `x` coordinate in `Fp` of the point `R` in the signing process
   # to a scalar in `Fr`, we potentially reduce it modulo the curve order (if `x >= r` with
-  # `M` the subgroup order).
+  # `r` the curve order).
   # As we don't know if this is the case, we need to loop until we either find a valid signature,
   # adding `M` each iteration or until we roll over again, in which case the signature is invalid.
   # NOTE: For secp256k1 this is _extremely_ unlikely, because prime of the curve `p` and subgroup

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -339,7 +339,7 @@ proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
   let M = Fp[Name].fromBig(Fr[Name].getModulus())
 
   # Due to the conversion of the `x` coordinate in `Fp` of the point `R` in the signing process
-  # to a scalar in `Fr`, we potentially reduce it modulo the subgroup order (if `x > M` with
+  # to a scalar in `Fr`, we potentially reduce it modulo the curve order (if `x >= r` with
   # `M` the subgroup order).
   # As we don't know if this is the case, we need to loop until we either find a valid signature,
   # adding `M` each iteration or until we roll over again, in which case the signature is invalid.

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -381,6 +381,7 @@ proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
     recovered.ccopy(Q.getAffine(), SecretBool validSig) # Copy `Q` if valid
     # 6. try next `i` in `x1 = r + i·M`
     x1 += M
+
 proc recoverPubkey*[Pubkey; Sig](
     recovered: var Pubkey,
     signature: Sig,

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -308,7 +308,8 @@ func coreVerify*[Pubkey, Sig](
   msgHash.fromDigest(dgst, truncateInput = true)
   # 2. verify
   result = pubKey.verifyImpl(signature, msgHash)
-proc recoverPubkeyImpl_vartime[Name: static Algebra; Sig](
+
+proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
     recovered: var EC_ShortW_Aff[Fp[Name], G1],
     signature: Sig,
     msgHash: Fr[Name],

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -344,7 +344,7 @@ proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
   # As we don't know if this is the case, we need to loop until we either find a valid signature,
   # adding `M` each iteration or until we roll over again, in which case the signature is invalid.
   # NOTE: For secp256k1 this is _extremely_ unlikely, because prime of the curve `p` and subgroup
-  # order `M` are so close!
+  # order `r` are so close!
   var validSig = false
   while (not validSig) and bool(x1.toBig() <= rInit):
     # 1. Get base `R` point

--- a/tests/ecdsa/t_ecdsa_verify_openssl.nim
+++ b/tests/ecdsa/t_ecdsa_verify_openssl.nim
@@ -66,7 +66,7 @@ func getPublicKey(secKey: SecretKey): PublicKey {.noinit.} =
 template toOA(x: string): untyped = toOpenArrayByte(x, 0, x.len-1)
 
 when not defined(windows) and not defined(macosx): # see above
-  proc signAndVerify(num: int, msg = "", nonceSampler = nsRandom) =
+  proc signVerifyRecover(num: int, msg = "", nonceSampler = nsRandom) =
     ## Generates `num` signatures and verify them against OpenSSL.
     ##
     ## If `msg` is given, use a fixed message. Otherwise will generate a message with
@@ -111,6 +111,22 @@ when not defined(windows) and not defined(macosx): # see above
       derSig.toDER(rOslFr, sOslFr)
       check derSig.data == osSig
 
+      # Attempt to recover public key from signature and hash. Two possible public keys
+      # verify the signature. Only one of them is the public key we actually derived from
+      # our private key. So recover both, check they verify the signature and one of them
+      # is equal to our initial public key.
+      var recEven {.noinit.}: PublicKey
+      var recOdd {.noinit.}: PublicKey
+      recEven.recoverPubkey(toOA msg, sigCTT, evenY = true)
+      recOdd.recoverPubkey(toOA msg, sigCTT, evenY = false)
+
+      # Check both verify signature
+      check recEven.verify(toOA msg, sigCTT)
+      check recOdd.verify(toOA msg, sigCTT)
+
+      # Check one of them is equal to our initial pubkey
+      check pubkeys_are_equal(recEven, pubKey) or pubkeys_are_equal(recOdd, pubKey)
+
   proc verifyPemWriter(num: int, msg = "") =
     ## We verify our PEM writers in a bit of a roundabout way.
     ##
@@ -148,7 +164,6 @@ when not defined(windows) and not defined(macosx): # see above
     ## using deterministic nonce generation and verifies the signature comes out
     ## identical each time.
     var derSig: DerSignature[DerSigSize(Secp256k1)]
-
     let secKey = generatePrivateKey()
     var sig {.noinit.}: Signature
     sig.sign(secKey, toOA msg, nonceSampler = nsRfc6979)
@@ -171,10 +186,10 @@ when not defined(windows) and not defined(macosx): # see above
 
   suite "ECDSA over secp256k1":
     test "Verify OpenSSL generated signatures from a fixed message (different nonces)":
-      signAndVerify(100, "Hello, Constantine!") # fixed message
+      signVerifyRecover(100, "Hello, Constantine!") # fixed message
 
     test "Verify OpenSSL generated signatures for different messages":
-      signAndVerify(100) # randomly generated message
+      signVerifyRecover(100) # randomly generated message
 
     test "Verify deterministic nonce generation via RFC6979 yields deterministic signatures":
       signRfc6979("Hello, Constantine!")

--- a/tests/ecdsa/t_ecdsa_verify_openssl.nim
+++ b/tests/ecdsa/t_ecdsa_verify_openssl.nim
@@ -17,7 +17,7 @@ import
   constantine/serialization/[codecs, codecs_ecdsa, codecs_ecdsa_secp256k1],
   constantine/math/arithmetic/[bigints, finite_fields],
   constantine/platforms/abstractions,
-  constantine/ecdsa_secp256k1
+  constantine/eth_ecdsa_signatures
 
 when not defined(windows) and not defined(macosx):
   # Windows (at least in GH actions CI) does not provide, among others `BN_new`

--- a/tests/ecdsa/t_ecdsa_verify_openssl.nim
+++ b/tests/ecdsa/t_ecdsa_verify_openssl.nim
@@ -8,6 +8,8 @@ We generate test vectors following these cases:
 
 Further, generate signatures using Constantine, which we verify
 with OpenSSL.
+
+NOTE: This test requires OpenSSL version >= 3.3, for Keccak256 support.
 ]##
 
 import

--- a/tests/openssl_wrapper.nim
+++ b/tests/openssl_wrapper.nim
@@ -92,6 +92,9 @@ proc EVP_DigestSignInit*(ctx: EVP_MD_CTX,
                        e: pointer,
                        pkey: EVP_PKEY): cint
 
+
+proc EVP_MD_fetch*(ctx: OSSL_LIB_CTX, algorithm: cstring, properties: cstring): pointer
+
 proc EVP_DigestSign*(ctx: EVP_MD_CTX,
                     sig: ptr byte,
                     siglen: ptr uint,
@@ -138,7 +141,12 @@ proc signMessageOpenSSL*(sig: var array[72, byte], msg: openArray[byte], key: EV
   let ctx = EVP_MD_CTX_new()
   var pctx: EVP_PKEY_CTX
 
-  if EVP_DigestSignInit(ctx, addr pctx, EVP_sha256(), nil, key) <= 0:
+  let md = EVP_MD_fetch(nil, "KECCAK-256", nil)
+  if md.isNil:
+    raise newException(Exception, "Failed to fetch KECCAK-256")
+
+
+  if EVP_DigestSignInit(ctx, addr pctx, md, nil, key) <= 0:
     raise newException(Exception, "Signing init failed")
 
   # Get required signature length

--- a/tests/t_ethereum_evm_precompiles.nim
+++ b/tests/t_ethereum_evm_precompiles.nim
@@ -82,7 +82,9 @@ template runPrecompileTests(filename: string, funcname: untyped, outsize: int, n
         else:
           let status = funcname(r, inputbytes)
         if status != cttEVM_Success:
-          doAssert test.ExpectedError.len > 0, "[Test Failure]\n" &
+          # `ecRecover.json` has failing test vectors where no `ExpectedError` exists, but the
+          # `Expected` output is simply empty.
+          doAssert test.ExpectedError.len > 0 or test.Expected.len == 0, "[Test Failure]\n" &
             "  " & test.Name & "\n" &
             "  " & funcname.astToStr & "\n" &
             "  " & "Nim proc returned failure, but test expected to pass.\n" &
@@ -163,3 +165,5 @@ runPrecompileTests("eip-2537/map_fp2_to_G2_bls.json", eth_evm_bls12381_map_fp2_t
 runPrecompileTests("eip-2537/fail-map_fp2_to_G2_bls.json", eth_evm_bls12381_map_fp2_to_g2, 256)
 
 runPrecompileTests("eip-4844/pointEvaluation.json", eth_evm_kzg_point_evaluation, 64, true)
+
+runPrecompileTests("ecRecover.json", eth_evm_ecrecover, 32)


### PR DESCRIPTION
This builds on top of the ECDSA implementation in PR #490 and adds public key recovery. Based on that implementing the `ECRecover` precompile is quite straightforward (recover an Ethereum address based on a given message digest and signature). 

We base our implementation of the precompile on Geth's implementation here:

https://github.com/ethereum/go-ethereum/blob/341647f1865dab437a690dc1424ba71495de2dd8/core/vm/contracts.go#L243-L272

and to a lesser extent appendix F in the Ethereum Yellow Paper.


For the general ECDSA public key recovery API I went with a variable time implementation. To my understanding this is essentially needed regardless, due to the fact that the signing process converts the coordinate of the point `R` in `Fp` to a scalar in `Fr`. While unlikely for Secp256k1 (because the subgroup order and the curve prime are both 256 bit integers), if the x coordinate is larger than the subgroup order, we reduce it. This reduction needs to be reversed in the recovery process requiring a loop.
In addition we have an `evenY` boolean argument, which decides if we recover the public key associated with the `R` coordinate with an even `y` coordinate or an odd one (if `y` is even then `-y` is odd in a finite field of odd size).


(I'll fix the CI failure in the other PR and will rebase this one on top of the other once that is done)