### PR TITLE
opt(ecc): jacobian doubling improvement

### DIFF
--- a/constantine/math/elliptic/ec_shortweierstrass_jacobian.md
+++ b/constantine/math/elliptic/ec_shortweierstrass_jacobian.md
@@ -222,3 +222,8 @@ we could use this formula instead:
 | Y₃ = R*(V-X₃)-2*S₁*J               | Y₃ = M*(S-X₃)-8*YY²                      |                 |                |
 | Z₃ = ((Z₁+Z₂)²-Z₁Z₁-Z₂Z₂)*H        | Z₃ = (Y₁+Z₁)² - YY - ZZ                  |                 |                |
 ```
+
+## References
+
+- https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
+- Bos, Costello, Longa, Naehrig, 2014: https://eprint.iacr.org/2014/130.pdf


### PR DESCRIPTION
Bench on a Mac M4 Max (no assembly)

![bench_ctt_ecc_double](https://github.com/user-attachments/assets/8067e9d8-723f-4969-a2d7-c793e57b7663)

This avoids many additions and includes multiplication by 8 by halving one intermediate computation (that then are squared twice so the 1/2 becomes 1/8 and cancel the factor 8).

Improvement is 5 to 8%, including on G2 where squaring a much cheaper than multiplication.