### PR TITLE
remove `when nimvm` condition to import

### DIFF
--- a/constantine/math/arithmetic/finite_fields.nim
+++ b/constantine/math/arithmetic/finite_fields.nim
@@ -39,10 +39,7 @@ when UseASM_X86_64:
 when UseASM_ARM64:
   import ./assembly/limbs_asm_modular_arm64
 
-when nimvm:
-  from constantine/named/deriv/precompute import montyResidue_precompute
-else:
-  discard
+from constantine/named/deriv/precompute import montyResidue_precompute
 
 export Fp, Fr, FF
 


### PR DESCRIPTION
Both branches of a `when nimvm` statement are compiled, so this import is always processed.