### PR TITLE
Fix Typos and Spelling Errors in Code and Documentation

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -66,7 +66,7 @@ Other tracks are stretch goals, contributions towards them are accepted.
   - Finish IPA for Verkle Tries:
     - Full test suite coverage https://github.com/mratsim/constantine/issues/396
 
-- Fast MSM for fixed base like Trusted Setups and Ethreum Verkle Tries
+- Fast MSM for fixed base like Trusted Setups and Ethereum Verkle Tries
   - Notes on MSMs with precomputation https://hackmd.io/WfIjm0icSmSoqy2cfqenhQ
   - Verkle Trees - Another iteration of VKTs MSMs https://hackmd.io/@jsign/vkt-another-iteration-of-vkt-msms
 
@@ -99,7 +99,7 @@ Other tracks are stretch goals, contributions towards them are accepted.
 - LLVM IR:
   - use internal or private linkage type
   - look into calling conventions like "fast" or "Tail fast"
-  - check if returning a value from function is propely optimized
+  - check if returning a value from function is properly optimized
     compared to in-place result
   - use readnone (pure) and readmem attribute for functions
   - look into passing parameter as arrays instead of pointers?
@@ -139,7 +139,7 @@ Create a "Constantine book" to introduce Constantine concepts and walkthrough av
       Example: Lasso or LogUp+GKR
 
     - Multilinear Polynomial Commitment Schemes
-      For efficiency when commiting to small values (for example coming from bit manipulation in hash functions)
+      For efficiency when committing to small values (for example coming from bit manipulation in hash functions)
       Example: KZG+Gemini/Zeromorph, Dory, Hyrax, Binius, ...
 
 - STARKS:

--- a/README-PERFORMANCE.md
+++ b/README-PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-High-performance is a sought out property.
+High-performance is a sought after property.
 Note that security and side-channel resistance takes priority over performance.
 
 New applications of elliptic curve cryptography like zero-knowledge proofs or
@@ -27,7 +27,7 @@ To measure the performance of Constantine
 ```bash
 git clone https://github.com/mratsim/constantine
 
-# Default compiler. We recommand enforcing CC=clang for best performance.
+# Default compiler. We recommend enforcing CC=clang for best performance.
 nimble bench_fp
 
 # Arithmetic
@@ -112,7 +112,7 @@ and provides the following paradigms:
 - Dataflow parallelism / Stream parallelism / Graph Parallelism / Pipeline parallelism
 - Structured Parallelism
 
-The threadpool parallel-for loops use lazy loop splitting and are fully adaptative to the workload being scheduled, the threads in-flight load and the hardware speed unlike most (all?) runtime, see:
+The threadpool parallel-for loops use lazy loop splitting and are fully adaptive to the workload being scheduled, the threads in-flight load and the hardware speed unlike most (all?) runtime, see:
 - OpenMP woes depending on hardware and workload: https://github.com/zy97140/omp-benchmark-for-pytorch
 - Raytracing ideal runtime, adapt to pixel compute load: ![load distribution](./media/parallel_load_distribution.png)\
   Most (all?) production runtime use scheduling A (split on number of threads like GCC OpenMP) or B (eager splitting, unable to adapt to actual work like LLVM/Intel OpenMP or Intel TBB) while Constantine uses C.


### PR DESCRIPTION
1.Ethreum → Ethereum – Fixed typo in the word Ethereum, the correct name of the blockchain platform.
2.propely → properly – Fixed spelling mistake in properly, meaning "correctly".
3.commiting → committing – Corrected the spelling of committing, referring to making a commit or saving changes in code.
4.sought out → sought after – Fixed the expression to the correct form sought-after, meaning "highly desired".
5.recommand → recommend – Corrected the spelling of recommend, meaning "suggest".
6.adaptative → adaptive – Replaced adaptative with adaptive.