### PR TITLE
docs: Update documentation of shiftRight, fixes #537

### DIFF
--- a/constantine/math/arithmetic/bigints.nim
+++ b/constantine/math/arithmetic/bigints.nim
@@ -323,7 +323,10 @@ func square*[rBits, aBits](r: var BigInt[rBits], a: BigInt[aBits]) =
 func shiftRight*(a: var BigInt, k: int) =
   ## Shift right by k.
   ##
-  ## k MUST be less than the base word size (2^31 or 2^63)
+  ## Precondition:
+  ## - On 32-bit platforms, k MUST be 0 < k < 32
+  ## - On 64-bit platforms, k MUST be 0 < k < 64
+  debug: doAssert 0 < k and k < WordBitwidth
   a.limbs.shiftRight(k)
 
 func bit*[bits: static int](a: BigInt[bits], index: int): Ct[uint8] =

--- a/constantine/math/arithmetic/limbs.nim
+++ b/constantine/math/arithmetic/limbs.nim
@@ -168,7 +168,9 @@ func isOne*(a: Limbs): SecretBool =
 func shiftRight*(a: var Limbs, k: int) =
   ## Shift right by k.
   ##
-  ## k MUST be less than the base word size (2^32 or 2^64)
+  ## Precondition:
+  ## - On 32-bit platforms, k MUST be 0 < k < 32
+  ## - On 64-bit platforms, k MUST be 0 < k < 64
   # We don't reuse shr as this is an in-place operation
   # Do we need to return the shifted out part?
   #
@@ -177,7 +179,7 @@ func shiftRight*(a: var Limbs, k: int) =
   #       is probably easier to parallelize for the compiler
   #       (antidependence WAR vs loop-carried dependence RAW)
 
-  # checkWordShift(k)
+  debug: doAssert 0 < k and k < WordBitwidth
 
   for i in 0 ..< a.len-1:
     a[i] = (a[i] shr k) or (a[i+1] shl (WordBitWidth - k))

--- a/constantine/named/deriv/precompute.nim
+++ b/constantine/named/deriv/precompute.nim
@@ -215,7 +215,9 @@ func `<`(a, b: BigInt): bool =
 func shiftRight*(a: var BigInt, k: int) =
   ## Shift right by k.
   ##
-  ## k MUST be less than the base word size (2^32 or 2^64)
+  ## Precondition:
+  ## - On 32-bit platforms, k MUST be 0 < k < 32
+  ## - On 64-bit platforms, k MUST be 0 < k < 64
 
   for i in 0 ..< a.limbs.len-1:
     a.limbs[i] = (a.limbs[i] shr k) or (a.limbs[i+1] shl (WordBitWidth - k))


### PR DESCRIPTION
This clarifies the precondition for shiftRight, i.e. a non-zero, non-max to avoid all exceptional/ISA-defined path.

shiftRight was initially introduced to optimized GCD/modular inversion in https://github.com/mratsim/constantine/commit/bde619155b34182552a236652842e9be12b863e5.

Today it is used in a couple more places and there are no "zero" input expected in constant-time path. In fact all inputs are statically known, the proc doesn't use a static k to avoid code bloat / monomorphization.

A version that can handles zero and sizes over the word bitwidth is available as `shiftRight_vartime`.


