### PR TITLE
Update actions/setup-go to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           install: base-devel git mingw-w64-x86_64-toolchain
 
       - name: Install Go [${{ matrix.go_toolchain }}]
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_toolchain }}
 


### PR DESCRIPTION

Updates actions/setup-go from v4 to v5 across our CI/CD workflows.

## Changes:
- Updates `actions/setup-go@v4` to `actions/setup-go@v5` in workflow files
- Improves self-hosted environment validation
- Enhances error handling with manifest validation

## Reference:
Latest version confirmation: https://github.com/actions/setup-go/releases/tag/v5.5.0

This update ensures we're using the most recent stable version of the GitHub setup-go action across our CI/CD pipelines, with improved validation and error handling capabilities.