### PR TITLE
fix NVRTC CUDA backend due to incompatible pointer types

### DIFF
--- a/constantine/math_compiler/experimental/cuda_execute_dsl.nim
+++ b/constantine/math_compiler/experimental/cuda_execute_dsl.nim
@@ -340,14 +340,14 @@ macro execCuda*(jitFn: CUfunction,
   ## as an input.
   ##
   ## NOTE: This function is mainly intended for convenient execution of a single kernel
-  result = execCudaImpl(jitFn, newLit 1, newLit 1, res, inputs, newLit 0, passStructByPointer = false)
+  result = execCudaImpl(jitFn, newLit 1, newLit 1, res, inputs, newLit 0, passStructByPointer = true)
 
 macro execCuda*(jitFn: CUfunction,
                 numBlocks, threadsPerBlock: int,
                 res: typed,
                 inputs: typed): untyped =
   ## Overload which takes a target number of threads and blocks
-  result = execCudaImpl(jitFn, numBlocks, threadsPerBlock, res, inputs, newLit 0, passStructByPointer = false)
+  result = execCudaImpl(jitFn, numBlocks, threadsPerBlock, res, inputs, newLit 0, passStructByPointer = true)
 
 macro execCuda*(jitFn: CUfunction,
                 numBlocks, threadsPerBlock: int,
@@ -355,9 +355,9 @@ macro execCuda*(jitFn: CUfunction,
                 inputs: typed,
                 sharedMemSize: typed): untyped =
   ## Overload which takes a target number of threads and blocks and a shared memory size
-  result = execCudaImpl(jitFn, numBlocks, threadsPerBlock, res, inputs, sharedMemSize, passStructByPointer = false)
+  result = execCudaImpl(jitFn, numBlocks, threadsPerBlock, res, inputs, sharedMemSize, passStructByPointer = true)
 
 macro execCuda*(jitFn: CUfunction,
                 res: typed): untyped =
   ## Overload of the above for empty `inputs`
-  result = execCudaImpl(jitFn, newLit 1, newLit 1, res, nnkBracket.newTree(), newLit 0, passStructByPointer = false)
+  result = execCudaImpl(jitFn, newLit 1, newLit 1, res, nnkBracket.newTree(), newLit 0, passStructByPointer = true)

--- a/constantine/math_compiler/experimental/nim_ast_to_cuda_ast.nim
+++ b/constantine/math_compiler/experimental/nim_ast_to_cuda_ast.nim
@@ -286,7 +286,11 @@ proc getTypeName(n: NimNode): string =
   ## Returns the name of the type
   case n.kind
   of nnkIdent, nnkSym: result = n.strVal
-  of nnkObjConstr:  result = n.getTypeInst.strVal
+  of nnkObjConstr:
+    if n[0].kind == nnkEmpty:
+      result = n.getTypeInst.strVal
+    else:
+      result = n[0].strVal # type is the first node
   else: raiseAssert "Unexpected node in `getTypeName`: " & $n.treerepr
 
 proc parseTypeFields(node: NimNode): seq[GpuTypeField]

--- a/constantine/math_compiler/experimental/nvrtc_field_ops.nim
+++ b/constantine/math_compiler/experimental/nvrtc_field_ops.nim
@@ -186,14 +186,15 @@ template defPtxHelpers*(): untyped {.dirty.} =
 """
     return res
 
+
 template defCoreFieldOps*(T: typed): untyped {.dirty.} =
   # Need to get the limbs & spare bits data in a static context
   template getM0ninv(): untyped = static: T.getModulus().negInvModWord().uint32
   template spareBits(): untyped = static: (BigInt().limbs.len * WordSize - T.bits())
+  template numLimbs(): untyped = static: BigInt().limbs.len
 
   ## TODO: avoid the explicit array size here
-  proc toBigInt(limbs: array[1, uint32]): BigInt {.nimonly.} =
-    result.limbs = limbs
+  template toBigInt(ar: typed): BigInt {.nimonly.} = BigInt(limbs: ar)
 
   const M = toBigInt(bigintToUint32Limbs(T.getModulus))
   const MontyOne = toBigInt(bigintToUint32Limbs(T.getMontyOne))

--- a/constantine/math_compiler/experimental/nvrtc_field_ops.nim
+++ b/constantine/math_compiler/experimental/nvrtc_field_ops.nim
@@ -101,7 +101,7 @@ template defPtxHelpers*(): untyped {.dirty.} =
 """
     return res
 
-  proc slct(a, b: uint32, pred: uint32): uint32 {.device, forceinline.} =
+  proc slct(a, b: uint32, pred: int32): uint32 {.device, forceinline.} =
     var res {.volatile.}: uint32
 # "slct.s32 %0, %1, %2, %3;" : "=r"(res) : "r"(a), "r"(b), "r"(pred)
     asm """

--- a/constantine/math_compiler/experimental/runtime_compile.nim
+++ b/constantine/math_compiler/experimental/runtime_compile.nim
@@ -192,7 +192,7 @@ proc load*(nvrtc: var NVRTC) =
   let status = cuModuleLoadData(nvrtc.module, cstring nvrtc.ptx)
   if status != CUDA_SUCCESS:
     var error_str: cstring #const char* error_str;
-    check cuGetErrorString(status, cast[cstringArray](addr error_str));
+    check cuGetErrorString(status, (error_str));
     echo "Module load failed: ", error_str
     echo "JIT Error log: ", error_log
     echo "JIT Info log: ", info_log
@@ -230,8 +230,7 @@ proc link*(nvrtc: var NVRTC) =
   var status: CUresult
   if res != CUDA_SUCCESS:
     var error_str: cstring
-    #discard cuGetErrorString(res, addr error_str)
-    check cuGetErrorString(status, cast[cstringArray](addr error_str))
+    check cuGetErrorString(status, error_str)
     echo "Link add PTX failed: ", error_str
     echo "Error log: ", errorLog
     quit(1)
@@ -243,7 +242,7 @@ proc link*(nvrtc: var NVRTC) =
                       0, nil, nil)
   if res != CUDA_SUCCESS:
     var error_str: cstring
-    check cuGetErrorString(status, cast[cstringArray](addr error_str));
+    check cuGetErrorString(status, error_str);
     echo "Link add device runtime failed: ", error_str
     echo "Error log: ", errorLog
     quit(1)
@@ -255,7 +254,7 @@ proc link*(nvrtc: var NVRTC) =
   nvrtc.cubinSize = cubinSize
   if res != CUDA_SUCCESS:
     var error_str: cstring
-    check cuGetErrorString(status, cast[cstringArray](addr error_str));
+    check cuGetErrorString(status, error_str);
     echo "Link complete failed: ", error_str
     echo "Error log: ", errorLog
     quit(1)

--- a/tests/gpu/t_nvrtc_misc_ops.nim
+++ b/tests/gpu/t_nvrtc_misc_ops.nim
@@ -59,7 +59,7 @@ const BigIntExample* = cuda:
     output[] = a
     output[].cSetOne(c)
 
-  proc testCsetZero(output: ptr BigInt, a, b: BigInt, c: uint32) {.global.} =
+  proc testCsetZero(output: ptr BigInt, a: BigInt, c: uint32) {.global.} =
     output[] = a
     output[].cSetZero(c.bool)
 
@@ -183,7 +183,7 @@ proc main =
     hOut[5] = 321
     var input: array[8, uint32]
     input = hOut
-    nvrtc.execute("testCsetZero", (hOut), (input, input, 0'u32))
+    nvrtc.execute("testCsetZero", (hOut), (input, 0'u32))
     let expF = [123'u32, 0, 0, 0, 0, 321, 0, 0]
     for i in 0 ..< 8:
       doAssert expF[i] == hOut[i]


### PR DESCRIPTION
Our previous approach of just a bare `distinct pointer` now leads to a mismatched pointer error on modern GCC / Clang.

Similarly for `cuGetErrorString` we now *need* a `const char**` argument and not just a `char **` argument...


Edit:

And a couple of other things I just noticed running some of the NVRTC tests locally:
- I hadn't ever committed the correct `slct` proc syntax (takes `int32` instead of `uint32`)
- fix a regression where we would generate duplicate device pointers if one passes in the same argument as an input twice
- avoids the need to hardcode the limb size in `defCoreFieldOps` 

Note: I still see test failures here that elude me at the moment. I'll need some time to debug them. Still, at least the code compiles and runs again, heh.