### PR TITLE
Nvidia: deactivate Edwards25519 on Nvidia backend for now

### DIFF
--- a/tests/gpu/t_nvidia_fp.nim
+++ b/tests/gpu/t_nvidia_fp.nim
@@ -94,7 +94,7 @@ proc main() =
     # P224,
     BN254_Nogami,
     BN254_Snarks,
-    Edwards25519,
+    # Edwards25519, # TODO - reactivate once Crandall accel is implemented on Nvidia #557
     Bandersnatch,
     Pallas,
     Vesta,

--- a/tests/math_fields/t_finite_fields_mulsquare.nim
+++ b/tests/math_fields/t_finite_fields_mulsquare.nim
@@ -216,6 +216,26 @@ suite "Random Modular Squaring is consistent with Modular Multiplication" & " ["
     for _ in 0 ..< Iters:
       random_long01Seq(Vesta)
 
+suite "Modular multiplication - bugs highlighted by property-based testing":
+    test "Edwards25519 - 32-bit Crandall prime acceleration":
+      block:
+        # Nvidia backend copied Crandall as-is without converting out of Montgomery domain.
+        var a, b: Fp[Edwards25519]
+        a.fromHex"0x007ffffff6825fff001ff67ff0a5fffffda0000000002567e00024d00000001f"
+        b.fromHex"0x7ffffffffecfc00000800097ffd200010088007fffffffffe007ffba97fed24d"
+
+        var r_mul, r_expected: Fp[Edwards25519]
+        r_expected.fromHex"0x271c295b1362f23fb414095b7c8385068685645b554289b99085b28cd43fd034"
+
+        r_mul.prod(a, b)
+
+        doAssert bool(r_mul == r_expected), block:
+          "\n" &
+          "a: " & a.toHex & "\n" &
+          "b: " & b.toHex & "\n" &
+          "result:   " & r_mul.toHex & "\n" &
+          "expected: " & r_expected.toHex & "\n"
+
 suite "Modular squaring - bugs highlighted by property-based testing":
   test "a² == (-a)² on for Fp[2^127 - 1] - #61":
     var a{.noInit.}: Fp[Mersenne127]
@@ -320,7 +340,6 @@ suite "Modular squaring - bugs highlighted by property-based testing":
     check:
       bool(a2mul == expected)
       bool(a2sqr == expected)
-
 
 proc random_sumprod(Name: static Algebra, N: static int) =
   template sumprod_test(random_instancer: untyped) =


### PR DESCRIPTION
Following #445, there are 2 representations used on CPU for field elements, either the canonical representation if a field has access to a fast reduction like for Mersenne or Pseudo-Mersenne/Crandall or Solinas primes or the Montgomery representation.

The Nvidia backend only supports Montgomery representation at the moment.

Inputs are memcpied into the GPU for computation assuming CPU and GPU representations are matching but they aren't.

Workarounding by checking if the inputs and output should be memcpied or not seems to be non-trivial work so for now we don't support Edwards25519 on Nvidia GPU while waiting got the Crandall acceleration introduced in #445, namely this file https://github.com/mratsim/constantine/blob/v0.2.0/constantine/math/arithmetic/limbs_crandall.nim to be ported to GPU.