### PR TITLE
LLVM: llvmFor has inclusive bounds

### DIFF
--- a/constantine/math_compiler/impl_fields_ops.nim
+++ b/constantine/math_compiler/impl_fields_ops.nim
@@ -422,10 +422,10 @@ proc nsqr*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a: ValueRef, count: int,
       rA[i] = aA[i]
 
     # `r` now stores `a`
-    for i in countdown(count, 1):
+    for i in countdown(count-1, 0):
       # `mtymul` does not touch `r` until the end to store the result. It uses a temporary
       # buffer internally. So we can just pass `r` 3 times!
-      let fR = i == 1 and not skipFinalSub # only reduce on last iteration
+      let fR = i == 0 and not skipFinalSub # only reduce on last iteration
       asy.mtymul(fd, ri, ri, ri, M, finalReduce = fR)
 
     asy.br.retVoid()

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -920,7 +920,8 @@ macro llvmFor*(asy: untyped, iter: untyped, start, stop, isCountup: typed, body:
     llvmForImpl(`asy`, `iter`, `label`, `start`, `stop`, `isCountup`, `body`)
 
 template llvmFor*(asy: untyped, iter: untyped, start, stop: typed, body: untyped): untyped {.dirty.} =
-  ## Start and stop must be Nim values
+  ## Start and stop must be Nim values.
+  ## Stop is included.
   block:
     let isCountup = start < stop
     asy.llvmFor iter, start, stop, isCountup:
@@ -928,12 +929,14 @@ template llvmFor*(asy: untyped, iter: untyped, start, stop: typed, body: untyped
 
 template llvmForCountup*(asy: untyped, iter: untyped, start, stop: typed, body: untyped): untyped  {.dirty.} =
   ## Start and stop can either be Nim or LLVM values
+  ## Stop is included.
   block:
     asy.llvmFor iter, start, stop, true:
       body
 
 template llvmForCountdown*(asy: untyped, iter: untyped, start, stop: typed, body: untyped): untyped  {.dirty.} =
   ## Start and stop can either be Nim or LLVM values
+  ## Stop is included.
   block:
     asy.llvmFor iter, start, stop, false:
       body

--- a/constantine/math_compiler/pub_fields.nim
+++ b/constantine/math_compiler/pub_fields.nim
@@ -311,7 +311,7 @@ template genCountdownLoop(asy: Assembler_LLVM, fn, initialValue: ValueRef, body:
   # Loop exit
   asy.br.positionAtEnd(loopExit)
 
-proc genFpNsqrRT*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
+proc genFpNsqrRt*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
   ## Generate a public field n-square proc
   ## with signature
   ##   `void name(FieldType r, FieldType a, count int)`
@@ -330,7 +330,7 @@ proc genFpNsqrRT*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
     for i in 0 ..< fd.numWords:
       rA[i] = aA[i]
 
-    asy.llvmForCountdown i, count, 0: # countdown from count to 0
+    asy.llvmForCountdown i, count, 1: # countdown from count to 1 (included)
       # use `mtymul` to multiply `r·r` and store it again in `r`
       asy.mtymul(fd, r, r, r, M)
 

--- a/tests/gpu/t_nsqr.nim
+++ b/tests/gpu/t_nsqr.nim
@@ -31,7 +31,7 @@ proc testName[Name: static Algebra](field: type FF[Name], wordSize: int, a: FF[N
     var rCPU: field
     rCPU = a
 
-    for i in countdown(count, 1):
+    for _ in 0 ..< count:
       rCPU = rCPU * rCPU
 
     # For GPU:
@@ -43,6 +43,7 @@ proc testName[Name: static Algebra](field: type FF[Name], wordSize: int, a: FF[N
     doAssert bool(rCPU == rGPU)
 
 let a = Fp[BN254_Snarks].fromHex("0x12345678FF11FFAA00321321CAFECAFE")
+echo "a: ", a.toHex()
 
 testName(Fp[BN254_Snarks], 32, a, 2)
 testName(Fp[BN254_Snarks], 32, a, 3)

--- a/tests/gpu/t_nsqr_rt.nim
+++ b/tests/gpu/t_nsqr_rt.nim
@@ -26,7 +26,7 @@ proc testName[Name: static Algebra](field: type FF[Name], wordSize: int, a: FF[N
     var rCPU: field
     rCPU = a
 
-    for i in countdown(count, 1):
+    for _ in 0 ..< count:
       rCPU = rCPU * rCPU
 
     # For GPU:
@@ -38,6 +38,7 @@ proc testName[Name: static Algebra](field: type FF[Name], wordSize: int, a: FF[N
     doAssert bool(rCPU == rGPU)
 
 let a = Fp[BN254_Snarks].fromHex("0x12345678FF11FFAA00321321CAFECAFE")
+echo "a: ", a.toHex()
 
 testName(Fp[BN254_Snarks], 32, a, 2)
 testName(Fp[BN254_Snarks], 32, a, 3)


### PR DESCRIPTION
This fix the other part of #557.

It seems like #466 is using inclusive bounds for the LLVM for loop, which are quite error prone and avoided in Constantine (for example in the `staticFor` macro)