### PR TITLE
nvrtc: fix cuda v2 overloads and var pointers

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -986,6 +986,9 @@ task test_nvidia, "Run all tests for Nvidia GPUs":
   cmdFile.addTestSetNvidia()
   for cmd in cmdFile.splitLines():
     if cmd != "": # Windows doesn't like empty commands
+      echo "\n=============================================================================================="
+      echo "Running '", cmd, "'"
+      echo "=============================================================================================="
       exec cmd
 
 # BigInt benchmark

--- a/constantine/math_compiler/experimental/nim_ast_to_cuda_ast.nim
+++ b/constantine/math_compiler/experimental/nim_ast_to_cuda_ast.nim
@@ -1114,13 +1114,10 @@ macro cuda*(body: typed): string =
   ## - most regular Nim features :)
   var ctx = GpuContext()
   let gpuAst = ctx.toGpuAst(body)
-  ## NOTE: `header` is currently unused. Not sure yet if we'll ever need it.
-  let header = """
-// #include "foo.h"
-"""
-
+  # NOTE: it doesn't seem like it's possible to add a header to a NVRTC kernel.
+  # NVRTC safe stdlib is implemented at https://github.com/NVIDIA/jitify
   let body = ctx.genCuda(gpuAst)
-  result = newLit(header & body)
+  result = newLit(body)
 
 when isMainModule:
   # Mini example

--- a/constantine/math_compiler/experimental/runtime_compile.nim
+++ b/constantine/math_compiler/experimental/runtime_compile.nim
@@ -108,15 +108,15 @@ proc initNvrtc*(cuda: string, name = "sample.cu"): NVRTC =
   ## Initializes an NVRTC object for the given program `cuda`
   when DebugCuda:
     var x: cint
-    check cuDriverGetVersion(x.addr)
+    check cuDriverGetVersion(x)
     echo "Driver version: ", x
 
     var rtVer: cint
-    echo cudaRuntimeGetVersion(addr rtVer)
+    echo cudaRuntimeGetVersion(rtVer)
     echo "Runtime ver: ", rtVer
 
     var prop: cudaDeviceProp
-    echo cudaGetDeviceProperties(addr prop, 0);
+    echo cudaGetDeviceProperties(prop, 0);
     echo "Compute capability: ", prop.major, " ", prop.minor
 
   var
@@ -129,7 +129,7 @@ proc initNvrtc*(cuda: string, name = "sample.cu"): NVRTC =
 
   # Create an instance of nvrtcProgram based on the passed code
   var prog: nvrtcProgram
-  check nvrtcCreateProgram(addr(prog), cstring cuda, cstring name, 0, nil, nil)
+  check nvrtcCreateProgram(prog, cstring cuda, cstring name, 0, nil, nil)
 
   result = NVRTC(prog: prog, name: name,
                  device: device,
@@ -139,7 +139,7 @@ proc initNvrtc*(cuda: string, name = "sample.cu"): NVRTC =
 proc log*(nvrtc: var NVRTC) =
   ## Retrieve the compilation log.
   var logSize: csize_t
-  check nvrtcGetProgramLogSize(nvrtc.prog, addr logSize)
+  check nvrtcGetProgramLogSize(nvrtc.prog, logSize)
 
   var log = cstring newString(Natural logSize)
 
@@ -151,7 +151,7 @@ proc compile*(nvrtc: var NVRTC) =
   # Note: Can specify GPU target architecture explicitly with '-arch' flag.
   const
     Options = [
-      cstring "--gpu-architecture=compute_61", # or whatever your GPU arch is
+      cstring "--gpu-architecture=compute_75", # or whatever your GPU arch is
       # "--fmad=false", # and whatever other options for example
     ]
 
@@ -169,12 +169,12 @@ proc compile*(nvrtc: var NVRTC) =
 proc getPtx*(nvrtc: var NVRTC) =
   ## Obtain PTX from the program.
   var ptxSize: csize_t
-  check nvrtcGetPTXSize(nvrtc.prog, addr ptxSize)
+  check nvrtcGetPTXSize(nvrtc.prog, ptxSize)
 
   var ptx = newString(int ptxSize)
   check nvrtcGetPTX(nvrtc.prog, ptx)
 
-  check nvrtcDestroyProgram(addr nvrtc.prog) # Destroy the program.
+  check nvrtcDestroyProgram(nvrtc.prog) # Destroy the program.
   nvrtc.ptx = ptx
 
   when DebugCuda:

--- a/constantine/platforms/abis/nvidia_abi.nim
+++ b/constantine/platforms/abis/nvidia_abi.nim
@@ -825,7 +825,8 @@ type                          ##
                            ##
     CU_JIT_INPUT_NVVM = 5, CU_JIT_NUM_INPUT_TYPES = 6
 
-
+{.pragma: v1, noconv, importc, dynlib: libCuda.}
+{.pragma: v2, noconv, importc: "$1_v2", dynlib: libCuda.}
 
 {.push noconv, importc, dynlib: libCuda.}
 
@@ -836,9 +837,14 @@ proc cuDeviceGet*(device: var CUdevice, ordinal: int32): CUresult
 proc cuDeviceGetName*(name: ptr char, len: int32, dev: CUdevice): CUresult
 proc cuDeviceGetAttribute*(r: var int32, attrib: CUdevice_attribute, dev: CUdevice): CUresult
 
-proc cuCtxCreate*(pctx: var CUcontext, flags: uint32, dev: CUdevice): CUresult {.importc: "cuCtxCreate_v2".}
+{.pop.}
+
+proc cuCtxCreate*(pctx: var CUcontext, flags: uint32, dev: CUdevice): CUresult {.v2.}
+proc cuCtxSynchronize*(ctx: CUcontext): CUresult {.v2.}
+
+{.push noconv, importc, dynlib: libCuda.}
+
 proc cuCtxDestroy*(ctx: CUcontext): CUresult
-proc cuCtxSynchronize*(ctx: CUcontext): CUresult {.importc: "cuCtxSynchronize_v2".}
 proc cuCtxSynchronize*(): CUresult
 proc cuCtxGetCurrent*(ctx: var CUcontext): CUresult
 proc cuCtxSetCurrent*(ctx: CUcontext): CUresult
@@ -865,31 +871,27 @@ proc cuLaunchKernel*(
        extra: ptr pointer
      ): CUresult {.used.}
 
-proc cuMemAlloc*(devptr: var CUdeviceptr, size: csize_t): CUresult
-proc cuMemAllocManaged*(devptr: var CUdeviceptr, size: csize_t, flags: Flag[CUmemAttach_flags]): CUresult
-proc cuMemFree*(devptr: CUdeviceptr): CUresult
-proc cuMemcpyHtoD*(dst: CUdeviceptr, src: pointer, size: csize_t): CUresult
-proc cuMemcpyDtoH*(dst: pointer, src: CUdeviceptr, size: csize_t): CUresult
+{.pop.} # {.push noconv, importc, dynlib: "libcuda.so"..}
 
-proc cuDriverGetVersion*(driverVersion: var cint): CUresult
+proc cuMemAlloc*(devptr: var CUdeviceptr, size: csize_t): CUresult {.v2.}
+proc cuMemAllocManaged*(devptr: var CUdeviceptr, size: csize_t, flags: Flag[CUmemAttach_flags]): CUresult {.v1.}
+proc cuMemFree*(devptr: CUdeviceptr): CUresult {.v2.}
+proc cuMemcpyHtoD*(dst: CUdeviceptr, src: pointer, size: csize_t): CUresult {.v2.}
+proc cuMemcpyDtoH*(dst: pointer, src: CUdeviceptr, size: csize_t): CUresult {.v2.}
+
+proc cuDriverGetVersion*(driverVersion: var cint): CUresult {.v1.}
 
 proc cuLinkCreate*(numOptions: cuint; options: ptr CUjit_option;
-                   optionValues: ptr pointer; stateOut: ptr CUlinkState): CUresult
+                   optionValues: ptr pointer; stateOut: ptr CUlinkState): CUresult {.v2.}
 proc cuLinkAddData*(state: CUlinkState; `type`: CUjitInputType; data: pointer;
                    size: csize_t; name: cstring; numOptions: cuint;
-                   options: ptr CUjit_option; optionValues: ptr pointer): CUresult
-proc cuLinkComplete*(state: CUlinkState; cubinOut: ptr pointer; sizeOut: ptr csize_t): CUresult
-
-
-proc cuGetErrorString*(error: CUresult; pStr: ptr constChar): CUresult
+                   options: ptr CUjit_option; optionValues: ptr pointer): CUresult {.v2.}
+proc cuLinkComplete*(state: CUlinkState; cubinOut: ptr pointer; sizeOut: ptr csize_t): CUresult {.v1.}
 proc cuLinkAddFile*(state: CUlinkState; `type`: CUjitInputType; path: cstring;
                     numOptions: cuint; options: ptr CUjit_option;
-                    optionValues: ptr pointer): CUresult
+                    optionValues: ptr pointer): CUresult {.v2.}
 
-
-
-
-{.pop.} # {.push noconv, importc, dynlib: "libcuda.so"..}
+proc cuGetErrorString*(error: CUresult; pStr: ptr constChar): CUresult {.v1.}
 
 proc cuGetErrorString*(error: CUresult; pStr: var cstring): CUresult =
   cuGetErrorString(error, cast[ptr constChar](pStr.addr))
@@ -926,24 +928,24 @@ type
     NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID = 10, NVRTC_ERROR_INTERNAL_ERROR = 11,
     NVRTC_ERROR_TIME_FILE_WRITE_FAILED = 12
 
-proc nvrtcCreateProgram*(prog: ptr nvrtcProgram; src: cstring; name: cstring;
+proc nvrtcCreateProgram*(prog: var nvrtcProgram; src: cstring; name: cstring;
                         numHeaders: cint; headers: cstringArray;
                         includeNames: cstringArray): nvrtcResult {.discardable, cdecl,
     importc: "nvrtcCreateProgram", dynlib: libNvrtc.}
 
-proc nvrtcDestroyProgram*(prog: ptr nvrtcProgram): nvrtcResult {.discardable, cdecl,
+proc nvrtcDestroyProgram*(prog: var nvrtcProgram): nvrtcResult {.discardable, cdecl,
     importc: "nvrtcDestroyProgram", dynlib: libNvrtc.}
 
 proc nvrtcCompileProgram*(prog: nvrtcProgram; numOptions: cint; options: cstringArray): nvrtcResult {.discardable,
     cdecl, importc: "nvrtcCompileProgram", dynlib: libNvrtc.}
 
-proc nvrtcGetPTXSize*(prog: nvrtcProgram; ptxSizeRet: ptr csize_t): nvrtcResult {.discardable,
+proc nvrtcGetPTXSize*(prog: nvrtcProgram; ptxSizeRet: var csize_t): nvrtcResult {.discardable,
     cdecl, importc: "nvrtcGetPTXSize", dynlib: libNvrtc.}
 
 proc nvrtcGetPTX*(prog: nvrtcProgram; ptx: cstring): nvrtcResult {.discardable, cdecl,
     importc: "nvrtcGetPTX", dynlib: libNvrtc.}
 
-proc nvrtcGetProgramLogSize*(prog: nvrtcProgram; logSizeRet: ptr csize_t): nvrtcResult {.discardable,
+proc nvrtcGetProgramLogSize*(prog: nvrtcProgram; logSizeRet: var csize_t): nvrtcResult {.discardable,
     cdecl, importc: "nvrtcGetProgramLogSize", dynlib: libNvrtc.}
 
 proc nvrtcGetProgramLog*(prog: nvrtcProgram; log: cstring): nvrtcResult {.discardable, cdecl,
@@ -1833,7 +1835,7 @@ type
 proc cudaRuntimeGetVersion*(runtimeVersion: var cint): cudaError_t {.cdecl,
     importc: "cudaRuntimeGetVersion", dynlib: libCudaRT.}
 
-proc cudaGetDeviceProperties*(prop: ptr cudaDeviceProp; device: cint): cudaError_t {.
+proc cudaGetDeviceProperties*(prop: var cudaDeviceProp; device: cint): cudaError_t {.
     cdecl, importc: "cudaGetDeviceProperties", dynlib: libCudaRT.}
 
 ######################################################################

--- a/tests/gpu/t_nvrtc_bigint_example.nim
+++ b/tests/gpu/t_nvrtc_bigint_example.nim
@@ -205,7 +205,7 @@ proc getBigints(): (Fp[BN254_Snarks], Fp[BN254_Snarks]) =
 proc main =
   var nvrtc = initNvrtc(BigIntExample)
   # echo the generated CUDA code
-  echo BigIntExample
+  # echo BigIntExample
 
   nvrtc.compile()
   nvrtc.getPtx()

--- a/tests/gpu/t_nvrtc_inbuilt_modadd.nim
+++ b/tests/gpu/t_nvrtc_inbuilt_modadd.nim
@@ -106,7 +106,7 @@ template checkOp(kernel, exp, hOut, a, b: untyped): untyped =
 proc main =
   var nvrtc = initNvrtc(BigIntExample)
   # echo the generated CUDA code
-  echo BigIntExample
+  # echo BigIntExample
 
   nvrtc.compile()
   nvrtc.getPtx()

--- a/tests/gpu/t_nvrtc_misc_ops.nim
+++ b/tests/gpu/t_nvrtc_misc_ops.nim
@@ -101,7 +101,7 @@ from std / sequtils import mapIt
 proc main =
   var nvrtc = initNvrtc(BigIntExample)
   # echo the generated CUDA code
-  echo BigIntExample
+  # echo BigIntExample
   writeFile("/tmp/kernel.cu", BigIntExample)
 
   nvrtc.compile()

--- a/tests/gpu/t_nvrtc_pass_pointer.nim
+++ b/tests/gpu/t_nvrtc_pass_pointer.nim
@@ -39,7 +39,7 @@ const BigIntExample* = cuda:
 proc main =
   var nvrtc = initNvrtc(BigIntExample)
   # echo the generated CUDA code
-  echo BigIntExample
+  # echo BigIntExample
 
   nvrtc.compile()
   nvrtc.getPtx()

--- a/tests/gpu/t_nvrtc_pass_var.nim
+++ b/tests/gpu/t_nvrtc_pass_var.nim
@@ -39,7 +39,7 @@ const BigIntExample* = cuda:
 proc main =
   var nvrtc = initNvrtc(BigIntExample)
   # echo the generated CUDA code
-  echo BigIntExample
+  # echo BigIntExample
 
   nvrtc.compile()
   nvrtc.getPtx()


### PR DESCRIPTION
This PR:

- uses `var` params instead of `ptr` param for NVRTC related mutations (followup from #558)
- fixes #558, `{.push importc.}` and `{.importc: "name_v2".}` conflicts and unfortunately the push is not overridden hence #558 wasn't applied.