### PR TITLE
WebGPU GPU compiler backend improvements (and small CUDA)

### DIFF
--- a/constantine/math_compiler/experimental/backends/backends.nim
+++ b/constantine/math_compiler/experimental/backends/backends.nim
@@ -34,7 +34,8 @@ proc genFunctionType*(typ: GpuType, fn: string, fnArgs: string): string =
 proc codegen*(ctx: var GpuContext, ast: GpuAst, kernel: string = ""): string =
   case Backend
   of bkCuda:
-    result = ctx.genCuda(ast)
+    ctx.preprocess(ast, kernel)
+    result = cuda.codegen(ctx)
   of bkWGSL:
     ctx.storagePass(ast, kernel)
     result = wgsl.codegen(ctx)

--- a/constantine/math_compiler/experimental/backends/common_utils.nim
+++ b/constantine/math_compiler/experimental/backends/common_utils.nim
@@ -6,9 +6,36 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+import std / tables
 import ../gpu_types
-# import ./backends
 
 proc address*(a: string): string = "&" & a
-
 proc size*(a: string): string = "sizeof(" & a & ")"
+
+proc isGlobal*(fn: GpuAst): bool =
+  doAssert fn.kind == gpuProc, "Not a function, but: " & $fn.kind
+  result = attGlobal in fn.pAttributes
+
+proc farmTopLevel*(ctx: var GpuContext, ast: GpuAst, kernel: string, varBlock, typBlock: var GpuAst) =
+  ## Farms the top level of the code for functions, variable and type definition.
+  ## All functions are added to the `allFnTab`, while only global ones (or even only
+  ## `kernel` if any) is added to the `fnTab` as the starting point for the remaining
+  ## logic.
+  ## Variables and types are collected in `varBlock` and `typBlock`.
+  case ast.kind
+  of gpuProc:
+    ctx.allFnTab[ast.pName] = ast
+    if kernel.len > 0 and ast.pName.ident() == kernel and ast.isGlobal():
+      ctx.fnTab[ast.pName] = ast.clone() # store global function extra
+    elif kernel.len == 0 and ast.isGlobal():
+      ctx.fnTab[ast.pName] = ast.clone() # store global function extra
+  of gpuBlock:
+    # could be a type definition or global variable
+    for ch in ast:
+      ctx.farmTopLevel(ch, kernel, varBlock, typBlock)
+  of gpuVar, gpuConstexpr:
+    varBlock.statements.add ast
+  of gpuTypeDef, gpuAlias:
+    typBlock.statements.add ast
+  else:
+    discard

--- a/constantine/math_compiler/experimental/backends/cuda.nim
+++ b/constantine/math_compiler/experimental/backends/cuda.nim
@@ -43,6 +43,7 @@ proc gpuTypeToString*(t: GpuTypeKind): string =
   of gtVoidPtr: "void*"
   of gtObject: "struct"
   of gtString: "const char*"
+  of gtUA: "" # `UncheckedArray` by itself is nothing in CUDA
   else:
     raiseAssert "Invalid type : " & $t
 

--- a/constantine/math_compiler/experimental/backends/cuda.nim
+++ b/constantine/math_compiler/experimental/backends/cuda.nim
@@ -256,7 +256,7 @@ proc genCuda*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
     result = ast.pOp & ctx.genCuda(ast.pVal)
 
   of gpuTypeDef:
-    result = "struct " & ast.tName & "{\n"
+    result = "struct " & gpuTypeToString(ast.tTyp) & "{\n"
     for el in ast.tFields:
       result.add "  " & gpuTypeToString(el.typ, el.name) & ";\n"
     result.add "}"

--- a/constantine/math_compiler/experimental/backends/cuda.nim
+++ b/constantine/math_compiler/experimental/backends/cuda.nim
@@ -58,6 +58,10 @@ proc gpuTypeToString*(t: GpuType, ident: string = "", allowArrayToPtr = false,
   var skipIdent = false
   case t.kind
   of gtPtr:
+    var t = t # if `ptr UncheckedArray`, remove the `gtUA` layer. No meaning on CUDA
+    if t.to.kind == gtUA:
+      t.to = t.to.uaTo
+
     if t.to.kind == gtArray: # ptr to array type
       # need to pass `*` for the pointer into the identifier, i.e.
       # `state: var array[4, BigInt]`

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -112,6 +112,14 @@ proc gpuTypeToString*(t: GpuType, id: GpuAst = newGpuIdent(), allowArrayToPtr = 
     else:
       result = &"{identPrefix}array<{typ}, {t.aLen}>"
     skipIdent = true
+  of gtGenericInst:
+    # NOTE: WGSL does not support actual custom generic types. And as we only anyway deal with generic instantiations
+    # we simply turn e.g. `foo[float32, uint32]` into `foo_f32_u32`.
+    result = t.gName & "_"
+    for i, g in t.gArgs:
+      result.add gpuTypeToString(g)
+      if i < t.gArgs.high:
+        result.add "_"
   of gtObject: result = t.name
   of gtUA:     result = gpuTypeToString(t.kind) & "<" & gpuTypeToString(t.uaTo, allowEmptyIdent = allowEmptyIdent) & ">"
   else:        result = gpuTypeToString(t.kind)

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -751,6 +751,10 @@ proc storagePass*(ctx: var GpuContext, ast: GpuAst, kernel: string = "") =
   ctx.globalBlocks.add varBlock
   ctx.globalBlocks.add typBlock
 
+  # Now add the generics to the `allFnTab`
+  for k, v in pairs(ctx.genericInsts):
+    ctx.allFnTab[k] = v
+
   # 2. Remove all arguments from global functions, as none are allowed in WGSL
   for (fnIdent, fn) in mpairs(ctx.fnTab): # mutating the function in the table
     if (fn.isGlobal() and kernel.len > 0 and fn.pName.ident() == kernel) or

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -813,7 +813,7 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
     if $attGlobal in attrs:
       doAssert fnArgs.len == 0, "Global function `" & $ast.pName.ident() & "` still has arguments!"
       ## XXX: make this more flexible. In theory can be any name
-      fnArgs = "@builtin(global_invocation_id) global_id: vec3<u32>"
+      fnArgs = "@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>"
     let fnSig = genFunctionType(ast.pRetType, ast.pName.ident(), fnArgs)
 
     result = indentStr & "fn " & fnSig & " {\n"

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -552,26 +552,17 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   case ast.kind
   of gpuVoid: return # nothing to emit
   of gpuProc:
-
-    ## XXX: if a {.global.} / attGlobal proc, lift arguments
-    ## Store all arguments in the `GpuContext`
-    ## *AFTER* processing all of the code, generate header and place at beginning
-    ## Most difficult:
-    ## - track identifiers from {.global.} functions into arbitrary layers and remove
-    ## BUT, we can also have a full preprocessing pass.
-
     let attrs = collect:
       for att in ast.pAttributes:
         $att
 
-    # Parameters
     var params: seq[string]
     for p in ast.pParams:
       params.add gpuTypeToString(p.typ, p.ident, allowEmptyIdent = false)
     var fnArgs = params.join(", ")
     if $attGlobal in attrs:
       doAssert fnArgs.len == 0, "Global function `" & $ast.pName.ident() & "` still has arguments!"
-      ## XXX: clean this up. Add the global id builtin
+      ## XXX: make this more flexible. In theory can be any name
       fnArgs = "@builtin(global_invocation_id) global_id: vec3<u32>"
     let fnSig = genFunctionType(ast.pRetType, ast.pName.ident(), fnArgs)
 

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -513,7 +513,8 @@ proc rewriteCompoundAssignment(n: GpuAst): GpuAst =
 proc getStructType(n: GpuAst): GpuType =
   ## Given an identifier `gpuIdent` (or `Deref` of one), return the struct type
   ## the ident is of or a GpuType of `void` if it is not (pointing to) a struct.
-  doAssert n.kind in [gpuIdent, gpuDeref], "Dot expression of anything not an address currently not supported: " & $n.kind
+  doAssert n.kind in [gpuIdent, gpuDeref], "Dot expression of anything not an address currently not supported: " &
+    $n.kind & " for node: " & $n
   var p = n
   if p.kind == gpuDeref:
     p = n.dOf

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -205,6 +205,7 @@ proc determineSymKind(arg: GpuAst): GpuSymbolKind =
   of gpuBlock: arg.statements[^1].determineSymKind() # look at last element
   of gpuPrefix: gsLocal # equivalent to constructing a local var
   of gpuConv: gsLocal # a converted value will be a local var
+  of gpuCast: arg.cExpr.determineSymKind() # symbol kind of the thing we cast
   else:
     raiseAssert "Not implemented to determine symbol kind from node: " & $arg
 
@@ -225,6 +226,7 @@ proc determineMutability(arg: GpuAst): bool =
   of gpuBlock: arg.statements[^1].determineMutability() # look at last element
   of gpuPrefix: false # equivalent to constructing a local var
   of gpuConv: false # a converted value will be immutable
+  of gpuCast: arg.cExpr.determineMutability() # mutability of the thing we cast
   else:
     raiseAssert "Not implemented to determine mutability from node: " & $arg
 
@@ -250,8 +252,9 @@ proc determineIdent(arg: GpuAst): GpuAst =
   of gpuBlock: arg.statements[^1].determineIdent()
   of gpuPrefix: dfl()
   of gpuConv: dfl()
+  of gpuCast: arg.cExpr.determineIdent() # ident of the thing we cast
   else:
-    raiseAssert "Not implemented to determine mutability from node: " & $arg
+    raiseAssert "Not implemented to determine ident from node: " & $arg
 
 proc getGenericArguments(args: seq[GpuAst], params: seq[GpuParam], callerParams: Table[string, GpuParam]): seq[GenericArg] =
   ## If an argument is not a ptr argument in the original function (`params`) then

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -56,7 +56,7 @@ proc fromAddressSpace(addrSpace: AddressSpace): GpuSymbolKind =
 proc constructPtrSignature(addrSpace: AddressSpace, idTyp: GpuType, ptrStr, typStr: string): string =
   ## Constructs the `ptr<addressSpace, typStr, [read / read_write]>` string, which only includes
   ## the RW string if the address space is `storage`
-  let rw = if not idTyp.isNil: idTyp.mutable else: false # symbol is a pointer -> mutable (can be implicit via `var T`)
+  let rw = if idTyp.kind != gtVoid: idTyp.mutable else: false # symbol is a pointer -> mutable (can be implicit via `var T`)
   let rwStr = if rw: "read_write" else: "read"
   case addrSpace
   of asStorage: result = &"{ptrStr}<{addrSpace}, {typStr}, {rwStr}>"

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -637,8 +637,8 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
         of gpuConv: dfl()
         else:
           raiseAssert "Not implemented to determine mutability from node: " & $arg
-      let leftTyp = ast.aLeft.determineIdent().iTyp
-      if leftTyp.kind == gtPtr and leftTyp.to.kind == gtInt32:
+      let leftId = ast.aLeft.determineIdent()
+      if leftId.kind != gpuVoid and leftId.iTyp.kind == gtPtr and leftId.iTyp.to.kind == gtInt32:
         # If the LHS is `i32` then a conversion to `i32` is either a no-op, if the left always was
         # `i32` (and the Nim compiler type checked it for us) *OR* the RHS is a boolean expression and
         # we patched the `bool -> i32` and thus need to convert it.

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -764,7 +764,12 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   of gpuObjConstr:
     result = ast.ocName & "("
     for i, el in ast.ocFields:
-      result.add ctx.genWebGpu(el.value)
+      if el.value.kind == gpuLit and el.value.lValue == "DEFAULT":
+        # use type to construct a default value
+        let typStr = gpuTypeToString(el.typ, allowEmptyIdent = true)
+        result.add typStr & "()"
+      else:
+        result.add ctx.genWebGpu(el.value)
       if i < ast.ocFields.len - 1:
         result.add ", "
     result.add ")"

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -542,6 +542,31 @@ proc storagePass*(ctx: var GpuContext, ast: GpuAst, kernel: string = "") =
       ctx.injectAddressOf(fn)
 
 
+  proc rewriteCompoundAssignment(n: GpuAst): GpuAst =
+    doAssert n.kind == gpuBinOp
+
+    template genAssign(left, rnode, op: typed): untyped =
+      let right = GpuAst(kind: gpuBinOp, bOp: op, bLeft: left, bRight: rnode)
+      GpuAst(kind: gpuAssign, aLeft: left, aRight: right, aRequiresMemcpy: false)
+
+    let op = n.bOp
+    if op.len >= 2 and op[^1] == '=':
+      result = genAssign(n.bLeft, n.bRight, op[0 .. ^2]) # all but last
+    else:
+      # leave untouched
+      result = n
+
+  proc makeCodeValid(ctx: var GpuContext, n: var GpuAst) =
+    case n.kind
+    of gpuBinOp: n = rewriteCompoundAssignment(n)
+    else:
+      for ch in mitems(n):
+        ctx.makeCodeValid(ch)
+  # 5. (Actually finally) patch all additional things invalid in WGSL, e.g. `x += 5` -> `x = x + 5`
+  for (fnIdent, fn) in mpairs(ctx.fnTab):
+    ctx.makeCodeValid(fn)
+
+
 proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string
 proc size(ctx: var GpuContext, a: GpuAst): string = size(ctx.genWebGpu(a))
 proc address(ctx: var GpuContext, a: GpuAst): string = address(ctx.genWebGpu(a))

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -825,5 +825,5 @@ proc codegen*(ctx: var GpuContext): string =
   for fnIdent, fn in ctx.fnTab:
     if fn.isGlobal():
       ## XXX: make adjustable!
-      result.add "@compute @workgroup_size(NUM_WORKGROUPS)\n"
+      result.add "@compute @workgroup_size(WORKGROUP_SIZE)\n"
     result.add ctx.genWebGpu(fn) & "\n\n"

--- a/constantine/math_compiler/experimental/cuda_execute_dsl.nim
+++ b/constantine/math_compiler/experimental/cuda_execute_dsl.nim
@@ -62,6 +62,12 @@ proc requiresCopy(n: NimNode, passStructByPointer: bool): bool =
       result = false
     else:
       result = true
+  of ntyAlias:
+    let impl = n.getTypeInst()
+    if impl.kind in [nnkIdent, nnkSym] and impl.strVal.normalize == "cudeviceptr":
+      result = false
+    else:
+      result = true
   else:
     result = true
 

--- a/constantine/math_compiler/experimental/cuda_execute_dsl.nim
+++ b/constantine/math_compiler/experimental/cuda_execute_dsl.nim
@@ -41,13 +41,15 @@ proc requiresCopy(n: NimNode, passStructByPointer: bool): bool =
   case n.typeKind
   of ntyBool, ntyChar, ntyInt .. ntyUint64: # range includes all floats
     result = false
-  of ntyObject, ntyArray:
+  of ntyObject:
     if passStructByPointer:
       result = false # regular objects can just be copied!
     else:
       result = true # struct passing by pointer forbidden
     ## NOTE: strictly speaking this is not the case of course! If the object
     ## contains refs, it won't hold!
+  of ntyArray: # statically sized arrays are passed by pointer in CUDA / C++ / C!
+    result = true
   of ntyGenericInst:
     if passStructByPointer:
       let impl = n.getTypeImpl()

--- a/constantine/math_compiler/experimental/gpu_compiler.nim
+++ b/constantine/math_compiler/experimental/gpu_compiler.nim
@@ -102,8 +102,9 @@ macro toGpuAst*(body: typed): (GpuGenericsInfo, GpuAst) =
   ## - most regular Nim features :)
   var ctx = GpuContext()
   let ast = ctx.toGpuAst(body)
-  let gen = toSeq(ctx.genericInsts.values)
-  let g = GpuGenericsInfo(data: gen)
+  let genProcs = toSeq(ctx.genericInsts.values)
+  let genTypes = toSeq(ctx.types.values)
+  let g = GpuGenericsInfo(procs: genProcs, types: genTypes)
   newLit((g, ast))
 
 macro cuda*(body: typed): string =
@@ -124,8 +125,10 @@ proc codegen*(gen: GpuGenericsInfo, ast: GpuAst, kernel: string = ""): string =
   ## Generates the code based on the given AST (optionally at runtime) and restricts
   ## it to a single global kernel (WebGPU) if any given.
   var ctx = GpuContext()
-  for fn in gen.data: # assign generics info to correct table
+  for fn in gen.procs: # assign generics info to correct table
     ctx.genericInsts[fn.pName] = fn
+  for typ in gen.types: # assign generics info to correct table
+    ctx.types[typ.tTyp] = typ
   result = ctx.codegen(ast, kernel)
 
 

--- a/constantine/math_compiler/experimental/gpu_compiler.nim
+++ b/constantine/math_compiler/experimental/gpu_compiler.nim
@@ -70,6 +70,7 @@ let threadIdx* {.builtin.} = NvThreadIdx()
 
 ## WebGPU specific
 let global_id* {.builtin.} = WgslGridDim()
+let num_workgroups* {.builtin.} = WgslGridDim()
 
 ## Similar for procs. They don't need any implementation, as they won't ever be actually called.
 proc printf*(fmt: string) {.varargs, builtin.} = discard

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -246,6 +246,10 @@ type
     #                        ## when we finish, we pop. Before we pop, we assign the variable definitions to the `gpuBlock`
     #                        ## `locals`
     genSymCount*: int ## increases for every generated identifier (currently only underscore `_`), hence the basic solution
+    ## Maps a struct type and field name, which is of pointer type to the value the user assigns
+    ## in the constructor. Allows us to later replace `foo.ptrField` by the assignment in the `Foo()`
+    ## constructor (WebGPU only).
+    structsWithPtrs*: Table[(string, string), GpuAst]
 
   GenericArg* = object
     addrSpace*: AddressSpace ## We store the address space, because that's what matters

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -250,6 +250,20 @@ type
     ## in the constructor. Allows us to later replace `foo.ptrField` by the assignment in the `Foo()`
     ## constructor (WebGPU only).
     structsWithPtrs*: Table[(string, string), GpuAst]
+    ## Set of all generic proc names we have encountered in Nim -> GpuAst. When
+    ## we see an `nnkCall` we check if we call a generic function. If so, look up
+    ## the instantiated generic, parse it and store in `genericInsts` below.
+    generics*: HashSet[string]
+
+    ## Stores the unique identifiers (keys) and the implementations of the
+    ## precise generic instantiations that are called.
+    genericInsts*: OrderedTable[GpuAst, GpuAst]
+
+  ## We rely on being able to compute a `newLit` from the result of `toGpuAst`. Currently we
+  ## only need the `genericInsts` field data (the values). Trying to `newLit` the full `GpuContext`
+  ## causes trouble.
+  GpuGenericsInfo* = object
+    data*: seq[GpuAst]
 
   GenericArg* = object
     addrSpace*: AddressSpace ## We store the address space, because that's what matters

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -703,6 +703,19 @@ iterator mitems*(ast: var GpuAst): var GpuAst =
 iterator items*(ast: GpuAst): GpuAst =
   iterImpl(ast, mutable = false)
 
+iterator mpairs*(ast: var GpuAst): (int, var GpuAst) =
+  ## Iterate over all child nodes of the given AST and the index
+  var i = 0
+  for el in mitems(ast):
+    yield (i, el)
+    inc i
+
+iterator pairs*(ast: GpuAst): (int, GpuAst) =
+  var i = 0
+  for el in items(ast):
+    yield (i, el)
+    inc i
+
 
 ## General utility helpers
 

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -212,6 +212,7 @@ type
   GpuFieldInit* = object
     name*: string
     value*: GpuAst
+    typ*: GpuType
 
   ## XXX: UNUSED
   TemplateInfo* = object
@@ -385,7 +386,13 @@ proc clone*(ast: GpuAst): GpuAst =
     result = GpuAst(kind: gpuObjConstr)
     result.ocName = ast.ocName
     for f in ast.ocFields:
-      result.ocFields.add(GpuFieldInit(name: f.name, value: f.value.clone()))
+      result.ocFields.add(
+        GpuFieldInit(
+          name: f.name,
+          value: f.value.clone(),
+          typ: f.typ.clone()
+        )
+      )
   of gpuInlineAsm:
     result = GpuAst(kind: gpuInlineAsm)
     result.stmt = ast.stmt

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -530,6 +530,31 @@ proc removePrefix(s, p: string): string =
   result = s
   result.removePrefix(p)
 
+proc pretty*(t: GpuType): string =
+  ## returns a flat (but lossy) string representation of the type
+  if t == nil:
+    result = "GpuType(nil)"
+  else:
+    case t.kind
+    of gtPtr:
+      result = if t.implicit: "var " else: "ptr "
+      result.add pretty(t.to)
+    of gtUA:
+      result = "UncheckedArray[" & t.uaTo.pretty() & "]"
+    of gtObject:
+      result = t.name # just the name
+    of gtArray:
+      result = "array[" & $t.aLen & ", " & t.aTyp.pretty() & "]"
+    of gtGenericInst:
+      result = t.gName & "["
+      for i, g in t.gArgs:
+        result.add pretty(g)
+        if i < t.gArgs.high:
+          result.add ", "
+      result.add "]"
+    else:
+      result = ($t.kind).removePrefix("gt")
+
 proc pretty*(n: GpuAst, indent: int = 0): string =
   template id(): untyped = repeat(" ", indent)
   template idn(x): untyped = repeat(" ", indent) & $x

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -559,10 +559,10 @@ proc pretty*(n: GpuAst, indent: int = 0): string =
     result.add pretty(n.vName, indent + 2)
     result.add pretty(n.vInit, indent + 2)
     if n.vAttributes.len > 0:
-      result.add id("Attributes")
+      result.add idd("Attributes")
       for attr in n.vAttributes:
         let indent = indent + 2
-        result.add id(attr)
+        result.add idd(attr)
   of gpuAssign:
     result.add pretty(n.aLeft, indent + 2)
     result.add pretty(n.aRight, indent + 2)
@@ -599,11 +599,13 @@ proc pretty*(n: GpuAst, indent: int = 0): string =
       let indent = indent + 2
       result.add id(t.name)
   of gpuObjConstr:
-    result.add id("Ident", n.ocName)
-    result.add id("Fields")
+    result.add idd("Ident", n.ocName)
+    result.add idd("Fields")
     for f in n.ocFields:
-      let indent = indent + 2
-      result.add id("Name", f.name)
+      var indent = indent + 2
+      result.add idd("Field")
+      indent = indent + 2
+      result.add idd("Name", f.name)
       result.add pretty(f.value, indent + 2)
   of gpuInlineAsm:
     result.add id(n.stmt)

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -104,6 +104,7 @@ type
       pParams*: seq[GpuParam]
       pBody*: GpuAst
       pAttributes*: set[GpuAttribute] # order not important, hence set
+      forwardDeclare*: bool ## can be set to true to _only_ generate a forward declaration
     of gpuCall:
       cName*: GpuAst ## Will be a `GpuIdent`
       cArgs*: seq[GpuAst]

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -59,6 +59,7 @@ type
     typ*: GpuType
 
   GpuType* = ref object
+    builtin*: bool ## Whether the type refers to a builtin type or not
     case kind*: GpuTypeKind
     of gtPtr:
       to*: GpuType # `ptr T` points to `to`

--- a/constantine/math_compiler/experimental/gpu_types.nim
+++ b/constantine/math_compiler/experimental/gpu_types.nim
@@ -33,6 +33,7 @@ type
     gpuDot          # Member access (a.b)
     gpuIndex        # Array indexing (a[b])
     gpuTypeDef      # Type definition
+    gpuAlias        # A type alias
     gpuObjConstr    # Object (struct) constructor
     gpuInlineAsm    # Inline assembly (PTX)
     gpuAddr         # Address of an expression
@@ -161,6 +162,10 @@ type
     of gpuTypeDef:
       tName*: string ## XXX: could make GpuAst, but don't really need the types as symbols
       tFields*: seq[GpuTypeField]
+    of gpuAlias:
+      aName*: string ## Name of the type alias
+      aTo*: GpuAst ## Type the alias maps to
+      aDistinct*: bool ## If the alias is a distinct type in Nim.
     of gpuObjConstr:
       ocName*: string  # type we construct
       ## XXX: it would be better if we already fill the fields with default values here
@@ -400,6 +405,10 @@ proc clone*(ast: GpuAst): GpuAst =
     result.tName = ast.tName
     for f in ast.tFields:
       result.tFields.add(GpuTypeField(name: f.name, typ: f.typ.clone()))
+  of gpuAlias:
+    result = GpuAst(kind: gpuAlias)
+    result.aName = ast.aName
+    result.aTo = ast.aTo.clone()
   of gpuObjConstr:
     result = GpuAst(kind: gpuObjConstr)
     result.ocName = ast.ocName
@@ -616,6 +625,9 @@ proc pretty*(n: GpuAst, indent: int = 0): string =
     for t in n.tFields:
       let indent = indent + 2
       result.add id(t.name)
+  of gpuAlias:
+    result.add id("Alias", n.aName)
+    result.add pretty(n.aTo, indent + 2)
   of gpuObjConstr:
     result.add idd("Ident", n.ocName)
     result.add idd("Fields")

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -299,6 +299,8 @@ proc collectProcAttributes(n: NimNode): set[GpuAttribute] =
       return
     of "importc": # encountered if we analyze a proc from outside `cuda` scope
       return # this _should_ be a builtin function that has a counterpart in Nim, e.g. `math.ceil`
+    of "varargs": # attached to some builtins, e.g. `printf` on CUDA backend
+      continue
     else:
       raiseAssert "Unexpected pragma for procs: " & $pragma.treerepr
 

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -92,6 +92,8 @@ proc getInnerPointerType(n: NimNode): GpuType =
     # VarTy
     #   Sym "BigInt"
     result = nimToGpuType(n[0])
+  elif n.kind == nnkSym: # symbol of e.g. `ntyVar`
+    result = nimToGpuType(n.getTypeInst())
   else:
     raiseAssert "Found what: " & $n.treerepr
 

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -658,16 +658,21 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     for i in 1 ..< node.len: # all fields to be init'd
       doAssert node[i].kind == nnkExprColonExpr
       ocFields.add GpuFieldInit(name: node[i][0].strVal,
-                                value: ctx.toGpuAst(node[i][1]))
+                                value: ctx.toGpuAst(node[i][1]),
+                                typ: GpuType(kind: gtVoid))
+
     # now add fields in order of the type declaration
     for i in 0 ..< flds.len:
       let idx = findIdx(ocFields, flds[i].name)
       if idx >= 0:
-        result.ocFields.add ocFields[idx]
+        var f = ocFields[idx]
+        f.typ = flds[i].typ
+        result.ocFields.add f
       else:
         let dfl = GpuAst(kind: gpuLit, lValue: "DEFAULT", lType: GpuType(kind: gtVoid))
         result.ocFields.add GpuFieldInit(name: flds[i].name,
-                                         value: dfl)
+                                         value: dfl,
+                                         typ: flds[i].typ)
 
   of nnkAsmStmt:
     doAssert node.len == 2

--- a/constantine/math_compiler/experimental/runtime_compile.nim
+++ b/constantine/math_compiler/experimental/runtime_compile.nim
@@ -86,15 +86,17 @@ proc log*(nvrtc: var NVRTC) =
 proc compile*(nvrtc: var NVRTC) =
   # Compile the program with fmad disabled.
   # Note: Can specify GPU target architecture explicitly with '-arch' flag.
-  const
-    Options = [
-      cstring "--gpu-architecture=compute_75", # or whatever your GPU arch is
-      # "--fmad=false", # and whatever other options for example
-    ]
+  var options = @[
+    cstring "--gpu-architecture=compute_75", # or whatever your GPU arch is
+    # "--fmad=false", # and whatever other options for example
+  ]
+  when defined(debugCuda):
+    options.add cstring "--device-debug"       # Equivalent to -g
+    options.add cstring "--generate-line-info" # Equivalent to -lineinfo
 
-    NumberOfOptions = cint Options.len
-  let compileResult =  nvrtcCompileProgram(nvrtc.prog, NumberOfOptions,
-                                           cast[cstringArray](addr Options[0]))
+  let numberOfOptions = cint options.len
+  let compileResult =  nvrtcCompileProgram(nvrtc.prog, numberOfOptions,
+                                           cast[cstringArray](addr options[0]))
 
   nvrtc.log()
   ## XXX: only in `DebugCuda`?

--- a/constantine/platforms/abis/nvidia_abi.nim
+++ b/constantine/platforms/abis/nvidia_abi.nim
@@ -840,11 +840,11 @@ proc cuDeviceGetAttribute*(r: var int32, attrib: CUdevice_attribute, dev: CUdevi
 {.pop.}
 
 proc cuCtxCreate*(pctx: var CUcontext, flags: uint32, dev: CUdevice): CUresult {.v2.}
+proc cuCtxDestroy*(ctx: CUcontext): CUresult {.v2.}
 proc cuCtxSynchronize*(ctx: CUcontext): CUresult {.v2.}
 
 {.push noconv, importc, dynlib: libCuda.}
 
-proc cuCtxDestroy*(ctx: CUcontext): CUresult
 proc cuCtxSynchronize*(): CUresult
 proc cuCtxGetCurrent*(ctx: var CUcontext): CUresult
 proc cuCtxSetCurrent*(ctx: CUcontext): CUresult
@@ -859,7 +859,6 @@ proc cuModuleUnload*(module: CUmodule): CUresult
 proc cuModuleGetFunction(kernel: var CUfunction, module: CUmodule, fnName: ptr char): CUresult {.used.}
 proc cuModuleLoadData*(module: var CUmodule; image: pointer): CUresult
 proc cuModuleGetFunction*(hfunc: var CUfunction; hmod: CUmodule; name: cstring): CUresult
-proc cuModuleGetGlobal*(dptr: var CUdeviceptr, bytes: ptr csize_t, hmod: CUmodule, name: cstring): CUresult
 
 proc cuLaunchKernel*(
        kernel: CUfunction,
@@ -872,6 +871,8 @@ proc cuLaunchKernel*(
      ): CUresult {.used.}
 
 {.pop.} # {.push noconv, importc, dynlib: "libcuda.so"..}
+
+proc cuModuleGetGlobal*(dptr: var CUdeviceptr, bytes: ptr csize_t, hmod: CUmodule, name: cstring): CUresult {.v2.}
 
 proc cuMemAlloc*(devptr: var CUdeviceptr, size: csize_t): CUresult {.v2.}
 proc cuMemAllocManaged*(devptr: var CUdeviceptr, size: csize_t, flags: Flag[CUmemAttach_flags]): CUresult {.v1.}


### PR DESCRIPTION
This improves the initial WebGPU backend added in #564 to make it practically useful. Aside from adding a lot of features and bug fixes for the WGSL spec, it also makes changes towards making the entire `cuda` macro more useful:

- Nim generic functions can now be used inside the GPU code. We emit one function for each generic instantiation. This of course includes e.g. `static int` arguments. We now _could_ replace the templates that receive a static parameter by a regular generic, e.g. for the `BigInt` type and generate the correct functions and types based on what is actually instantiated. For the moment we don't update the code in `gpu_field_ops.nim` though.
- Functions don't _need_ to be defined inside the `cuda` block anymore. We will pull any code used inside of the GPU block in, if it is called. This is a good step towards making code naturally run on CPU and GPU for example. Only the code called from the host still needs to be in the `cuda` macro. Note that keeping GPU code in `templates` can still be a good idea to not pollute the namespace and if one wants a clearer separation between GPU and CPU code.
- Similarly types are also pulled in from outside the macro, if they are used.

As a result also the CUDA backend was updated slightly to follow a similar structure as the WGSL backend. That is have a `preprocess` pass before the actual codegen pass to scan the global functions for functions and types actually used.