### PR TITLE
Remove `importc` in Nvidia wrapped types

### DIFF
--- a/constantine/platforms/abis/nvidia_abi.nim
+++ b/constantine/platforms/abis/nvidia_abi.nim
@@ -825,6 +825,21 @@ type                          ##
                            ##
     CU_JIT_INPUT_NVVM = 5, CU_JIT_NUM_INPUT_TYPES = 6
 
+type
+  CUlimit* {.size: sizeof(cint).} = enum
+    CU_LIMIT_STACK_SIZE                       = 0x00, ## < GPU thread stack size */
+    CU_LIMIT_PRINTF_FIFO_SIZE                 = 0x01, ## < GPU printf FIFO size */
+    CU_LIMIT_MALLOC_HEAP_SIZE                 = 0x02, ## < GPU malloc heap size */
+    CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH           = 0x03, ## < GPU device runtime launch synchronize depth */
+    CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT = 0x04, ## < GPU device runtime pending launch count */
+    CU_LIMIT_MAX_L2_FETCH_GRANULARITY         = 0x05, ## < A value between 0 and 128 that indicates the maximum fetch granularity of L2 (in Bytes). This is a hint */
+    CU_LIMIT_PERSISTING_L2_CACHE_SIZE         = 0x06, ## < A size in bytes for L2 persisting lines cache size */
+    CU_LIMIT_SHMEM_SIZE                       = 0x07, ## < A maximum size in bytes of shared memory available to CUDA kernels on a CIG context. Can only be queried, cannot be set */
+    CU_LIMIT_CIG_ENABLED                      = 0x08, ## < A non-zero value indicates this CUDA context is a CIG-enabled context. Can only be queried, cannot be set */
+    CU_LIMIT_CIG_SHMEM_FALLBACK_ENABLED       = 0x09, ## < When set to zero, CUDA will fail to launch a kernel on a CIG context, instead of using the fallback path, if the kernel uses more shared memory than available */
+    CU_LIMIT_MAX
+
+
 {.pragma: v1, noconv, importc, dynlib: libCuda.}
 {.pragma: v2, noconv, importc: "$1_v2", dynlib: libCuda.}
 
@@ -848,6 +863,7 @@ proc cuCtxDestroy*(ctx: CUcontext): CUresult
 proc cuCtxSynchronize*(): CUresult
 proc cuCtxGetCurrent*(ctx: var CUcontext): CUresult
 proc cuCtxSetCurrent*(ctx: CUcontext): CUresult
+proc cuCtxSetLimit*(limit: CUlimit, value: csize_t): CUresult
 
 proc cuEventCreate*(event: var CUevent, flags: cuint = 0): CUresult
 proc cuEventDestroy*(event: CUevent): CUresult


### PR DESCRIPTION
With our current Nvidia wrapper these are actively harmful. With them we get C compiler errors.

Also adds the `cuCtxSetLimit` function, which allows setting custom limits (like increasing the stack size).