### PR TITLE
[ec]: batchAffine does not use alloca anymore

### DIFF
--- a/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
@@ -29,7 +29,7 @@ import
 func batchAffine*[F, G](
        affs: ptr UncheckedArray[EC_ShortW_Aff[F, G]],
        projs: ptr UncheckedArray[EC_ShortW_Prj[F, G]],
-       N: int) {.noInline, tags:[Alloca], meter.} =
+       N: int) {.meter.} =
   # Algorithm: Montgomery's batch inversion
   # - Speeding the Pollard and Elliptic Curve Methods of Factorization
   #   Section 10.3.1
@@ -94,7 +94,7 @@ func batchAffine*[N: static int, F, G](
 func batchAffine*[F, G](
        affs: ptr UncheckedArray[EC_ShortW_Aff[F, G]],
        jacs: ptr UncheckedArray[EC_ShortW_Jac[F, G]],
-       N: int) {.noInline, tags:[Alloca], meter.} =
+       N: int) {.meter.} =
   # Algorithm: Montgomery's batch inversion
   # - Speeding the Pollard and Elliptic Curve Methods of Factorization
   #   Section 10.3.1


### PR DESCRIPTION
Fix #578, should help with https://github.com/status-im/nimbus-eth1/pull/3389

Though looking at the CI, nimbus-eth1 should probably not use LTO for constantine as well.

cc @advaita-saha, @arnetheduck 