### PR TITLE
ARM CI: Runners test Linux ARM Assembly + upgrade to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,14 @@ jobs:
             ctt_backend: ASM
             host: ubuntu-latest
 
-          # ASM code for ARM Linux is not available yet
           - os: linux
             cpu: arm64
             ctt_backend: NO_ASM
-            host: ubuntu-22.04-arm
+            host: ubuntu-24.04-arm
+          - os: linux
+            cpu: arm64
+            ctt_backend: ASM
+            host: ubuntu-24.04-arm
 
           - os: windows
             cpu: amd64


### PR DESCRIPTION
After adding ARM assembly I forgot to test it also on Linux in CI.

Also upgrade from Ubuntu 22.04 -> Ubuntu 24.04.

And trying to narrow down downstream issue https://github.com/status-im/nimbus-eth1/actions/runs/17517080710/job/49755993475?pr=3587

```
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/constantine/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_arm64.nim: In function ‘_ZN24limbs_asm_mul_mont_arm6432mulMont_CIOS_sparebit_asm_sfalseE3varI5arrayI7range052CtI6uInt64EEE5arrayI7range052CtI6uInt64EE5arrayI7range052CtI6uInt64EE5arrayI7range052CtI6uInt64EE6uInt64’:
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/constantine/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_arm64.nim:248:1: error: more than 30 operands in ‘asm’
  248 | 
      | ^  
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/constantine/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_arm64.nim: In function ‘_ZN24limbs_asm_mul_mont_arm6443mulMont_CIOS_sparebit_asm_s6_s6_s6_s6_strueE3varI5LimbsIEE5LimbsIE5LimbsIE5LimbsIE6uInt64’:
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/constantine/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_arm64.nim:248:1: error: more than 30 operands in ‘asm’
```

It runs fine on MacOS ARM so:
- either GCC register allocations is less efficient on ARM or ARM-linux, in that case we need a workaround in Constantine
- or there is inlining that is still causing an issue, in that case we need a workaround in Nimbus.