### PR TITLE
Support more uint literals, simplify registering types for GPU, regular finite field `pow` typo fix

### DIFF
--- a/constantine/math/arithmetic/finite_fields.nim
+++ b/constantine/math/arithmetic/finite_fields.nim
@@ -613,7 +613,7 @@ func pow*(r: var FF, a: FF, exponent: BigInt or openArray[byte] or FF) =
   ## ``a``: a field element to be exponentiated
   ## ``exponent``: a finite field element or big integer
   r = a
-  a.pow(exponent)
+  r.pow(exponent)
 
 # Vartime exponentiation
 # -------------------------------------------------------------------

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -11,7 +11,8 @@ import std / [macros, strutils, sequtils, options, sugar, tables, strformat, has
 import ./gpu_types
 import ./backends/backends
 
-proc nimToGpuType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType
+proc nimToGpuType(ctx: var GpuContext, n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType
+proc maybeAddType*(ctx: var GpuContext, typ: GpuType)
 
 proc initGpuType(kind: GpuTypeKind): GpuType =
   ## If `kind` is `gtPtr` `to` must be the type we point to
@@ -39,9 +40,9 @@ proc initGpuObjectType(name: string, flds: seq[GpuTypeField]): GpuType =
   ## If `kind` is `gtPtr` `to` must be the type we point to
   result = GpuType(kind: gtObject, name: name, oFields: flds)
 
-proc initGpuArrayType(aTyp: NimNode, len: int): GpuType =
+proc initGpuArrayType(ctx: var GpuContext, aTyp: NimNode, len: int): GpuType =
   ## Construct an statically sized array type
-  result = GpuType(kind: gtArray, aTyp: nimToGpuType(aTyp), aLen: len)
+  result = GpuType(kind: gtArray, aTyp: ctx.nimToGpuType(aTyp), aLen: len)
 
 proc toTypeDef(typ: GpuType): GpuAst =
   ## Converts a given object or generic instantiation type into an AST of a
@@ -78,7 +79,7 @@ proc toGpuTypeKind(t: NimTypeKind): GpuTypeKind =
   else:
     raiseAssert "Not supported yet: " & $t
 
-proc parseTypeFields(node: NimNode): seq[GpuTypeField]
+proc parseTypeFields(ctx: var GpuContext, node: NimNode): seq[GpuTypeField]
 
 proc getGenericTypeName(t: NimNode): string =
   ## Returns the base name of the generic type, i.e. for
@@ -88,30 +89,30 @@ proc getGenericTypeName(t: NimNode): string =
   of nnkBracketExpr: result = t[0].getGenericTypeName()
   else: raiseAssert "Unexpected node kind for generic instantiation type: " & $t.treerepr
 
-proc parseGenericArgs(t: NimNode): seq[GpuType] =
+proc parseGenericArgs(ctx: var GpuContext, t: NimNode): seq[GpuType] =
   case t.kind
   of nnkSym: return # no generic arguments
   of nnkBracketExpr:
     for i in 1 ..< t.len:
-      result.add nimToGpuType(t[i])
+      result.add ctx.nimToGpuType(t[i])
   else:
     raiseAssert "Unexpected node kind in parseGenericArgs: " & $t.treerepr
 
-proc initGpuGenericInst(t: NimNode): GpuType =
+proc initGpuGenericInst(ctx: var GpuContext, t: NimNode): GpuType =
   doAssert t.typeKind == ntyGenericInst, "Input is not a generic instantiation: " & $t.treerepr & " of typeKind: " & $t.typeKind
   case t.kind
   of nnkBracketExpr: # regular generic instantiation
     result = GpuType(kind: gtGenericInst, gName: getGenericTypeName(t))
-    result.gArgs = parseGenericArgs(t)
+    result.gArgs = ctx.parseGenericArgs(t)
     # now parse the object fields
     let impl = t.getTypeImpl() # impl for the `gFields`
-    result.gFields = parseTypeFields(impl)
+    result.gFields = ctx.parseTypeFields(impl)
   of nnkObjConstr:
     if t.len == 1:   # Generic instantiation without arguments
-      result = initGpuGenericInst(t[0])
+      result = ctx.initGpuGenericInst(t[0])
     elif t.len == 2: # ...and with arguments
       doAssert t[1].kind == nnkExprColonExpr, "ObjConstr does not contain initialization as [1], but: " & $t.treerepr
-      result = initGpuGenericInst(t[0])
+      result = ctx.initGpuGenericInst(t[0])
     else:
       raiseAssert "Unexpected number of elements in `nnkObjConstr` node for generic instantiation: " & $t.treerepr
   of nnkSym:
@@ -119,12 +120,12 @@ proc initGpuGenericInst(t: NimNode): GpuType =
     case impl.kind
     of nnkDistinctTy:
       ## XXX: assumes distinct of inbuilt type, not object!
-      result = nimToGpuType(impl[0])
+      result = ctx.nimToGpuType(impl[0])
     of nnkObjectTy:
       doAssert impl.kind == nnkObjectTy, "Unexpected node kind for generic inst: " & $impl.treerepr
       ## XXX: use signature hash for type name? Otherwise will produce duplicates
       result = GpuType(kind: gtGenericInst, gName: t.repr)
-      result.gFields = parseTypeFields(impl)
+      result.gFields = ctx.parseTypeFields(impl)
     else:
       raiseAssert "Unexpected node kind in for genericInst: " & $t.treerepr
   else:
@@ -145,25 +146,25 @@ proc unpackGenericInst(t: NimNode): NimNode =
 proc toGpuTypeKind(t: NimNode): GpuTypeKind =
   result = t.unpackGenericInst().typeKind.toGpuTypeKind()
 
-proc getInnerPointerType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType =
+proc getInnerPointerType(ctx: var GpuContext, n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType =
   doAssert n.typeKind in {ntyPtr, ntyPointer, ntyUncheckedArray, ntyVar} or n.kind == nnkPtrTy, "But was: " & $n.treerepr & " of typeKind " & $n.typeKind
   if n.typeKind in {ntyPointer, ntyUncheckedArray}:
     let typ = n.getTypeInst()
     doAssert typ.kind == nnkBracketExpr, "No, was: " & $typ.treerepr
     doAssert typ[0].kind in {nnkIdent, nnkSym}
     doAssert typ[0].strVal in ["ptr", "UncheckedArray"]
-    result = nimToGpuType(typ[1], allowToFail, allowArrayIdent)
+    result = ctx.nimToGpuType(typ[1], allowToFail, allowArrayIdent)
   elif n.kind == nnkPtrTy:
-    result = nimToGpuType(n[0], allowToFail, allowArrayIdent)
+    result = ctx.nimToGpuType(n[0], allowToFail, allowArrayIdent)
   elif n.kind == nnkAddr:
     let typ = n.getTypeInst()
-    result = getInnerPointerType(typ, allowToFail, allowArrayIdent)
+    result = ctx.getInnerPointerType(typ, allowToFail, allowArrayIdent)
   elif n.kind == nnkVarTy:
     # VarTy
     #   Sym "BigInt"
-    result = nimToGpuType(n[0], allowToFail, allowArrayIdent)
+    result = ctx.nimToGpuType(n[0], allowToFail, allowArrayIdent)
   elif n.kind == nnkSym: # symbol of e.g. `ntyVar`
-    result = nimToGpuType(n.getTypeInst(), allowToFail, allowArrayIdent)
+    result = ctx.nimToGpuType(n.getTypeInst(), allowToFail, allowArrayIdent)
   else:
     raiseAssert "Found what: " & $n.treerepr
 
@@ -294,23 +295,27 @@ proc getTypeName(n: NimNode, recursedSym: bool = false): string =
         result.add "_"
   else: raiseAssert "Unexpected node in `getTypeName`: " & $n.treerepr
 
-proc nimToGpuType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType =
+proc nimToGpuType(ctx: var GpuContext, n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType =
   ## Maps a Nim type to a type on the GPU
   ##
   ## If `allowToFail` is `true`, we return `GpuType(kind: gtVoid)` in cases
   ## where we would otherwise raise. This is so that in some cases where
   ## we only _attempt_ to determine a type, we can do so safely.
+  template addAndReturn(arg: untyped): untyped =
+    ctx.maybeAddType(arg)
+    return arg
+
   case n.kind
   of nnkIdentDefs: # extract type for let / var based on explicit or implicit type
     if n[n.len - 2].kind != nnkEmpty: # explicit type
-      result = nimToGpuType(n[n.len - 2], allowToFail, allowArrayIdent)
+      result = ctx.nimToGpuType(n[n.len - 2], allowToFail, allowArrayIdent)
     else: # take from last element
-      result = nimToGpuType(n[n.len - 1].getTypeInst(), allowToFail, allowArrayIdent)
+      result = ctx.nimToGpuType(n[n.len - 1].getTypeInst(), allowToFail, allowArrayIdent)
   of nnkConstDef:
     if n[1].kind != nnkEmpty: # has an explicit type
-      result = nimToGpuType(n[1], allowToFail, allowArrayIdent)
+      result = ctx.nimToGpuType(n[1], allowToFail, allowArrayIdent)
     else:
-      result = nimToGpuType(n[2], allowToFail, allowArrayIdent) # derive from the RHS literal
+      result = ctx.nimToGpuType(n[2], allowToFail, allowArrayIdent) # derive from the RHS literal
   else:
     if n.kind == nnkEmpty: return initGpuType(gtVoid)
     case n.typeKind
@@ -319,27 +324,27 @@ proc nimToGpuType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool =
     of ntyString: # only supported on some backends!
       result = initGpuType(toGpuTypeKind n.typeKind)
     of ntyPtr:
-      result = initGpuPtrType(getInnerPointerType(n, allowToFail, allowArrayIdent), implicitPtr = false)
+      result = initGpuPtrType(ctx.getInnerPointerType(n, allowToFail, allowArrayIdent), implicitPtr = false)
     of ntyVar:
-      result = initGpuPtrType(getInnerPointerType(n, allowToFail, allowArrayIdent), implicitPtr = true)
+      result = initGpuPtrType(ctx.getInnerPointerType(n, allowToFail, allowArrayIdent), implicitPtr = true)
     of ntyPointer:
       result = initGpuVoidPtr()
     of ntyUncheckedArray:
       ## Note: this is just the internal type of the array. It is only a pointer due to
       ## `ptr UncheckedArray[T]`. We simply remove the `UncheckedArray` part.
-      result = initGpuUAType(getInnerPointerType(n, allowToFail, allowArrayIdent))
+      result = initGpuUAType(ctx.getInnerPointerType(n, allowToFail, allowArrayIdent))
     of ntyObject, ntyAlias, ntyTuple:
       # for aliases, treat them identical to regular object types, but
       # `getTypeName` returns the alias!
       let impl = if n.kind == nnkTupleConstr: n # might actually _lose_ information if used getTypeImpl
                  else: n.getTypeImpl
-      let flds = impl.parseTypeFields()
+      let flds = ctx.parseTypeFields(impl)
       let typName = getTypeName(n) # might be an object construction
       result = initGpuObjectType(typName, flds)
     of ntyArray:
       # For a generic, static array type, e.g.:
       if n.kind == nnkSym:
-        return nimToGpuType(getTypeImpl(n), allowToFail, allowArrayIdent)
+        addAndReturn ctx.nimToGpuType(getTypeImpl(n), allowToFail, allowArrayIdent)
       if n.len == 3:
         # BracketExpr
         #   Sym "array"
@@ -356,13 +361,13 @@ proc nimToGpuType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool =
           #   Sym "BigInt"
           return GpuType(kind: gtInvalid)
         else:
-          result = initGpuArrayType(n[2], len)
+          result = ctx.initGpuArrayType(n[2], len)
       else:
         # just an array literal
         # Bracket
         #   UIntLit 2013265921
         let len = n.len
-        result = initGpuArrayType(n[0], len)
+        result = ctx.initGpuArrayType(n[0], len)
     #of ntyCompositeTypeClass:
     #  echo n.getTypeImpl.treerepr
     #  error("o")
@@ -370,24 +375,27 @@ proc nimToGpuType(n: NimNode, allowToFail: bool = false, allowArrayIdent: bool =
       result = initGpuType(gtInvalid)
       error("Generics are not supported in the CUDA DSL so far.") # Note: this should not appear nowadays
     of ntyGenericInst:
-      result = initGpuGenericInst(n)
+      result = ctx.initGpuGenericInst(n)
     of ntyTypeDesc:
       # `getType` returns a `BracketExpr` of eg:
       # BracketExpr
       #   Sym "typeDesc"
       #   Sym "float32"
-      result = n.getType[1].nimToGpuType(allowToFail, allowArrayIdent) # for a type desc we need to recurse using the type of it
+      result = ctx.nimToGpuType(n.getType[1], allowToFail, allowArrayIdent) # for a type desc we need to recurse using the type of it
     of ntyUnused2:
       # BracketExpr
       #   Sym "lent"
       #   Sym "BigInt"
       doAssert n.kind == nnkBracketExpr and n[0].strVal == "lent", "ntyUnused2: " & $n.treerepr
-      result = initGpuPtrType(nimToGpuType(n[1]), implicitPtr = false)
+      result = initGpuPtrType(ctx.nimToGpuType(n[1]), implicitPtr = false)
     else:
       if allowToFail:
         result = GpuType(kind: gtVoid)
       else:
         raiseAssert "Type : " & $n.typeKind & " not supported yet: " & $n.treerepr
+
+  # now add this type if not known
+  ctx.maybeAddType(result)
 
 proc assignOp(op: string, isBoolean: bool): string =
   ## Returns the correct CUDA operation given the Nim operator.
@@ -408,19 +416,19 @@ proc assignPrefixOp(op: string): string =
   of "not": result = "!"
   else: result = op
 
-proc parseTypeFields(node: NimNode): seq[GpuTypeField] =
+proc parseTypeFields(ctx: var GpuContext, node: NimNode): seq[GpuTypeField] =
   case node.kind
   of nnkObjectTy:
     doAssert node[2].kind == nnkRecList
     for ch in node[2]:
       doAssert ch.kind == nnkIdentDefs and ch.len == 3
       result.add GpuTypeField(name: ch[0].strVal,
-                              typ: nimToGpuType(ch[1]))
+                              typ: ctx.nimToGpuType(ch[1]))
   of nnkTupleTy:
     for ch in node:
       doAssert ch.kind == nnkIdentDefs and ch.len == 3
       result.add GpuTypeField(name: ch[0].strVal,
-                              typ: nimToGpuType(ch[1]))
+                              typ: ctx.nimToGpuType(ch[1]))
   of nnkTupleConstr:
     # TupleConstr
     #   Sym "BaseType"
@@ -429,12 +437,12 @@ proc parseTypeFields(node: NimNode): seq[GpuTypeField] =
       case ch.kind
       of nnkSym:
         result.add GpuTypeField(name: "Field" & $i,
-                                typ: nimToGpuType(ch))
+                                typ: ctx.nimToGpuType(ch))
       of nnkExprColonExpr:
         result.add GpuTypeField(name: ch[0].strVal,
-                                typ: nimToGpuType(ch[1]))
+                                typ: ctx.nimToGpuType(ch[1]))
       else:
-        return parseTypeFields(node.getTypeImpl) # will likely fall back to constr with `nnkSym`
+        return ctx.parseTypeFields(node.getTypeImpl) # will likely fall back to constr with `nnkSym`
   else:
     raiseAssert "Unsupported type to parse fields from: " & $node.kind
 
@@ -606,15 +614,15 @@ proc getFnName(ctx: var GpuContext, n: NimNode): GpuAst =
     # ctx.sigTab[sig] = result
   result.symbolKind = gsProc # make sure it's a proc
 
-proc gpuTypeMaybeFromSymbol(t: NimNode, n: NimNode): GpuType =
+proc gpuTypeMaybeFromSymbol(ctx: var GpuContext, t: NimNode, n: NimNode): GpuType =
   ## Returns the type from a given Nim node `t` representing a type.
   ## If that fails due to an identifier in the type, we instead try
   ## to look up the type from the associated symbol, `n`.
-  result = nimToGpuType(t, allowArrayIdent = true)
+  result = ctx.nimToGpuType(t, allowArrayIdent = true)
   if result.kind == gtInvalid:
     # an existing symbol cannot be `void` by definition, then it wouldn't be a symbol. Means
     # `allowArrayIdent` triggered due to an ident in the type. Use symbol for type instead
-    result = n.getTypeInst.nimToGpuType()
+    result = ctx.nimToGpuType(n.getTypeInst)
 
 proc stripPtrOrArrayType(t: GpuType): GpuType =
   ## Strips any pointer or array type to return any struct / generic instantiation
@@ -649,8 +657,7 @@ proc parseProcParameters(ctx: var GpuContext, params: NimNode, attrs: set[GpuAtt
     #   PtrTy
     #     Ident "float32"   # `param.len - 2`
     #   Empty               # `param.len - 1`
-    let paramType = gpuTypeMaybeFromSymbol(param[typIdx], param[typIdx-1])
-    ctx.maybeAddType(paramType)
+    let paramType = ctx.gpuTypeMaybeFromSymbol(param[typIdx], param[typIdx-1])
     for i in 0 ..< numParams:
       var p = ctx.toGpuAst(param[i])
       let symKind = if attGlobal in attrs: gsGlobalKernelParam
@@ -671,10 +678,9 @@ proc parseProcReturnType(ctx: var GpuContext, params: NimNode): GpuType =
     # attempt to get type. If fails, we need to wait for a caller to this function to get types
     # (e.g. returns something like `array[FOO, BigInt]` where `FOO` is a constant defined outside
     # the macro. We then rely on our generics logic to later look this up when called
-    result = nimToGpuType(retType, allowArrayIdent = true)
+    result = ctx.nimToGpuType(retType, allowArrayIdent = true)
     if result.kind == gtVoid: # stop parsing this function
       result = GpuType(kind: gtInvalid)
-  ctx.maybeAddType(result)
 
 proc toGpuProcSignature(ctx: var GpuContext, params: NimNode, attrs: set[GpuAttribute]): GpuProcSignature =
   ## Creates a `GpuProcSignature` from the given `params` node of type `nnkFormalParams`
@@ -914,8 +920,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
         doAssert declaration[0][1].kind == nnkPragma
         varNode.vAttributes = collectAttributes(declaration[0][1])
       else: raiseAssert "Unexpected node kind for variable: " & $declaration.treeRepr
-      varNode.vType = gpuTypeMaybeFromSymbol(declaration, declaration[0])
-      ctx.maybeAddType(varNode.vType)
+      varNode.vType = ctx.gpuTypeMaybeFromSymbol(declaration, declaration[0])
       varNode.vName.iTyp = varNode.vType # also store the type in the symbol, for easier lookup later
       # This is a *local* variable (i.e. `function` address space on WGSL) unless it is
       # annotated with `{.shared.}` (-> `workspace` in WGSL)
@@ -1029,8 +1034,8 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     #   Sym "int"  <- return type
     #   Sym "int"  <- left op type
     #   Sym "int"  <- right op type
-    result.bLeftTyp = nimToGpuType(typ[0][1])
-    result.bRightTyp = nimToGpuType(typ[0][2])
+    result.bLeftTyp = ctx.nimToGpuType(typ[0][1])
+    result.bRightTyp = ctx.nimToGpuType(typ[0][2])
     # if either is not a base type (`gtBool .. gtSize_t`) we actually deal with a _function call_
     # instead of an binary operation. Will thus rewrite.
     proc ofBasicType(t: GpuType, allowPtrLhs: bool): bool =
@@ -1080,9 +1085,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     case node[0].typeKind
     of ntyTuple:
       # need to replace `[idx]` by field access
-      let typ = nimToGpuType(node[0].getTypeImpl)
-      ctx.maybeAddType(typ)
-      #doAssert typ in ctx.types
+      let typ = ctx.nimToGpuType(node[0].getTypeImpl)
       doAssert node[1].kind == nnkIntLit
       let idx = node[1].intVal
       let field = typ.oFields[idx].name
@@ -1193,11 +1196,11 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
                                          # will store the instantiatons in `nnkObjConstr`
       result = GpuAst(kind: gpuVoid)
     else:
-      let typ = nimToGpuType(node[0])
+      let typ = ctx.nimToGpuType(node[0])
       case node[2].kind
       of nnkObjectTy: # regular `type foo = object`
         result = GpuAst(kind: gpuTypeDef, tTyp: typ)
-        result.tFields = parseTypeFields(node[2])
+        result.tFields = ctx.parseTypeFields(node[2])
       of nnkSym:      # a type alias `type foo = bar`
         result = GpuAst(kind: gpuAlias, aTyp: typ,
                         aTo: ctx.toGpuAst(node[2]))
@@ -1211,8 +1214,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
       result = GpuAst(kind: gpuVoid)
   of nnkObjConstr:
     ## this should never see `genericParam` I think
-    let typ = nimToGpuType(node)
-    ctx.maybeAddType(typ)
+    let typ = ctx.nimToGpuType(node)
     result = GpuAst(kind: gpuObjConstr, ocType: typ)
     # get all fields of the type
     let flds = if typ.kind == gtObject: typ.oFields
@@ -1239,8 +1241,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
                                          value: dfl,
                                          typ: flds[i].typ)
   of nnkTupleConstr:
-    let typ = nimToGpuType(node)
-    ctx.maybeAddType(typ)
+    let typ = ctx.nimToGpuType(node)
 
     result = GpuAst(kind: gpuObjConstr, ocType: typ)
     # get all fields of the type
@@ -1279,7 +1280,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
                     stmt: node[1].strVal)
 
   of nnkBracket:
-    let aLitTyp = nimToGpuType(node[0])
+    let aLitTyp = ctx.nimToGpuType(node[0])
     var aValues = newSeq[GpuAst]()
     for el in node:
       aValues.add ctx.toGpuAst(el)
@@ -1295,10 +1296,10 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     result = ctx.toGpuAst(node[1])
   of nnkConv:
     # maps type conversion, e.g. `let i: int = 5; i.uint32`
-    result = GpuAst(kind: gpuConv, convTo: nimToGpuType(node[0]), convExpr: ctx.toGpuAst(node[1]))
+    result = GpuAst(kind: gpuConv, convTo: ctx.nimToGpuType(node[0]), convExpr: ctx.toGpuAst(node[1]))
   of nnkCast:
     # only maps real bit casts
-    result = GpuAst(kind: gpuCast, cTo: nimToGpuType(node[0]), cExpr: ctx.toGpuAst(node[1]))
+    result = GpuAst(kind: gpuCast, cTo: ctx.nimToGpuType(node[0]), cExpr: ctx.toGpuAst(node[1]))
 
   of nnkAddr, nnkHiddenAddr:
     # `HiddenAddr` appears for accesses to `var` passed arguments
@@ -1313,7 +1314,7 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     result = GpuAst(kind: gpuConstexpr,
                     cIdent: ctx.toGpuAst(node[0]),
                     cValue: ctx.toGpuAst(node[2]),
-                    cType: nimToGpuType(node))
+                    cType: ctx.nimToGpuType(node))
     result.cIdent.iTyp = result.cType # also store the type in the symbol, for easier lookup later
     result.cIdent.symbolKind = gsLocal #if atvShared in result.vAttributes: gsShared
                                #elif atvPrivate in varNode.vAttributes: gsPrivate

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -1127,14 +1127,18 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
     result = GpuAst(kind: gpuLit)
     result.lValue = $node.intVal
     result.lType = initGpuType(gtInt32)
-  of nnkUInt32Lit:
-    result = GpuAst(kind: gpuLit)
-    result.lValue = $node.intVal
-    result.lType = initGpuType(gtUInt32)
-  of nnkUIntLit:
+  of nnkUIntLit, nnkUint64Lit:
     result = GpuAst(kind: gpuLit)
     result.lValue = $node.intVal
     result.lType = initGpuType(gtUInt64) ## XXX: base on target platform!
+  of nnkUInt16Lit:
+    result = GpuAst(kind: gpuLit)
+    result.lValue = $node.intVal
+    result.lType = initGpuType(gtUInt16) ## XXX: base on target platform!
+  of nnkUInt32Lit:
+    result = GpuAst(kind: gpuLit)
+    result.lValue = $node.intVal
+    result.lType = initGpuType(gtUInt32) ## XXX: base on target platform!
   of nnkFloat64Lit, nnkFloatLit:
     result = GpuAst(kind: gpuLit)
     result.lValue = $node.floatVal & "f"


### PR DESCRIPTION
Decided to put a small typo fix of in-place `pow` for finite fields into this PR, because I noticed it in the same context and it's one character change. 

On the GPU compiler side this:
- adds support for all uint literal types 
- simplifies how we register types in the Nim -> GPU Ast transformation. We now do this in one place only, namely in `nimToGpuType`. We needed to pass the GPU context into this proc, which initially I didn't intend to do. But the code was getting a bit ugly with `maybeAddType` calls all over the place.
