### PR TITLE
Fix compilation warnings

### DIFF
--- a/bindings/lib_hashes.nim
+++ b/bindings/lib_hashes.nim
@@ -23,7 +23,7 @@ import constantine/zoo_exports
 
 import constantine/hashes
 
-func keccak256_hash(digest: var array[32, byte], message: openArray[byte], clearMem: bool) {.libPrefix: "ctt_".} =
+func keccak256_hash(digest: var array[32, byte], message: openArray[byte], clearMem: bool) {.used, libPrefix: "ctt_".} =
   ## Compute the Keccak256 hash of message
   ## and store the result in digest.
   ## Optionally, clear the memory buffer used.
@@ -35,7 +35,7 @@ func keccak256_hash(digest: var array[32, byte], message: openArray[byte], clear
   # - Can be LTO-optimized
   keccak256.hash(digest, message, clearMem)
 
-func sha256_hash(digest: var array[32, byte], message: openArray[byte], clearMem: bool) {.libPrefix: "ctt_".} =
+func sha256_hash(digest: var array[32, byte], message: openArray[byte], clearMem: bool) {.used, libPrefix: "ctt_".} =
   ## Compute the SHA-256 hash of message
   ## and store the result in digest.
   ## Optionally, clear the memory buffer used.

--- a/constantine/ethereum_bls_signatures.nim
+++ b/constantine/ethereum_bls_signatures.nim
@@ -60,7 +60,6 @@ export hashes # generic sandwich on sha256
 import
     ./platforms/[abstractions, views, allocs],
     ./named/algebras,
-    ./named/zoo_subgroups,
     ./math/[
       ec_shortweierstrass,
       extension_fields,

--- a/constantine/ethereum_evm_precompiles.nim
+++ b/constantine/ethereum_evm_precompiles.nim
@@ -22,7 +22,6 @@ import
   ./hash_to_curve/hash_to_curve,
   # For KZG point precompile
   ./ethereum_eip4844_kzg,
-  ./serialization/codecs_status_codes,
   # ECDSA for ECRecover
   ./ethereum_ecdsa_signatures
 

--- a/constantine/ethereum_verkle_ipa.nim
+++ b/constantine/ethereum_verkle_ipa.nim
@@ -110,7 +110,7 @@ template checkReturn(evalExpr: CttCodecEccStatus): untyped {.dirty.} =
     of cttCodecEcc_PointNotInSubgroup:                  return cttEthVerkleIpa_EccPointNotInSubGroup
     of cttCodecEcc_PointAtInfinity:                     discard
 
-template check(Section: untyped, evalExpr: CttCodecScalarStatus): untyped {.dirty.} =
+template check(Section: untyped, evalExpr: CttCodecScalarStatus): untyped {.dirty, used.} =
   # Translate codec status code to KZG status code
   # Exit current code block
   block:
@@ -120,7 +120,7 @@ template check(Section: untyped, evalExpr: CttCodecScalarStatus): untyped {.dirt
     of cttCodecScalar_Zero:                             discard
     of cttCodecScalar_ScalarLargerThanCurveOrder:       result = cttEthVerkleIpa_ScalarLargerThanCurveOrder; break Section
 
-template check(Section: untyped, evalExpr: CttCodecEccStatus): untyped {.dirty.} =
+template check(Section: untyped, evalExpr: CttCodecEccStatus): untyped {.dirty, used.} =
   # Translate codec status code to KZG status code
   # Exit current code block
   block:

--- a/constantine/hash_to_curve/h2c_hash_to_field.nim
+++ b/constantine/hash_to_curve/h2c_hash_to_field.nim
@@ -103,7 +103,6 @@ func expandMessageXMD*[len_in_bytes: static int](
   mixin digestSize
   type Hash = H # Otherwise the VM says "cannot evaluate at compiletime H"
   const DigestSize = Hash.digestSize()
-  const BlockSize = Hash.internalBlockSize()
 
   static:
     doAssert output.len mod 8 == 0  # By spec

--- a/constantine/hashes/h_ripemd160.nim
+++ b/constantine/hashes/h_ripemd160.nim
@@ -6,11 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import constantine/zoo_exports
-
 import
-  constantine/platforms/[abstractions, views],
-  constantine/serialization/endians,
   ./ripemd160/ripemd160_generic
 
 
@@ -50,11 +46,11 @@ export Ripemd160Context
 
 template digestSize*(H: type ripemd160): int =
   ## Returns the output size in bytes
-  DigestSize
+  RMD160_DigestSize
 
 template internalBlockSize*(H: type ripemd160): int =
   ## Returns the byte size of the hash function ingested blocks
-  BlockSize
+  RMD160_BlockSize
 
 func init*(ctx: var Ripemd160Context) =
   ## Initialize or reinitialize a Ripemd160 context
@@ -71,7 +67,7 @@ func update*(ctx: var Ripemd160Context, message: openarray[byte]) =
   ## in memory considered secure for your threat model.
   ctx.write(message, message.len.uint64)
 
-func finish*(ctx: var Ripemd160Context, digest: var array[DigestSize, byte])  =
+func finish*(ctx: var Ripemd160Context, digest: var array[RMD160_DigestSize, byte])  =
   ## Finalize a Ripemd160 computation and output the
   ## message digest to the `digest` buffer.
   ##

--- a/constantine/hashes/h_sha256.nim
+++ b/constantine/hashes/h_sha256.nim
@@ -38,7 +38,7 @@ type
   Sha256Context* = object
     # Align to 64 for cache line and SIMD friendliness
     s{.align: 64}: Sha256_state
-    buf{.align: 64}: array[BlockSize, byte]
+    buf{.align: 64}: array[Sha256_BlockSize, byte]
     msgLen: uint64
 
   sha256* = Sha256Context
@@ -68,7 +68,7 @@ func hashMessageBlocks(
     hashMessageBlocks_generic(s, message, numBlocks)
 
 func dumpHash(
-       digest: var array[DigestSize, byte],
+       digest: var array[Sha256_DigestSize, byte],
        s: Sha256_state) {.inline.} =
   ## Convert the internal hash into a message digest
   var dstIdx = 0
@@ -85,11 +85,11 @@ func hashBuffer(ctx: var Sha256Context) {.inline.} =
 
 template digestSize*(H: type sha256): int =
   ## Returns the output size in bytes
-  DigestSize
+  Sha256_DigestSize
 
 template internalBlockSize*(H: type sha256): int =
   ## Returns the byte size of the hash function ingested blocks
-  BlockSize
+  Sha256_BlockSize
 
 func init*(ctx: var Sha256Context) {.libPrefix: prefix_sha256.} =
   ## Initialize or reinitialize a Sha256 context
@@ -110,7 +110,7 @@ func initZeroPadded*(ctx: var Sha256Context) =
   ## Initialize a Sha256 context
   ## with the result of
   ## ctx.init()
-  ## ctx.update default(array[BlockSize, byte])
+  ## ctx.update default(array[Sha256_BlockSize, byte])
   #
   # This work arounds `toOpenArray`
   # not working in the Nim VM, preventing `sha256.update`
@@ -143,25 +143,25 @@ func update*(ctx: var Sha256Context, message: openarray[byte]) {.libPrefix: pref
   ## use a Key Derivation Function instead (KDF)
 
   # Message processing state machine
-  var bufIdx = uint(ctx.msgLen mod BlockSize)
+  var bufIdx = uint(ctx.msgLen mod Sha256_BlockSize)
   var cur = 0'u
   var bytesLeft = message.len.uint
 
-  if bufIdx != 0 and bufIdx+bytesLeft >= BlockSize:
+  if bufIdx != 0 and bufIdx+bytesLeft >= Sha256_BlockSize:
     # Previous partial update, fill the buffer and do one sha256 hash
-    let free = BlockSize - bufIdx
+    let free = Sha256_BlockSize - bufIdx
     ctx.buf.rawCopy(dStart = bufIdx, message, sStart = 0, len = free)
     ctx.hashBuffer()
     bufIdx = 0
     cur = free
     bytesLeft -= free
 
-  if bytesLeft >= BlockSize:
+  if bytesLeft >= Sha256_BlockSize:
     # Process n blocks (64 byte each)
-    let numBlocks = bytesLeft div BlockSize
+    let numBlocks = bytesLeft div Sha256_BlockSize
     ctx.s.hashMessageBlocks(message.asUnchecked +% cur, numBlocks)
-    cur += numBlocks * BlockSize
-    bytesLeft -= numBlocks * BlockSize
+    cur += numBlocks * Sha256_BlockSize
+    bytesLeft -= numBlocks * Sha256_BlockSize
 
   if bytesLeft != 0:
     # Store the tail in buffer
@@ -181,7 +181,7 @@ func finish*(ctx: var Sha256Context, digest: var array[32, byte]) {.libPrefix: p
   ## For passwords and secret keys, you MUST NOT use raw SHA-256
   ## use a Key Derivation Function instead (KDF)
 
-  let bufIdx = uint(ctx.msgLen mod BlockSize)
+  let bufIdx = uint(ctx.msgLen mod Sha256_BlockSize)
 
   # Add '1' bit at the end of the message (+7 zero bits)
   ctx.buf[bufIdx] = 0b1000_0000

--- a/constantine/hashes/ripemd160/ripemd160_generic.nim
+++ b/constantine/hashes/ripemd160/ripemd160_generic.nim
@@ -14,16 +14,16 @@ import
   constantine/platforms/abstractions
 import std / macros
 
-type Word* = uint32
+type Word = uint32
 const
-  DigestSize* = 20
-  BlockSize* = 64
-  HashSize* = DigestSize div sizeof(Word) # 5 uint32 = 20 bytes = 160 bits
+  RMD160_DigestSize* = 20
+  RMD160_BlockSize* = 64
+  RMD160_HashSize = RMD160_DigestSize div sizeof(Word) # 5 uint32 = 20 bytes = 160 bits
 
 type
   Ripemd160Context* = object
-    s*: array[HashSize, uint32]
-    buf {.align: 64.}: array[BlockSize, byte]
+    s*: array[RMD160_HashSize, uint32]
+    buf {.align: 64.}: array[RMD160_BlockSize, byte]
     bytes: uint64
 
 template f1(x, y, z: uint32): untyped = x xor y xor z
@@ -32,16 +32,13 @@ template f3(x, y, z: uint32): untyped = (x or (not y)) xor z
 template f4(x, y, z: uint32): untyped = (x and z) or (y and (not z))
 template f5(x, y, z: uint32): untyped = x xor (y or (not z))
 
-proc initialize*(s: var array[HashSize, uint32]) =
+proc initialize*(s: var array[RMD160_HashSize, uint32]) =
   ## Initialize RIPEMD-160 state.
   s[0] = 0x67452301'u32
   s[1] = 0xEFCDAB89'u32
   s[2] = 0x98BADCFE'u32
   s[3] = 0x10325476'u32
   s[4] = 0xC3D2E1F0'u32
-
-proc initRipemdCtx(): Ripemd160Context =
-  result.s.initialize()
 
 template rol(x: uint32, i: int32): untyped = (x shl i) or (x shr (32 - i))
 
@@ -72,7 +69,7 @@ macro generateWs(): untyped =
     result.add quote do:
       var `wId` = ReadLE32(chunk, `idx`)
 
-proc transform(s: var array[HashSize, uint32], chunk: openArray[byte]) =
+proc transform(s: var array[RMD160_HashSize, uint32], chunk: openArray[byte]) =
   ## Perform a RIPEMD-160 transformation, processing a 64-byte chunk. */
   var
     a1 = s[0]
@@ -284,11 +281,9 @@ proc write*(ctx: var Ripemd160Context, data: openArray[byte], length: uint64) =
     copyMem(ctx.buf +! bufsize, data +! dataPos, length - dataPos)
     ctx.bytes += length - dataPos
 
-template ReadLE32(chunk: openArray[byte], offset: int): untyped = uint32.fromBytes(chunk, offset, littleEndian)
-
 proc arrayFirst(x: byte): array[64, byte] = result[0] = x
 
-proc finalize*(ctx: var Ripemd160Context, hash: var array[DigestSize, byte]) =
+proc finalize*(ctx: var Ripemd160Context, hash: var array[RMD160_DigestSize, byte]) =
   const pad: array[64, byte] = arrayFirst(0x80)
   var sizedesc: array[8, byte]
   sizedesc.blobFrom(ctx.bytes shl 3, 0, littleEndian)

--- a/constantine/hashes/sha256/sha256_arm64_sha2.nim
+++ b/constantine/hashes/sha256/sha256_arm64_sha2.nim
@@ -134,6 +134,6 @@ func hashMessageBlocks_arm_sha*(
     abcd = vaddq_u32(abcd, state0)
     efgh = vaddq_u32(efgh, state1)
 
-    data +%= BlockSize
+    data +%= Sha256_BlockSize
 
   vst1q_u32_x2(H.H[0].addr, abcd_efgh)

--- a/constantine/hashes/sha256/sha256_generic.nim
+++ b/constantine/hashes/sha256/sha256_generic.nim
@@ -27,18 +27,18 @@ import
 # ------------------------------------------------
 # The enforced alignment should help the compiler produce optimized code
 
-type Word* = uint32
+type Sha256_Word* = uint32
 
 const
-  DigestSize* = 32
-  BlockSize* = 64
-  HashSize* = DigestSize div sizeof(Word) # 8
+  Sha256_DigestSize* = 32
+  Sha256_BlockSize* = 64
+  Sha256_HashSize = Sha256_DigestSize div sizeof(Sha256_Word) # 8
 
 type Sha256_MessageSchedule* = object
-  w*{.align: 64.}: array[BlockSize div sizeof(Word), Word]
+  w*{.align: 64.}: array[Sha256_BlockSize div sizeof(Sha256_Word), Sha256_Word]
 
 type Sha256_state* = object
-  H*{.align: 64.}: array[HashSize, Word]
+  H*{.align: 64.}: array[Sha256_HashSize, Sha256_Word]
 
 const K256* = [
   0x428a2f98'u32, 0x71374491'u32, 0xb5c0fbcf'u32, 0xe9b5dba5'u32, 0x3956c25b'u32, 0x59f111f1'u32, 0x923f82a4'u32, 0xab1c5ed5'u32,
@@ -98,24 +98,24 @@ template copy*(dst: var Sha256_state, src: Sha256_state) =
   ## State copy
   # Should compile with a specialized aligned copy.
   # No bounds check
-  for i in 0 ..< HashSize:
+  for i in 0 ..< Sha256_HashSize:
     dst.H[i] = src.H[i]
 
 template accumulate*(dst: var Sha256_state, src: Sha256_state) =
   ## State accumulation
   # No bounds check
-  for i in 0 ..< HashSize:
+  for i in 0 ..< Sha256_HashSize:
     dst.H[i] += src.H[i]
 
-template sha256_round*(s: var Sha256_state, wt, kt: Word) =
-  template a: Word = s.H[0]
-  template b: Word = s.H[1]
-  template c: Word = s.H[2]
-  template d: Word = s.H[3]
-  template e: Word = s.H[4]
-  template f: Word = s.H[5]
-  template g: Word = s.H[6]
-  template h: Word = s.H[7]
+template sha256_round*(s: var Sha256_state, wt, kt: Sha256_Word) =
+  template a: Sha256_Word {.redefine.} = s.H[0]
+  template b: Sha256_Word {.redefine.} = s.H[1]
+  template c: Sha256_Word {.redefine.} = s.H[2]
+  template d: Sha256_Word {.redefine.} = s.H[3]
+  template e: Sha256_Word {.redefine.} = s.H[4]
+  template f: Sha256_Word {.redefine.} = s.H[5]
+  template g: Sha256_Word {.redefine.} = s.H[6]
+  template h: Sha256_Word {.redefine.} = s.H[7]
 
   let T1 = h + S1(e) + ch(e, f, g) + kt + wt
   let T2 = S0(a) + maj(a, b, c)
@@ -132,7 +132,7 @@ func sha256_rounds_0_15(
        ms: var Sha256_MessageSchedule,
        message: ptr UncheckedArray[byte]) {.inline.} =
   staticFor t, 0, 16:
-    ms.w[t] = uint32.fromBytes(message, t * sizeof(Word), bigEndian)
+    ms.w[t] = uint32.fromBytes(message, t * sizeof(Sha256_Word), bigEndian)
     sha256_round(s, ms.w[t], K256[t])
 
 func sha256_rounds_16_63(
@@ -162,7 +162,7 @@ func hashMessageBlocks_generic*(
 
   for _ in 0 ..< numBlocks:
     sha256_rounds_0_15(s, ms, msg)
-    msg +%= BlockSize
+    msg +%= Sha256_BlockSize
 
     sha256_rounds_16_63(s, ms)
 

--- a/constantine/hashes/sha256/sha256_x86_sha.nim
+++ b/constantine/hashes/sha256/sha256_x86_sha.nim
@@ -122,7 +122,7 @@ func hashMessageBlocks_x86_sha*(
     abef = add_u32x4(abef, state0)
     cdgh = add_u32x4(cdgh, state1)
 
-    data +%= BlockSize
+    data +%= Sha256_BlockSize
 
   # The SHA state is stored in this order:
   #   D, C, B, A, H, G, F, E

--- a/constantine/hashes/sha256/sha256_x86_ssse3.nim
+++ b/constantine/hashes/sha256/sha256_x86_ssse3.nim
@@ -46,8 +46,8 @@ import
 # Vectorized message scheduler
 # ------------------------------------------------
 
-const VecNum = BlockSize div 16      # BlockSize / sizeof(m128i)
-const VecWords = 16 div sizeof(Word) # sizeof(m128i) / sizeof(Word)
+const VecNum = Sha256_BlockSize div 16      # BlockSize / sizeof(m128i)
+const VecWords = 16 div sizeof(Sha256_Word) # sizeof(m128i) / sizeof(Word)
 
 func initMessageSchedule(
        msnext: var array[VecNum, m128i],
@@ -206,7 +206,7 @@ func hashMessageBlocks_ssse3*(
 
   for _ in 0 ..< numBlocks:
     initMessageSchedule(msnext, ms, msg)
-    msg +%= BlockSize
+    msg +%= Sha256_BlockSize
 
     sha256_rounds_0_47(s, ms, msnext)
     sha256_rounds_48_63(s, ms)

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86.nim
@@ -86,7 +86,7 @@ macro mulMont_CIOS_sparebit_gen[N: static int](
   # We might be able to save registers by having `r` and `M` be memory operand as well
 
   result.add quote do:
-    static: doAssert: sizeof(SecretWord) == sizeof(ByteAddress)
+    static: doAssert: sizeof(SecretWord) == sizeof(uint)
 
     var `tSym`{.noInit, used.}: typeof(`r_PIR`)
     # Assumes 64-bit limbs on 64-bit arch (or you can't store an address)
@@ -258,7 +258,7 @@ macro sumprodMont_CIOS_spare2bits_gen[N, K: static int](
   # but this prevent reusing the same code for multiple curves like BLS12-377 and BLS12-381
   # We might be able to save registers by having `r` and `M` be memory operand as well
   result.add quote do:
-    static: doAssert: sizeof(SecretWord) == sizeof(ByteAddress)
+    static: doAssert: sizeof(SecretWord) == sizeof(uint)
 
     var `tsym`{.noInit, used.}: typeof(`r_PIR`)
     # Assumes 64-bit limbs on 64-bit arch (or you can't store an address)

--- a/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_mul_mont_x86_adx_bmi2.nim
@@ -221,7 +221,7 @@ macro mulMont_CIOS_sparebit_adx_gen[N: static int](
   # We might be able to save registers by having `r` and `M` be memory operand as well
 
   result.add quote do:
-    static: doAssert: sizeof(SecretWord) == sizeof(ByteAddress)
+    static: doAssert: sizeof(SecretWord) == sizeof(uint)
 
     var `tsym`{.noInit, used.}: typeof(`r_PIR`)
     # Assumes 64-bit limbs on 64-bit arch (or you can't store an address)
@@ -360,7 +360,7 @@ macro sumprodMont_CIOS_spare2bits_adx_gen[N, K: static int](
   # We might be able to save registers by having `r` and `M` be memory operand as well
 
   result.add quote do:
-    static: doAssert: sizeof(SecretWord) == sizeof(ByteAddress)
+    static: doAssert: sizeof(SecretWord) == sizeof(uint)
 
     var `tsym`{.noInit, used.}: typeof(`r_PIR`)
     # Assumes 64-bit limbs on 64-bit arch (or you can't store an address)

--- a/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
+++ b/constantine/math/arithmetic/assembly/limbs_asm_redc_mont_x86_adx_bmi2.nim
@@ -58,7 +58,7 @@ macro redc2xMont_adx_gen[N: static int](
 
   # Prologue
   result.add quote do:
-    static: doAssert: sizeof(SecretWord) == sizeof(ByteAddress)
+    static: doAssert: sizeof(SecretWord) == sizeof(uint)
     var `uSym`{.noinit, used.}: Limbs[`uSlots`]
     var `vSym` {.noInit.}: Limbs[`vSlots`]
     `vSym`[0] = cast[SecretWord](`r_PIR`[0].unsafeAddr)

--- a/constantine/math/arithmetic/limbs_crandall.nim
+++ b/constantine/math/arithmetic/limbs_crandall.nim
@@ -169,7 +169,7 @@ func reduceCrandallFinal_impl[N: static int](
 
 func reduceCrandallFinal[N: static int](
         a: var Limbs[N],
-        p: Limbs[N]) {.inline.} =
+        p: Limbs[N]) {.inline, used.} =
   ## Final Reduction modulo p
   ## with p with special form 2ᵐ-c
   ## called "Crandall prime" or Pseudo-Mersenne Prime in the litterature

--- a/constantine/math/elliptic/ec_multi_scalar_mul_parallel.nim
+++ b/constantine/math/elliptic/ec_multi_scalar_mul_parallel.nim
@@ -323,7 +323,6 @@ proc msmAffine_vartime_parallel[bits: static int, EC, ECaff](
   # --------
   const numBuckets {.used.} = 1 shl (c-1)
   const numFullWindows = bits div c
-  const numWindows = numFullWindows + 1 # Even if `bits div c` is exact, the signed recoding needs to see an extra 0 after the MSB
 
   # Instead of storing the result in futures, risking them being scattered in memory
   # we store them in a contiguous array, and the synchronizing future just returns a bool.

--- a/constantine/math/elliptic/ec_scalar_mul.nim
+++ b/constantine/math/elliptic/ec_scalar_mul.nim
@@ -331,7 +331,7 @@ func scalarMulEndo*[scalBits; EC](
   for i in countdown(L-2, 0):
     Q.double()
     tmp.secretLookup(lut, recoded.getRecodedIndex(i))
-    tmp.cneg(SecretBool recoded.getRecodedNegate(i))
+    tmp.cneg(recoded.getRecodedNegate(i))
     Q += tmp
 
   # Now we need to correct if the sign miniscalar was not odd

--- a/constantine/math/elliptic/ec_scalar_mul_vartime.nim
+++ b/constantine/math/elliptic/ec_scalar_mul_vartime.nim
@@ -351,13 +351,6 @@ func scalarMul_vartime*[scalBits; EC](P: var EC, scalar: BigInt[scalBits]) {.met
   ## - 0 <= scalar < curve order
   ## Those conditions will be assumed.
 
-  when P.F is Fp:
-    const M = 2
-  elif P.F is Fp2:
-    const M = 4
-  else:
-    {.error: "Unconfigured".}
-
   let usedBits = scalar.limbs.getBits_LE_vartime()
 
   when EC.getName().hasEndomorphismAcceleration():

--- a/constantine/math/polynomials/polynomials.nim
+++ b/constantine/math/polynomials/polynomials.nim
@@ -7,7 +7,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  constantine/named/algebras,
   constantine/math/arithmetic,
   constantine/math/io/io_fields,
   constantine/platforms/[primitives, allocs, static_for]

--- a/constantine/math/polynomials/polynomials_parallel.nim
+++ b/constantine/math/polynomials/polynomials_parallel.nim
@@ -10,7 +10,6 @@ import ./polynomials {.all.}
 export polynomials
 
 import
-  constantine/named/algebras,
   constantine/math/arithmetic,
   constantine/platforms/[allocs, bithacks],
   ../../threadpool/threadpool

--- a/constantine/math_compiler/experimental/backends/cuda.nim
+++ b/constantine/math_compiler/experimental/backends/cuda.nim
@@ -6,7 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std / [macros, strformat, strutils, sugar, sequtils, tables, algorithm]
+import std / [macros, strformat, strutils, sugar, sequtils, tables]
 
 import ../gpu_types
 import ./common_utils
@@ -447,7 +447,6 @@ proc genCuda*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   else:
     echo "Unhandled node kind in genCuda: ", ast.kind
     raiseAssert "Unhandled node kind in genCuda: " & ast.repr
-    result = ""
 
 proc codegen*(ctx: var GpuContext): string =
   ## Generate the actual code for all pieces of the puzzle

--- a/constantine/math_compiler/experimental/backends/wgsl.nim
+++ b/constantine/math_compiler/experimental/backends/wgsl.nim
@@ -6,7 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std / [macros, strformat, strutils, sugar, sequtils, tables, sets, options]
+import std / [macros, strformat, strutils, sugar, sequtils, tables, options]
 
 import ../gpu_types
 
@@ -1016,10 +1016,6 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   of gpuConstexpr:
     result = indentStr & "const " & ctx.genWebGpu(ast.cIdent) & ": " & gpuTypeToString(ast.cType, allowEmptyIdent = true) & " = " & ctx.genWebGpu(ast.cValue)
 
-  else:
-    echo "Unhandled node kind in genWebGpu: ", ast.kind
-    raiseAssert "Unhandled node kind in genWebGpu: " & ast.repr
-    result = ""
 
 proc codegen*(ctx: var GpuContext): string =
   ## Generate the actual code for all pieces of the puzzle

--- a/constantine/math_compiler/experimental/cuda_execute_dsl.nim
+++ b/constantine/math_compiler/experimental/cuda_execute_dsl.nim
@@ -218,11 +218,8 @@ proc execCudaImpl*(jitFn, numBlocks, threadsPerBlock, res, inputs, sharedMemSize
   result = newStmtList()
   result.add endianCheck()
 
-  # get the types of the inputs
-  let rTypes = getTypes(res)
-  let iTypes = getTypes(inputs)
-
   # determine all required `CUdeviceptr`
+  let iTypes = getTypes(inputs)
   let devPtrs = determineDevicePtrs(res, inputs, iTypes, passStructByPointer)
 
   # generate device pointers, allocate memory and copy data

--- a/constantine/math_compiler/experimental/gpu_compiler.nim
+++ b/constantine/math_compiler/experimental/gpu_compiler.nim
@@ -6,7 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std / [macros, strutils, sequtils, options, sugar, tables, strformat, hashes, sets]
+import std/[macros, sequtils, tables]
 
 import ./gpu_types
 import ./backends/backends

--- a/constantine/math_compiler/experimental/nim_to_gpu.nim
+++ b/constantine/math_compiler/experimental/nim_to_gpu.nim
@@ -6,10 +6,9 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std / [macros, strutils, sequtils, options, sugar, tables, strformat, hashes, sets]
+import std / [macros, strutils, sequtils, options, tables, sets]
 
 import ./gpu_types
-import ./backends/backends
 
 proc nimToGpuType(ctx: var GpuContext, n: NimNode, allowToFail: bool = false, allowArrayIdent: bool = false): GpuType
 proc maybeAddType*(ctx: var GpuContext, typ: GpuType)
@@ -1191,7 +1190,6 @@ proc toGpuAst*(ctx: var GpuContext, node: NimNode): GpuAst =
       result.statements.add ctx.toGpuAst(el)
   of nnkTypeDef:
     doAssert node.len == 3, "TypeDef node does not have 3 children: " & $node.len
-    let name = ctx.toGpuAst(node[0])
     if node[1].kind == nnkGenericParams: # if this is a generic, only store existence of it
                                          # will store the instantiatons in `nnkObjConstr`
       result = GpuAst(kind: gpuVoid)

--- a/constantine/math_compiler/experimental/runtime_compile.nim
+++ b/constantine/math_compiler/experimental/runtime_compile.nim
@@ -6,8 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import
-  std / [strformat, strutils]
+import std/strformat
 
 import constantine/platforms/abis/nvidia_abi
 

--- a/constantine/math_compiler/impl_curves_ops_affine.nim
+++ b/constantine/math_compiler/impl_curves_ops_affine.nim
@@ -9,10 +9,8 @@
 # NOTE: We probably don't want the explicit `asm_nvidia` dependency here, I imagine? Currently it's
 # for direct usage of `slct` in `neg`.
 import
-  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/llvm/llvm,
   ./ir,
-  ./impl_fields_globals,
-  ./impl_fields_dispatch,
   ./impl_fields_ops,
   std / typetraits # for distinctBase
 
@@ -88,15 +86,15 @@ template declEllipticAffOps*(asy: Assembler_LLVM, cd: CurveDescriptor): untyped 
   ## more convenient.
   ## XXX: extend to include all ops
   # Boolean checks
-  template isNeutral(res, x: EcPointAff): untyped = asy.isNeutralAff(cd, res, x.buf)
-  template isNeutral(x: EcPointAff): untyped =
+  template isNeutral(res, x: EcPointAff): untyped {.used.} = asy.isNeutralAff(cd, res, x.buf)
+  template isNeutral(x: EcPointAff): untyped {.used.} =
     var res = asy.br.alloca(asy.ctx.int1_t())
     asy.isNeutralAff(cd, res, x.buf)
     res
 
   # Accessors
-  template x(ec: EcPointAff): Field = ec.getX()
-  template y(ec: EcPointAff): Field = ec.getY()
+  template x(ec: EcPointAff): Field {.used.} = ec.getX()
+  template y(ec: EcPointAff): Field {.used.} = ec.getY()
 
 
 proc isNeutralAff*(asy: Assembler_LLVM, cd: CurveDescriptor, r, a: ValueRef) {.used.} =

--- a/constantine/math_compiler/impl_curves_ops_jacobian.nim
+++ b/constantine/math_compiler/impl_curves_ops_jacobian.nim
@@ -9,10 +9,8 @@
 # NOTE: We probably don't want the explicit `asm_nvidia` dependency here, I imagine? Currently it's
 # for direct usage of `slct` in `neg`.
 import
-  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/llvm/llvm,
   ./ir,
-  ./impl_fields_globals,
-  ./impl_fields_dispatch,
   ./impl_fields_ops,
   ./impl_curves_ops_affine,
   std / typetraits # for distinctBase
@@ -90,32 +88,32 @@ template declEllipticJacOps*(asy: Assembler_LLVM, cd: CurveDescriptor): untyped 
   ## This template can be used to make operations on `Field` elements
   ## more convenient.
   # Setters
-  template setNeutral(x: EcPointJac): untyped = asy.setNeutral(cd, x.buf)
+  template setNeutral(x: EcPointJac): untyped {.used.} = asy.setNeutral(cd, x.buf)
 
   # Boolean checks
-  template isNeutral(res, x: EcPointJac): untyped = asy.isNeutral(cd, res, x.buf)
-  template isNeutral(x: EcPointJac): untyped =
+  template isNeutral(res, x: EcPointJac): untyped {.used.} = asy.isNeutral(cd, res, x.buf)
+  template isNeutral(x: EcPointJac): untyped {.used.} =
     var res = asy.br.alloca(asy.ctx.int1_t())
     asy.isNeutral(cd, res, x.buf)
     res
 
   # Mutating assignment ops
-  template sum(res, x, y: EcPointJac): untyped = asy.sum(cd, res.buf, x.buf, y.buf)
-  template `+=`(x, y: EcPointJac): untyped     = x.sum(x, y)
-  template mixedSum(res, x: EcPointJac, y: EcPointAff): untyped = asy.mixedSum(cd, res.buf, x.buf, y.buf)
-  template `+=`(x: EcPointJac, y: EcPointAff): untyped = x.mixedSum(x, y)
+  template sum(res, x, y: EcPointJac): untyped {.used.} = asy.sum(cd, res.buf, x.buf, y.buf)
+  template `+=`(x, y: EcPointJac): untyped     {.used.} = x.sum(x, y)
+  template mixedSum(res, x: EcPointJac, y: EcPointAff): untyped {.used.} = asy.mixedSum(cd, res.buf, x.buf, y.buf)
+  template `+=`(x: EcPointJac, y: EcPointAff): untyped {.used.} = x.mixedSum(x, y)
 
   # Arithmetic mutations
-  template double(res, x: EcPointJac): untyped = asy.double(cd, res.buf, x.buf)
-  template double(x: EcPointJac): untyped      = x.double(x)
+  template double(res, x: EcPointJac): untyped {.used.} = asy.double(cd, res.buf, x.buf)
+  template double(x: EcPointJac): untyped      {.used.} = x.double(x)
 
   # Conditional ops
-  template ccopy(x, y: EcPointJac, c): untyped = asy.ccopy(cd, x.buf, y.buf, derefBool c)
+  template ccopy(x, y: EcPointJac, c): untyped {.used.} = asy.ccopy(cd, x.buf, y.buf, derefBool c)
 
   # Accessors
-  template x(ec: EcPointJac): Field = ec.getX()
-  template y(ec: EcPointJac): Field = ec.getY()
-  template z(ec: EcPointJac): Field = ec.getZ()
+  template x(ec: EcPointJac): Field {.used.} = ec.getX()
+  template y(ec: EcPointJac): Field {.used.} = ec.getY()
+  template z(ec: EcPointJac): Field {.used.} = ec.getZ()
 
 proc fromAffine_impl*(asy: Assembler_LLVM, cd: CurveDescriptor, jac: var EcPointJac, aff: EcPointAff) =
   # Inject templates for convenient access

--- a/constantine/math_compiler/impl_fields_ops.nim
+++ b/constantine/math_compiler/impl_fields_ops.nim
@@ -8,7 +8,7 @@
 
 import
   constantine/platforms/bithacks, # for log2_vartime
-  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/llvm/llvm,
   ./ir,
   ./impl_fields_globals,
   ./impl_fields_dispatch
@@ -31,14 +31,14 @@ template declFieldOps*(asy: Assembler_LLVM, fd: FieldDescriptor): untyped {.dirt
 
   ## XXX: extend to include all ops
   # Boolean checks
-  template isZero(res, x: Field): untyped  = asy.isZero(fd, res, x.buf)
-  template isZero(x: Field): untyped =
+  template isZero(res, x: Field): untyped  {.used.} = asy.isZero(fd, res, x.buf)
+  template isZero(x: Field): untyped {.used.} =
     var res = asy.br.alloca(asy.ctx.int1_t())
     asy.isZero(fd, res, x.buf)
     res
 
   # Boolean logic
-  template `not`(x: ValueRef): untyped     = asy.br.`not`(x)
+  template `not`(x: ValueRef): untyped     {.used.} = asy.br.`not`(x)
 
   template checkIsBool(x: TypeRef): bool =
     x.getTypeKind == tkInteger and x.getIntTypeWidth == 1'u32
@@ -59,50 +59,50 @@ template declFieldOps*(asy: Assembler_LLVM, fd: FieldDescriptor): untyped {.dirt
       raiseIfNotBool(x, false)
       # will raise
 
-  template `and`(x, y): untyped            = asy.br.`and`(derefBool x, derefBool y) # returns `i1`
+  template `and`(x, y): untyped            {.used.} = asy.br.`and`(derefBool x, derefBool y) # returns `i1`
 
   # Mutators
-  template setZero(x: Field): untyped      = asy.setZero(fd, x.buf)
-  template setOne(x: Field): untyped       = asy.setOne(fd, x.buf)
-  template neg(res, y: Field): untyped     = asy.neg(fd, res.buf, y.buf)
-  template neg(x: Field): untyped          =
+  template setZero(x: Field): untyped      {.used.} = asy.setZero(fd, x.buf)
+  template setOne(x: Field): untyped       {.used.} = asy.setOne(fd, x.buf)
+  template neg(res, y: Field): untyped     {.used.} = asy.neg(fd, res.buf, y.buf)
+  template neg(x: Field): untyped          {.used.} =
     var res = asy.newField(fd)
     res.store(x)
     x.neg(res)
 
   # Conditional setters
-  template csetZero(x: Field, c): untyped  = asy.csetZero(fd, x.buf, derefBool c)
-  template csetOne(x: Field, c): untyped   = asy.csetOne(fd, x.buf, derefBool c)
+  template csetZero(x: Field, c): untyped  {.used.} = asy.csetZero(fd, x.buf, derefBool c)
+  template csetOne(x: Field, c): untyped   {.used.} = asy.csetOne(fd, x.buf, derefBool c)
 
   # Basic arithmetic
-  template sum(res, x, y: Field): untyped  = asy.add(fd, res.buf, x.buf, y.buf)
-  template add(res, x, y: Field): untyped  = res.sum(x, y)
-  template diff(res, x, y: Field): untyped = asy.sub(fd, res.buf, x.buf, y.buf)
-  template prod(res, x, y: Field, skipFinalSub: bool): untyped = asy.mul(fd, res.buf, x.buf, y.buf, skipFinalSub)
-  template prod(res, x, y: Field): untyped = res.prod(x, y, skipFinalSub = false)
+  template sum(res, x, y: Field): untyped  {.used.} = asy.add(fd, res.buf, x.buf, y.buf)
+  template add(res, x, y: Field): untyped  {.used.} = res.sum(x, y)
+  template diff(res, x, y: Field): untyped {.used.} = asy.sub(fd, res.buf, x.buf, y.buf)
+  template prod(res, x, y: Field, skipFinalSub: bool): untyped {.used.} = asy.mul(fd, res.buf, x.buf, y.buf, skipFinalSub)
+  template prod(res, x, y: Field): untyped {.used.} = res.prod(x, y, skipFinalSub = false)
 
   # Conditional arithmetic
-  template cadd(x, y: Field, c): untyped   = asy.cadd(fd, x.buf, y.buf, derefBool c)
-  template csub(x, y: Field, c): untyped   = asy.csub(fd, x.buf, y.buf, derefBool c)
-  template ccopy(x, y: Field, c): untyped  = asy.ccopy(fd, x.buf, y.buf, derefBool c)
+  template cadd(x, y: Field, c): untyped   {.used.} = asy.cadd(fd, x.buf, y.buf, derefBool c)
+  template csub(x, y: Field, c): untyped   {.used.} = asy.csub(fd, x.buf, y.buf, derefBool c)
+  template ccopy(x, y: Field, c): untyped  {.used.} = asy.ccopy(fd, x.buf, y.buf, derefBool c)
 
   # Extended arithmetic
-  template square(res, y: Field, skipFinalSub: bool): untyped = asy.nsqr(fd, res.buf, y.buf, count = 1, skipFinalSub)
-  template square(res, y: Field): untyped  = res.square(y, skipFinalSub = false)
-  template square(x: Field, skipFinalSub: bool): untyped = square(x, x, skipFinalSub)
-  template square(x: Field): untyped       = square(x, x, skipFinalSub = false)
-  template double(res, x: Field): untyped  = asy.double(fd, res.buf, x.buf)
-  template double(x: Field): untyped       = x.double(x)
-  template div2(x: Field): untyped         = asy.div2(fd, x.buf)
+  template square(res, y: Field, skipFinalSub: bool): untyped {.used.} = asy.nsqr(fd, res.buf, y.buf, count = 1, skipFinalSub)
+  template square(res, y: Field): untyped  {.used.} = res.square(y, skipFinalSub = false)
+  template square(x: Field, skipFinalSub: bool): untyped {.used.} = square(x, x, skipFinalSub)
+  template square(x: Field): untyped       {.used.} = square(x, x, skipFinalSub = false)
+  template double(res, x: Field): untyped  {.used.} = asy.double(fd, res.buf, x.buf)
+  template double(x: Field): untyped       {.used.} = x.double(x)
+  template div2(x: Field): untyped         {.used.} = asy.div2(fd, x.buf)
 
   # Mutating assignment ops
-  template `*=`(x, y: Field): untyped      = x.prod(x, y)
-  template `+=`(x, y: Field): untyped      = x.add(x, y)
-  template `-=`(x, y: Field): untyped      = x.diff(x, y)
-  template `*=`(x: Field, b: int): untyped = asy.scalarMul(fd, x.buf, b)
+  template `*=`(x, y: Field): untyped      {.used.} = x.prod(x, y)
+  template `+=`(x, y: Field): untyped      {.used.} = x.add(x, y)
+  template `-=`(x, y: Field): untyped      {.used.} = x.diff(x, y)
+  template `*=`(x: Field, b: int): untyped {.used.} = asy.scalarMul(fd, x.buf, b)
 
   # Other helpers that do not warrant a full LLVM internal/public proc
-  template mulCheckSparse(x: Field, y: int) =
+  template mulCheckSparse(x: Field, y: int) {.used.} =
     ## Multiplication with optimization for sparse inputs
     ## intended to be used with curve `coaf_a` as argument `y`.
     if y == 1:
@@ -127,7 +127,6 @@ proc setZero*(asy: Assembler_LLVM, fd: FieldDescriptor, r: ValueRef) {.used.} =
           asy.void_t, toTypes([r]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
 
     let ri = llvmParams
     let rA = asy.asField(fd, ri)
@@ -151,7 +150,6 @@ proc setOne*(asy: Assembler_LLVM, fd: FieldDescriptor, r: ValueRef) {.used.} =
           asy.void_t, toTypes([r]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
     let ri = llvmParams
     let rF = asy.asField(fd, ri)
 
@@ -253,7 +251,6 @@ proc csetOne*(asy: Assembler_LLVM, fd: FieldDescriptor, r, c: ValueRef) {.used.}
           asy.void_t, toTypes([r, c]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
     let mOne = asy.getMontyOnePtr(fd)
 
     let (ri, ci) = llvmParams
@@ -277,7 +274,6 @@ proc csetZero*(asy: Assembler_LLVM, fd: FieldDescriptor, r, c: ValueRef) {.used.
           asy.void_t, toTypes([r, c]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
 
     let (ri, ci) = llvmParams
 
@@ -318,11 +314,9 @@ proc cadd*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, c: ValueRef) {.used.}
           asy.void_t, toTypes([r, a, c]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
 
     let (ri, ai, ci) = llvmParams
     let t = asy.newField(fd)          # temp field for `add`
-    let aA = asy.asField(fd, ai)
     asy.add(fd, t.buf, ri, ai)   # `t = r + b`
     asy.ccopy(fd, ai, t.buf, ci) # `a.ccopy(t, condition)`
 
@@ -364,7 +358,6 @@ proc csub*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, c: ValueRef) {.used.}
           asy.void_t, toTypes([r, a, c]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
 
     let (ri, ai, ci) = llvmParams
     let t = asy.newField(fd)          # temp field for `sub`
@@ -444,7 +437,6 @@ proc isZero*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a: ValueRef) {.used.} 
           asy.void_t, toTypes([r, a]),
           {kHot}):
     tagParameter(1, "sret")
-    let M = asy.getModulusPtr(fd)
 
     let (ri, ai) = llvmParams
     let aA = asy.asArray(ai, fd.fieldTy)
@@ -547,7 +539,6 @@ proc cneg*(asy: Assembler_LLVM, fd: FieldDescriptor, r, a, c: ValueRef) {.used.}
 
     tagParameter(1, "sret")
     let (ri, ai, ci) = llvmParams
-    let M = asy.getModulusPtr(fd)
 
     # first call the regular negation
     asy.neg(fd, ri, ai)
@@ -742,7 +733,6 @@ proc getWindowAt*(asy: Assembler_LLVM, cd: CurveDescriptor, r, c, bI, wI: ValueR
     declNumberOps(asy, cd.fd)
 
     let (ri, ci, bitIndex, windowSize) = llvmParams
-    let rA = asy.asFieldScalar(cd, ri)
     let cA = asy.asFieldScalar(cd, ci)
     let fd = cd.fd
 

--- a/constantine/math_compiler/impl_msm_nvidia.nim
+++ b/constantine/math_compiler/impl_msm_nvidia.nim
@@ -7,11 +7,9 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  constantine/platforms/llvm/[llvm, asm_nvidia],
-  constantine/platforms/[primitives],
+  constantine/platforms/llvm/llvm,
+  constantine/platforms/primitives,
   ./ir,
-  ./impl_fields_globals,
-  ./impl_fields_dispatch,
   ./impl_fields_ops,
   ./impl_curves_ops_affine,
   ./impl_curves_ops_jacobian,
@@ -58,7 +56,6 @@ proc msm*(asy: Assembler_LLVM, cd: CurveDescriptor, r, coefs, points: ValueRef,
 
     # Algorithm
     # ---------
-    var cNonZero = asy.initMutVal(cd.fd.wordTy)
     asy.llvmFor w, 0, numWindows - 1, true:
       # Place our points in a bucket corresponding to
       # how many times their bit pattern in the current window of size c

--- a/constantine/math_compiler/ir.nim
+++ b/constantine/math_compiler/ir.nim
@@ -950,27 +950,27 @@ template declNumberOps*(asy: Assembler_LLVM, fd: FieldDescriptor): untyped =
   template genLhsRhsVariants(name, fn: untyped): untyped =
     ## Generates variants for mix of Nim integer + ValueRef and
     ## pure ValueRef
-    type T = int | uint32 | uint64
+    type T {.used.} = int | uint32 | uint64
     type U = ValueRef | MutableValue | ConstantValue
     type X = MutableValue | ConstantValue
 
     let I = fd.wordTy
 
-    template name(lhs, rhs: ValueRef): untyped =
+    template name(lhs, rhs: ValueRef): untyped {.used.} =
       if $getTypeOf(lhs) != $getTypeOf(rhs):
         raise newException(ValueError, "Inputs do not have matching types. LHS = " & $getTypeOf(lhs) & ", RHS = " & $getTypeOf(rhs))
       elif getTypeOf(lhs).isPointerType():
         raise newException(ValueError, "Inputs must not be pointer types.")
       asy.br.fn(lhs, rhs)
-    template name(lhs: SomeInteger, rhs: U): untyped =
+    template name(lhs: SomeInteger, rhs: U): untyped {.used.} =
       block:
         let lhsV = constInt(I, lhs)
         asy.br.fn(lhsV, getValueRef rhs)
-    template name(lhs: U, rhs: SomeInteger): untyped =
+    template name(lhs: U, rhs: SomeInteger): untyped {.used.} =
       block:
         let rhsV = constInt(I, rhs)
         asy.br.fn(getValueRef lhs, rhsV)
-    template name[T: X; U: X](lhs: T; rhs: U): untyped =
+    template name[T: X; U: X](lhs: T; rhs: U): untyped {.used.} =
       asy.br.fn(getValueRef lhs, getValueRef rhs)
 
   template genLhsRhsBooleanVariants(name, pred: untyped): untyped =
@@ -982,21 +982,21 @@ template declNumberOps*(asy: Assembler_LLVM, fd: FieldDescriptor): untyped =
 
     let I = fd.wordTy
 
-    template name(lhs, rhs: ValueRef): untyped =
+    template name(lhs, rhs: ValueRef): untyped {.used.} =
       if $getTypeOf(lhs) != $getTypeOf(rhs):
         raise newException(ValueError, "Inputs do not have matching types. LHS = " & $getTypeOf(lhs) & ", RHS = " & $getTypeOf(rhs))
       elif getTypeOf(lhs).isPointerType():
         raise newException(ValueError, "Inputs must not be pointer types.")
       asy.br.icmp(pred, lhs, rhs)
-    template name(lhs: T; rhs: U): untyped =
+    template name(lhs: T; rhs: U): untyped {.used.} =
       block:
         let lhsV = constInt(I, lhs)
         name(lhsV, getValueRef rhs)
-    template name(lhs: U; rhs: T): untyped =
+    template name(lhs: U; rhs: T): untyped {.used.} =
       block:
         let rhsV = constInt(I, rhs)
         name(getValueRef lhs, rhsV)
-    template name[T: X; U: X](lhs: T; rhs: U): untyped =
+    template name[T: X; U: X](lhs: T; rhs: U): untyped {.used.} =
       name(getValueRef lhs, getValueRef rhs)
 
   # standard binary operations

--- a/constantine/math_compiler/pub_curves_jacobian.nim
+++ b/constantine/math_compiler/pub_curves_jacobian.nim
@@ -9,12 +9,8 @@
 # NOTE: We probably don't want the explicit `asm_nvidia` dependency here, I imagine? Currently it's
 # for direct usage of `slct` in `neg`.
 import
-  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/llvm/llvm,
   ./ir,
-  ./impl_fields_globals,
-  ./impl_fields_dispatch,
-  ./impl_fields_ops,
-  ./impl_curves_ops_affine,
   ./impl_curves_ops_jacobian,
   ./impl_msm_nvidia
 
@@ -61,7 +57,6 @@ proc genEcSetNeutral*(asy: Assembler_LLVM, cd: CurveDescriptor): string =
   ##
   ## It returns the corresponding name to call it
   let name = cd.name & "_setNeutral"
-  let ptrBool = pointer_t(asy.ctx.int1_t())
   asy.llvmPublicFnDef(name, "ctt." & cd.name, asy.void_t, [cd.curveTy]):
     let r = llvmParams
     asy.setNeutral(cd, r)

--- a/constantine/math_compiler/pub_fields.nim
+++ b/constantine/math_compiler/pub_fields.nim
@@ -9,7 +9,7 @@
 # NOTE: We probably don't want the explicit `asm_nvidia` dependency here, I imagine? Currently it's
 # for direct usage of `slct` in `neg`.
 import
-  constantine/platforms/llvm/[llvm, asm_nvidia],
+  constantine/platforms/llvm/llvm,
   ./ir,
   ./impl_fields_globals,
   ./impl_fields_dispatch,
@@ -57,8 +57,6 @@ proc genFpAdd*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
 
   let name = fd.name & "_add"
   asy.llvmPublicFnDef(name, "ctt." & fd.name, asy.void_t, [fd.fieldTy, fd.fieldTy, fd.fieldTy]):
-    let M = asy.getModulusPtr(fd)
-
     let (r, a, b) = llvmParams
     asy.add(fd, r, a, b)
     asy.br.retVoid()
@@ -73,7 +71,6 @@ proc genFpMul*(asy: Assembler_LLVM, fd: FieldDescriptor): string =
   ## and return the corresponding name to call it
   let name = fd.name & "_mul"
   asy.llvmPublicFnDef(name, "ctt." & fd.name, asy.void_t, [fd.fieldTy, fd.fieldTy, fd.fieldTy]):
-    let M = asy.getModulusPtr(fd)
     let (r, a, b) = llvmParams
     asy.mul(fd, r, a, b)
     asy.br.retVoid()

--- a/constantine/math_compiler/pub_fields.nim
+++ b/constantine/math_compiler/pub_fields.nim
@@ -6,8 +6,6 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# NOTE: We probably don't want the explicit `asm_nvidia` dependency here, I imagine? Currently it's
-# for direct usage of `slct` in `neg`.
 import
   constantine/platforms/llvm/llvm,
   ./ir,

--- a/constantine/named/constants/bandersnatch_endomorphisms.nim
+++ b/constantine/named/constants/bandersnatch_endomorphisms.nim
@@ -6,8 +6,9 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import
-    constantine/math/io/io_bigints
+{.used.} # The compiler misreports the file as unused (tested on Nim v2.2.8)
+
+import constantine/math/io/io_bigints
 
 # Bandersnatch
 # ------------------------------------------------------------

--- a/constantine/named/constants/banderwagon_endomorphisms.nim
+++ b/constantine/named/constants/banderwagon_endomorphisms.nim
@@ -6,8 +6,9 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import
-    constantine/math/io/io_bigints
+{.used.} # The compiler misreports the file as unused (tested on Nim v2.2.8)
+
+import constantine/math/io/io_bigints
 
 # Banderwagon
 # ------------------------------------------------------------

--- a/constantine/named/constants/secp256k1_endomorphisms.nim
+++ b/constantine/named/constants/secp256k1_endomorphisms.nim
@@ -6,6 +6,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.} # The compiler misreports the file as unused (tested on Nim v2.2.8)
+
 import
   constantine/named/algebras,
   constantine/math/io/[io_bigints, io_fields]

--- a/constantine/named/properties_fields.nim
+++ b/constantine/named/properties_fields.nim
@@ -27,6 +27,7 @@ template matchingBigInt*(Name: static Algebra): untyped =
   # Workaround: https://github.com/nim-lang/Nim/issues/16774
   # as we cannot do array accesses in type section.
   # Due to generic sandwiches, it must be exported.
+  bind BigInt
   BigInt[CurveBitWidth[Name]]
 
 template matchingOrderBigInt*(Name: static Algebra): untyped =
@@ -34,6 +35,7 @@ template matchingOrderBigInt*(Name: static Algebra): untyped =
   # Workaround: https://github.com/nim-lang/Nim/issues/16774
   # as we cannot do array accesses in type section.
   # Due to generic sandwiches, it must be exported.
+  bind BigInt
   BigInt[CurveOrderBitWidth[Name]]
 
 type

--- a/constantine/platforms/constant_time/ct_routines.nim
+++ b/constantine/platforms/constant_time/ct_routines.nim
@@ -122,14 +122,17 @@ template `-`*[T: Ct](x: T): T =
 
 template isMsbSet*[T: Ct](x: T): CTBool[T] =
   ## Returns the most significant bit of an integer
+  bind CTBool
   const msb_pos = T.sizeof * 8 - 1
   (CTBool[T])(x shr msb_pos)
 
 template fmap[T: Ct](x: CTBool[T], op: untyped, y: CTBool[T]): CTBool[T] =
+  bind CTBool
   CTBool[T](op(T(x), T(y)))
 
 template `not`*[T: Ct](ctl: CTBool[T]): CTBool[T] =
   ## Negate a constant-time boolean
+  bind CTBool
   CTBool[T](T(ctl) xor T(1))
 
 template `and`*(x, y: CTBool): CTBool = fmap(x, `and`, y)

--- a/constantine/platforms/loadtime_functions.nim
+++ b/constantine/platforms/loadtime_functions.nim
@@ -15,6 +15,8 @@
 # Implement functions that are automatically called at program/library load time.
 # Note: They cannot use {.global.} variables as {.global.} are initialized by Nim routines
 
+{.used.} # The compiler UnusedImport seems to misreports macro as pragma (Nim v2.2.8)
+
 import std/macros, ./config
 
 macro loadTime*(procAst: untyped): untyped =

--- a/constantine/proof_systems/constraint_systems/r1cs_circom_parser.nim
+++ b/constantine/proof_systems/constraint_systems/r1cs_circom_parser.nim
@@ -17,7 +17,7 @@
 # - should allow parallelization, down to field -> raw bytes, before writing to file or inversely
 
 import
-  ../../serialization/[io_limbs, parsing],
+  ../../serialization/parsing,
   constantine/platforms/[fileio, abstractions]
 
 # We use `sortedByIt` to sort the different sections in the file by their
@@ -231,7 +231,6 @@ proc parseR1csFile*(path: string): R1csBin =
   result.sections = newSeq[Section](result.numberSections)
   # 1. determine the section kind, size & file position for each section in the file
   var pos = newSeq[(R1csSectionKind, uint64, int64)](result.numberSections)
-  let fp = f.getFilePosition()
   for i in 0 ..< result.numberSections:
     var kind: R1csSectionKind
     var size: uint64 # section size

--- a/constantine/signatures/bls_signatures.nim
+++ b/constantine/signatures/bls_signatures.nim
@@ -224,8 +224,8 @@ func finalVerify*[F, G](ctx: var BLSAggregateSigAccumulator, aggregateSignature:
   ## Returns false if nothing was accumulated
   ## Rteturns false on verification failure
 
-  type FF1 = BLSAggregateSigAccumulator.FF1
-  type FF2 = BLSAggregateSigAccumulator.FF2
+  type FF1 {.used.} = BLSAggregateSigAccumulator.FF1
+  type FF2 {.used.} = BLSAggregateSigAccumulator.FF2
   type Fpk = BLSAggregateSigAccumulator.Fpk
 
   when G == G2:
@@ -507,8 +507,8 @@ func finalVerify*(ctx: var BLSBatchSigAccumulator): bool =
   if not ctx.aggSigOnce:
     return false
 
-  type FF1 = BLSBatchSigAccumulator.FF1
-  type FF2 = BLSBatchSigAccumulator.FF2
+  type FF1 {.used.} = BLSBatchSigAccumulator.FF1
+  type FF2 {.used.} = BLSBatchSigAccumulator.FF2
   type Fpk = BLSBatchSigAccumulator.Fpk
 
   when BLSBatchSigAccumulator.SigAccum.G == G2:

--- a/constantine/signatures/ecc_sig_ops.nim
+++ b/constantine/signatures/ecc_sig_ops.nim
@@ -6,10 +6,7 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import
-    constantine/math/[ec_shortweierstrass],
-    constantine/named/zoo_generators,
-    constantine/named/algebras
+import constantine/math/[ec_shortweierstrass]
 
 func derivePubkey*[Pubkey, SecKey](pubkey: var Pubkey, seckey: SecKey) =
   ## Generates the public key associated with the input secret key.
@@ -18,7 +15,6 @@ func derivePubkey*[Pubkey, SecKey](pubkey: var Pubkey, seckey: SecKey) =
   ## 0 is INVALID
   const Group = Pubkey.G
   type Field = Pubkey.F
-  const EC = Field.Name
 
   var pk {.noInit.}: EC_ShortW_Jac[Field, Group]
   pk.setGenerator()

--- a/constantine/signatures/ecdsa.nim
+++ b/constantine/signatures/ecdsa.nim
@@ -9,11 +9,10 @@
 import
   constantine/hashes,
   constantine/named/algebras,
-  constantine/math/io/[io_bigints, io_fields, io_ec],
+  constantine/math/io/[io_bigints, io_fields],
   constantine/math/elliptic/[ec_shortweierstrass_affine, ec_shortweierstrass_jacobian, ec_scalar_mul, ec_multi_scalar_mul],
   constantine/math/[arithmetic, ec_shortweierstrass],
   constantine/platforms/[abstractions, views],
-  constantine/serialization/codecs, # for fromHex and (in the future) base64 encoding
   constantine/mac/mac_hmac, # for deterministic nonce generation via RFC 6979
   constantine/named/zoo_generators, # for generator
   constantine/csprngs/sysrand,
@@ -348,7 +347,7 @@ proc recoverPubkeyImpl_vartime*[Name: static Algebra; Sig](
   var validSig = false
   while (not validSig) and bool(x1.toBig() <= rInit):
     # 1. Get base `R` point
-    var R {.noinit.}: EC_ShortW_Aff[Fp[Name], G1]
+    var R {.noinit.}: ECAff
     let valid = R.trySetFromCoordX(x1) # from `r = x1`
     if not bool(valid):
       x1 += M # add modulus of `Fr`. As long as we don't overflow in `Fp` we try again

--- a/constantine/threadpool/crossthread/scoped_barriers.nim
+++ b/constantine/threadpool/crossthread/scoped_barriers.nim
@@ -61,11 +61,11 @@ type
 # Note: If one is defined, the other destructors proc are not implictly create inline
 #       even if trivial
 
-proc `=`*(dst: var ScopedBarrier, src: ScopedBarrier) {.error: "A scoped barrier cannot be copied.".}
+proc `=copy`*(dst: var ScopedBarrier, src: ScopedBarrier) {.error: "A scoped barrier cannot be copied.".}
 
 proc `=sink`*(dst: var ScopedBarrier, src: ScopedBarrier) {.inline.} =
   # Nim doesn't respect noinit and tries to zeroMem then move the type
-  {.warning: "Moving a shared resource (an atomic type).".}
+  # {.warning: "Moving a shared resource (an atomic type).".}
   system.`=sink`(dst.descendants, src.descendants)
 
 proc `=destroy`*(sb: var ScopedBarrier) {.inline.}=

--- a/constantine/threadpool/instrumentation.nim
+++ b/constantine/threadpool/instrumentation.nim
@@ -145,8 +145,12 @@ macro defCountersType*(name: untyped, countersDesc: static seq[tuple[field, desc
     records.add newIdentDefs(ident(field), ident"int64")
 
   result = nnkTypeSection.newTree(
+    # type Counters {.used.} = object
     nnkTypeDef.newTree(
-      name,
+      nnkPragmaExpr.newTree(
+        name,
+        nnkPragma.newTree(ident"used")
+      ),
       newEmptyNode(),
       nnkObjectTy.newTree(
         newEmptyNode(),

--- a/constantine/threadpool/parallel_offloading.nim
+++ b/constantine/threadpool/parallel_offloading.nim
@@ -555,7 +555,7 @@ proc generateClosure(ld: LoopDescriptor): NimNode =
       proc `closureName`(env: pointer) {.nimcall, gcsafe, raises: [].} =
         let taskSelfReference = cast[ptr ptr Task](env)
         when bool(`withCaptures`):
-          let offset = cast[ByteAddress](env) +% sizeof((ptr Task, `retTy`))
+          let offset = cast[int](env) +% sizeof((ptr Task, `retTy`))
           let `env` = cast[ptr `capturedTypes`](offset)
         let res = `loopFnCall`
         readyWith(taskSelfReference[], res)

--- a/constantine/threadpool/primitives/topology_linux.nim
+++ b/constantine/threadpool/primitives/topology_linux.nim
@@ -27,7 +27,9 @@ proc queryNumPhysicalCoresLinux*(): cint =
   ##
   ## This can only handle up to 64 cores (logical or physical)
   ## CPU-based solutions using CPUID-like instructions should be preferred.
-  {.warning: "queryNumPhysicalCoresLinux: Only up to 64 cores can be handled on Linux at the moment.".}
+
+  # Currently parent function `getNumCoresPhysical()` is unused
+  # {.warning: "queryNumPhysicalCoresLinux: Only up to 64 cores can be handled on Linux at the moment.".}
   result = 0
 
   var logiCoresBitField = culonglong 0

--- a/tests/gpu/t_msm.nim
+++ b/tests/gpu/t_msm.nim
@@ -14,9 +14,7 @@ import
   constantine/math/elliptic/[ec_shortweierstrass_affine, ec_shortweierstrass_jacobian, ec_multi_scalar_mul],
   constantine/platforms/abstractions,
   constantine/platforms/llvm/llvm,
-  constantine/math_compiler/[ir, pub_fields, pub_curves_jacobian, codegen_nvidia, impl_fields_globals],
-  # Test utilities
-  helpers/prng_unsafe
+  constantine/math_compiler/[ir, pub_curves_jacobian, codegen_nvidia]
 
 type
   EC = EC_ShortW_Jac[Fp[BN254_Snarks], G1]

--- a/tests/t_ethereum_eip4844_deneb_kzg_parallel.nim
+++ b/tests/t_ethereum_eip4844_deneb_kzg_parallel.nim
@@ -173,21 +173,22 @@ testGen(compute_kzg_proof, testVector):
   else:
     doAssert testVector["output"].content == "null"
 
-testGen(verify_kzg_proof, testVector):
-  parseAssign(commitment, 48, testVector["input"]["commitment"].content)
-  parseAssign(z,          32, testVector["input"]["z"].content)
-  parseAssign(y,          32, testVector["input"]["y"].content)
-  parseAssign(proof,      48, testVector["input"]["proof"].content)
-
-  let status = ctx.verify_kzg_proof(commitment[], z[], y[], proof[])
-  stdout.write "[" & $status & "]\n"
-
-  if status == cttEthKzg_Success:
-    doAssert testVector["output"].content == "true"
-  elif status == cttEthKzg_VerificationFailure:
-    doAssert testVector["output"].content == "false"
-  else:
-    doAssert testVector["output"].content == "null"
+# Test is not parallel
+# testGen(verify_kzg_proof, testVector):
+#   parseAssign(commitment, 48, testVector["input"]["commitment"].content)
+#   parseAssign(z,          32, testVector["input"]["z"].content)
+#   parseAssign(y,          32, testVector["input"]["y"].content)
+#   parseAssign(proof,      48, testVector["input"]["proof"].content)
+#
+#   let status = ctx.verify_kzg_proof(commitment[], z[], y[], proof[])
+#   stdout.write "[" & $status & "]\n"
+#
+#   if status == cttEthKzg_Success:
+#     doAssert testVector["output"].content == "true"
+#   elif status == cttEthKzg_VerificationFailure:
+#     doAssert testVector["output"].content == "false"
+#   else:
+#     doAssert testVector["output"].content == "null"
 
 testGen(compute_blob_kzg_proof, testVector):
   parseAssign(blob,  32*4096, testVector["input"]["blob"].content)

--- a/tests/t_hash_keccak_sha3_vs_openssl.nim
+++ b/tests/t_hash_keccak_sha3_vs_openssl.nim
@@ -28,7 +28,7 @@ else:
 # OpenSSL wrapper
 # --------------------------------------------------------------------
 # Hash API isn't available on Windows, MacOS uses LibreSSL which doesn't provide OpenSSL 3.0 API as well
-when not defined(windows) and not defined(macosx):
+when false: # seems unavailable on al platforms now including Linux
   proc EVP_Q_digest[T: byte|char](
                   ossl_libctx: pointer,
                   algoName: cstring,
@@ -107,7 +107,7 @@ proc t_keccak256_abclong =
 const SmallSizeIters = 64
 const LargeSizeIters =  1
 
-when not defined(windows) and not defined(macosx):
+when false:
   proc innerTest(rng: var RngState, sizeRange: Slice[int]) =
     let size = rng.random_unsafe(sizeRange)
     let msg = rng.random_byte_seq(size)
@@ -172,7 +172,7 @@ proc main() =
   var rng: RngState
   rng.seed(0xFACADE)
 
-  when not defined(windows) and not defined(macosx):
+  when false:
     echo "SHA3-256 - 0 <= size < 64 - exhaustive"
     for i in 0 ..< 64:
       rng.innerTest(i .. i)
@@ -183,7 +183,7 @@ proc main() =
   for i in 0 ..< 64:
     rng.chunkTest(i .. i)
 
-  when not defined(windows)and not defined(macosx):
+  when false:
     echo "SHA3-256 - 135 <= size < 138 - exhaustive (sponge rate = 136)"
     for i in 135 ..< 138:
       rng.innerTest(i .. i)
@@ -194,7 +194,7 @@ proc main() =
   for i in 135 ..< 138:
     rng.chunkTest(i .. i)
 
-  when not defined(windows) and not defined(macosx):
+  when false:
     echo "SHA3-256 - 64 <= size < 1024B"
     for _ in 0 ..< SmallSizeIters:
       rng.innerTest(0 ..< 1024)
@@ -203,7 +203,7 @@ proc main() =
   for _ in 0 ..< SmallSizeIters:
     rng.chunkTest(0 ..< 1024)
 
-  when not defined(windows) and not defined(macosx):
+  when false:
     echo "SHA3-256 - 1MB <= size < 50MB"
     for _ in 0 ..< LargeSizeIters:
       rng.innerTest(1_000_000 ..< 50_000_000)


### PR DESCRIPTION
This fixes most compilation warnings and hints.

Tested on:
- EIP 4844 KZG (tests KZG, serialization, hashes, pairings, ...)
  - Parallel KZG
- BLS Signatures
- lib_constantine (tests everything exported to C/Rust/Go and all curves and field primitives)
- EVM precompiles
- Verkle
- Poly1305, HMAC, HKDF, Chacha20
- R1CS
- Polynomials
- Multilinear extensions

Has leftover:
- LLVM IR + Nvidia PTX codegen
- NVRTC compiler (unexpected Ast node to fix)

I've also removed SHA3 tests against OpenSSL as `EVP_Q_digest` support is very spotty: not on Windows, MacOS (libressl) or my dev machine (Archlinux).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Renamed internal cryptographic constants for clearer, more consistent naming.

* **Code Cleanup**
  * Removed unused imports and local variables across modules to simplify builds.

* **Chores**
  * Added compiler pragmas and tightened type-size assertions to reduce warnings and improve build reliability.

* **Tests**
  * Disabled or silenced select platform-specific tests to avoid flaky or unsupported executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->