### PR TITLE
[EC] Fix mutable assignment in batch affine - followup #579

### DIFF
--- a/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
+++ b/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim
@@ -42,21 +42,21 @@ func batchAffine*[F, G](
 
   # To avoid temporaries, we store partial accumulations
   # in affs[i].x and affs[i].y will store if the input was 0
-  template zero(i: int): SecretBool =
+  template zero(i: int): SecretWord =
     when F is Fp:
-      SecretBool affs[i].y.mres.limbs[0]
+      affs[i].y.mres.limbs[0]
     else:
-      SecretBool affs[i].y.coords[0].mres.limbs[0]
+      affs[i].y.coords[0].mres.limbs[0]
 
   affs[0].x = projs[0].z
-  zero(0) = affs[0].x.isZero()
-  affs[0].x.csetOne(zero(0))
+  zero(0) = SecretWord affs[0].x.isZero()
+  affs[0].x.csetOne(SecretBool zero(0))
 
   for i in 1 ..< N:
     # Skip zero z-coordinates (infinity points)
     var z = projs[i].z
-    zero(i) = z.isZero()
-    z.csetOne(zero(i))
+    zero(i) = SecretWord z.isZero()
+    z.csetOne(SecretBool zero(i))
 
     if i != N-1:
       affs[i].x.prod(affs[i-1].x, z, lazyReduce = true)
@@ -70,11 +70,11 @@ func batchAffine*[F, G](
     # Extract 1/Pᵢ
     var invi {.noInit.}, invi_next {.noInit.}: F
     invi.prod(accInv, affs[i-1].x, lazyReduce = true)
-    invi.csetZero(zero(i))
+    invi.csetZero(SecretBool zero(i))
 
     # next iteration (zero and affs[i].y are aliasing)
     invi_next = projs[i].z
-    invi_next.csetOne(zero(i))
+    invi_next.csetOne(SecretBool zero(i))
     accInv.prod(accInv, invi_next, lazyReduce = true)
 
     # Now convert Pᵢ to affine
@@ -82,7 +82,7 @@ func batchAffine*[F, G](
     affs[i].y.prod(projs[i].y, invi)
 
   block: # tail
-    accInv.csetZero(zero(0))
+    accInv.csetZero(SecretBool zero(0))
     affs[0].x.prod(projs[0].x, accInv)
     affs[0].y.prod(projs[0].y, accInv)
 
@@ -107,21 +107,21 @@ func batchAffine*[F, G](
 
   # To avoid temporaries, we store partial accumulations
   # in affs[i].x and whether z == 0 in affs[i].y
-  template zero(i: int): SecretBool =
+  template zero(i: int): SecretWord =
     when F is Fp:
-      SecretBool affs[i].y.mres.limbs[0]
+      affs[i].y.mres.limbs[0]
     else:
-      SecretBool affs[i].y.coords[0].mres.limbs[0]
+      affs[i].y.coords[0].mres.limbs[0]
 
   affs[0].x  = jacs[0].z
-  zero(0) = affs[0].x.isZero()
-  affs[0].x.csetOne(zero(0))
+  zero(0) = SecretWord affs[0].x.isZero()
+  affs[0].x.csetOne(SecretBool zero(0))
 
   for i in 1 ..< N:
     # Skip zero z-coordinates (infinity points)
     var z = jacs[i].z
-    zero(i) = z.isZero()
-    z.csetOne(zero(i))
+    zero(i) = SecretWord z.isZero()
+    z.csetOne(SecretBool zero(i))
 
     if i != N-1:
       affs[i].x.prod(affs[i-1].x, z, lazyReduce = true)
@@ -135,11 +135,11 @@ func batchAffine*[F, G](
     # Extract 1/Pᵢ
     var invi {.noInit.}, invi_next {.noInit.}: F
     invi.prod(accInv, affs[i-1].x, lazyReduce = true)
-    invi.csetZero(zero(i))
+    invi.csetZero(SecretBool zero(i))
 
     # next iteration (zero and affs[i].y are aliasing)
     invi_next = jacs[i].z
-    invi_next.csetOne(zero(i))
+    invi_next.csetOne(SecretBool zero(i))
     accInv.prod(accInv, invi_next, lazyReduce = true)
 
     # Now convert Pᵢ to affine
@@ -152,7 +152,7 @@ func batchAffine*[F, G](
 
   block: # tail
     var invi2 {.noinit.}: F
-    accInv.csetZero(zero(0))
+    accInv.csetZero(SecretBool zero(0))
     invi2.square(accInv, lazyReduce = true)
     affs[0].x.prod(jacs[0].x, invi2)
     accInv.prod(accInv, invi2, lazyReduce = true)


### PR DESCRIPTION
Currently we have a failure `constantine/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim(52, 3) Error: 'SecretBool(affs[0].y.mres.limbs[0])' cannot be assigned to`

This is because after #579, the `SecretWord myExpression` creates an immutable expression

https://github.com/mratsim/constantine/blob/cedcf0da4b72964154edd1701bb51ae77426e6c5/constantine/math/elliptic/ec_shortweierstrass_batch_ops.nim#L45-L59

The strange thing is that, when compiling through `nimble test` or `nimble test_parallel` that do a simple exec, compilation works and test is run:

<img width="3211" height="962" alt="image" src="https://github.com/user-attachments/assets/6ce3b703-7a92-485d-aece-839a2b6085b2" />

but compiling the code directly triggers a compiler error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal consistency and performance in cryptographic batch operations through improved type handling in elliptic curve computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->