### PR TITLE
Try disabling LTO to fix Go CI failures

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -102,7 +102,7 @@ proc getEnvVars(): tuple[useAsmIfAble, force32, forceLto, useLtoDefault: bool] =
     result.useLtoDefault = false
   else:
     result.forceLto = false
-    result.useLtoDefault = true
+    result.useLtoDefault = false # GCC 15 LTO bug - https://github.com/mratsim/constantine/issues/588
 
 # Library compilation
 # ----------------------------------------------------------------


### PR DESCRIPTION
This tries to fix #595 by disabling LTO as this is the latest suspicious upstream change #588 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Link Time Optimization (LTO) by default to prevent compilation issues with GCC 15. LTO can still be explicitly enabled via environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->