### PR TITLE
Workaround GMP regressions and breaking changes from https://github.com/subsetpark/nim-gmp/pull/3

### DIFF
--- a/benchmarks/bench_gmp_modexp.nim
+++ b/benchmarks/bench_gmp_modexp.nim
@@ -83,10 +83,10 @@ for i in 0 ..< 5:
     mpz_init(mm)
     mpz_init(rr)
 
-    aa.mpz_import(a.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, a.limbs[0].unsafeAddr)
+    aa.mpz_import(a.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a.limbs[0].unsafeAddr)
     let e = BigInt[expBits].unmarshal(exponent, bigEndian)
-    ee.mpz_import(e.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, e.limbs[0].unsafeAddr)
-    mm.mpz_import(M.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, M.limbs[0].unsafeAddr)
+    ee.mpz_import(e.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, e.limbs[0].unsafeAddr)
+    mm.mpz_import(M.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, M.limbs[0].unsafeAddr)
 
     let start = getMonotime()
     rr.mpz_powm(aa, ee, mm)
@@ -95,16 +95,19 @@ for i in 0 ..< 5:
     elapsedGMP = inNanoSeconds(stop-start)
 
     var r: BigInt[bits]
-    var rWritten: csize
-    discard r.limbs[0].addr.mpz_export(rWritten.addr, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, rr)
+    var rWritten: csize_t
+    discard r.limbs[0].addr.mpz_export(rWritten.addr, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, rr)
 
     echo "  r GMP:               ", r.toHex()
     echo "  elapsed GMP:         ", elapsedGMP, " ns"
 
-    mpz_clear(rr)
-    mpz_clear(mm)
-    mpz_clear(ee)
-    mpz_clear(aa)
+    # Commented out: =destroy regression introduced in nim-gmp PR#3
+    # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+    # Destructors were specifically removed with motivated explanation in PR#2
+    # mpz_clear(rr)
+    # mpz_clear(mm)
+    # mpz_clear(ee)
+    # mpz_clear(aa)
 
   # echo &"\n  ratio Stint/Constantine: {float64(elapsedStint)/float64(elapsedCtt):.3f}x"
   echo &"  ratio GMP/Constantine: {float64(elapsedGMP)/float64(elapsedCtt):.3f}x"

--- a/benchmarks/bench_gmp_modmul.nim
+++ b/benchmarks/bench_gmp_modmul.nim
@@ -61,11 +61,14 @@ proc main() =
   mpz_init(rMod)
   mpz_init(a)
   mpz_init(b)
-  defer:
-    mpz_clear(b)
-    mpz_clear(a)
-    mpz_clear(rMod)
-    mpz_clear(r)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # defer:
+  #   mpz_clear(b)
+  #   mpz_clear(a)
+  #   mpz_clear(rMod)
+  #   mpz_clear(r)
 
   testSizes(rBits, aBits, bBits):
     # echo "--------------------------------------------------------------------------------"
@@ -86,8 +89,8 @@ proc main() =
     aBuf.marshal(aTest, bigEndian)
     bBuf.marshal(bTest, bigEndian)
 
-    mpz_import(a, aLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, aBuf[0].addr)
-    mpz_import(b, bLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, bBuf[0].addr)
+    mpz_import(a, aLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aBuf[0].addr)
+    mpz_import(b, bLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, bBuf[0].addr)
 
     #########################################################
     # Multiplication
@@ -164,22 +167,20 @@ proc main() =
     #########################################################
     # Check
 
-    {.push warnings: off.} # deprecated csize
-    var aW, bW, rW: csize  # Word written by GMP
-    {.pop.}
+    var aW, bW, rW: csize_t  # Word written by GMP
 
     const rLen = numWords * WordBitWidth
     var rGMP: array[rLen, byte]
-    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, r)
+    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, r)
 
     var rConstantine: array[rLen, byte]
     marshal(rConstantine, rTest, bigEndian)
 
     # Note: in bigEndian, GMP aligns left while constantine aligns right
-    doAssert rGMP.toOpenArray(0, rW-1) == rConstantine.toOpenArray(rLen-rW, rLen-1), block:
+    doAssert rGMP.toOpenArray(0, rW.int-1) == rConstantine.toOpenArray(rLen-rW.int, rLen-1), block:
       # Reexport as bigEndian for debugging
-      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, a)
-      discard mpz_export(bBuf[0].addr, bW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, b)
+      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a)
+      discard mpz_export(bBuf[0].addr, bW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, b)
       "\nMultiplication with operands\n" &
       "  a (" & align($aBits, 4) & "-bit):   " & aBuf.toHex & "\n" &
       "  b (" & align($bBits, 4) & "-bit):   " & bBuf.toHex & "\n" &

--- a/benchmarks/bench_powmod.nim
+++ b/benchmarks/bench_powmod.nim
@@ -140,11 +140,11 @@ proc benchAll(desc: seq[BenchDesc]) =
 
     for i in 0 ..< desc.len:
       let aCtt = BigInt[bits].fromHex(desc[i].a)
-      a.mpz_import(aCtt.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, aCtt.limbs[0].unsafeAddr)
+      a.mpz_import(aCtt.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aCtt.limbs[0].unsafeAddr)
       let eCtt = BigInt[bits].fromHex(desc[i].e)
-      e.mpz_import(eCtt.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, eCtt.limbs[0].unsafeAddr)
+      e.mpz_import(eCtt.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, eCtt.limbs[0].unsafeAddr)
       let mCtt = BigInt[bits].fromHex(desc[i].M)
-      M.mpz_import(mCtt.limbs.len, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, mCtt.limbs[0].unsafeAddr)
+      M.mpz_import(mCtt.limbs.len.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, mCtt.limbs[0].unsafeAddr)
 
       bench(
         r.mpz_powm(a, e, M),
@@ -153,10 +153,13 @@ proc benchAll(desc: seq[BenchDesc]) =
     report("GMP", nanoseconds, ticks, desc.len)
     perfGMP = nanoseconds
 
-    mpz_clear(r)
-    mpz_clear(M)
-    mpz_clear(e)
-    mpz_clear(a)
+    # Commented out: =destroy regression introduced in nim-gmp PR#3
+    # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+    # Destructors were specifically removed with motivated explanation in PR#2
+    # mpz_clear(r)
+    # mpz_clear(M)
+    # mpz_clear(e)
+    # mpz_clear(a)
 
   block: # Stint
     var ticks, nanoseconds: int64

--- a/tests/math_arbitrary_precision/t_bigints_mod_vs_gmp.nim
+++ b/tests/math_arbitrary_precision/t_bigints_mod_vs_gmp.nim
@@ -120,8 +120,8 @@ proc main() =
     aBuf.marshal(aTest, bigEndian)
     mBuf.marshal(mTest, bigEndian)
 
-    mpz_import(a, aLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, aBuf[0].addr)
-    mpz_import(m, mLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, mBuf[0].addr)
+    mpz_import(a, aLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aBuf[0].addr)
+    mpz_import(m, mLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, mBuf[0].addr)
 
     #########################################################
     # Modulus
@@ -134,12 +134,10 @@ proc main() =
     #########################################################
     # Check
 
-    {.push warnings: off.} # deprecated csize
-    var aW, mW, rW: csize  # Words written by GMP
-    {.pop.}
+    var aW, mW, rW: csize_t  # Words written by GMP
 
     var rGMP: array[mLen, byte]
-    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, r)
+    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, r)
 
     var rConstantine, rCttVartime: array[mLen, byte]
     marshal(rConstantine, rTest, bigEndian)
@@ -149,10 +147,10 @@ proc main() =
     # echo "rConstantine: ", rConstantine.toHex()
 
     # Note: in bigEndian, GMP aligns left while constantine aligns right
-    doAssert rGMP.toOpenArray(0, rW-1) == rConstantine.toOpenArray(mLen-rW, mLen-1), block:
+    doAssert rGMP.toOpenArray(0, rW.int-1) == rConstantine.toOpenArray(mLen-rW.int, mLen-1), block:
       # Reexport as bigEndian for debugging
-      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, a)
-      discard mpz_export(mBuf[0].addr, mW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, m)
+      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a)
+      discard mpz_export(mBuf[0].addr, mW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, m)
       "\nModulus with operands\n" &
       "  a (" & align($aBits, 4) & "-bit):   " & aBuf.toHex & "\n" &
       "  m (" & align($mBits, 4) & "-bit):   " & mBuf.toHex & "\n" &
@@ -161,9 +159,9 @@ proc main() =
       "  Constantine:    " & rConstantine.toHex() & "\n" &
       "(Note that GMP aligns bytes left while constantine aligns bytes right)"
 
-    doAssert rGMP.toOpenArray(0, rW-1) == rCttVartime.toOpenArray(mLen-rW, mLen-1), block:
+    doAssert rGMP.toOpenArray(0, rW.int-1) == rCttVartime.toOpenArray(mLen-rW.int, mLen-1), block:
       # Reexport as bigEndian for debugging
-      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, a)
+      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a)
       discard mpz_export(mBuf[0].addr, mW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, m)
       "\nModulus with operands\n" &
       "  a (" & align($aBits, 4) & "-bit):   " & aBuf.toHex & "\n" &
@@ -173,8 +171,11 @@ proc main() =
       "  Constantine:    " & rCttVartime.toHex() & "\n" &
       "(Note that GMP aligns bytes left while constantine aligns bytes right)"
 
-  mpz_clear(r)
-  mpz_clear(m)
-  mpz_clear(a)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # mpz_clear(r)
+  # mpz_clear(m)
+  # mpz_clear(a)
 
 main()

--- a/tests/math_arbitrary_precision/t_bigints_powmod_vs_gmp.nim
+++ b/tests/math_arbitrary_precision/t_bigints_powmod_vs_gmp.nim
@@ -71,19 +71,22 @@ proc test(rng: var RngState) =
   mpz_init(mm)
   mpz_init(rr)
 
-  aa.mpz_import(aLen, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, a[0].addr)
-  ee.mpz_import(eLen, GMP_MostSignificantWordFirst, sizeof(byte), GMP_WordNativeEndian, 0, e[0].addr)
-  mm.mpz_import(mLen, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, M[0].addr)
+  aa.mpz_import(aLen.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a[0].addr)
+  ee.mpz_import(eLen.csize_t, GMP_MostSignificantWordFirst.cint, sizeof(byte).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, e[0].addr)
+  mm.mpz_import(mLen.csize_t, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, M[0].addr)
 
   rr.mpz_powm(aa, ee, mm)
 
-  var rWritten: csize
-  discard rGMP[0].addr.mpz_export(rWritten.addr, GMP_LeastSignificantWordFirst, sizeof(SecretWord), GMP_WordNativeEndian, 0, rr)
+  var rWritten: csize_t
+  discard rGMP[0].addr.mpz_export(rWritten.addr, GMP_LeastSignificantWordFirst.cint, sizeof(SecretWord).csize_t, GMP_WordNativeEndian.cint, 0.csize_t, rr)
 
-  mpz_clear(rr)
-  mpz_clear(mm)
-  mpz_clear(ee)
-  mpz_clear(aa)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # mpz_clear(rr)
+  # mpz_clear(mm)
+  # mpz_clear(ee)
+  # mpz_clear(aa)
 
   let
     aBits = a.getBits_LE_vartime()

--- a/tests/math_bigints/t_bigints_mul_high_words_vs_gmp.nim
+++ b/tests/math_bigints/t_bigints_mul_high_words_vs_gmp.nim
@@ -63,10 +63,13 @@ proc main() =
   mpz_init(r)
   mpz_init(a)
   mpz_init(b)
-  defer:
-    mpz_clear(b)
-    mpz_clear(a)
-    mpz_clear(r)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # defer:
+  #   mpz_clear(b)
+  #   mpz_clear(a)
+  #   mpz_clear(r)
 
   testRandomModSizes(12, rBits, aBits, bBits, wordsStartIndex):
     # echo "--------------------------------------------------------------------------------"
@@ -91,8 +94,8 @@ proc main() =
     aBuf.marshal(aTest, bigEndian)
     bBuf.marshal(bTest, bigEndian)
 
-    mpz_import(a, aLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, aBuf[0].addr)
-    mpz_import(b, bLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, bBuf[0].addr)
+    mpz_import(a, aLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aBuf[0].addr)
+    mpz_import(b, bLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, bBuf[0].addr)
 
     #########################################################
     # Multiplication + drop low words

--- a/tests/math_bigints/t_bigints_mul_vs_gmp.nim
+++ b/tests/math_bigints/t_bigints_mul_vs_gmp.nim
@@ -61,10 +61,13 @@ proc main() =
   mpz_init(r)
   mpz_init(a)
   mpz_init(b)
-  defer:
-    mpz_clear(b)
-    mpz_clear(a)
-    mpz_clear(r)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # defer:
+  #   mpz_clear(b)
+  #   mpz_clear(a)
+  #   mpz_clear(r)
 
   testRandomModSizes(12, rBits, aBits, bBits):
     # echo "--------------------------------------------------------------------------------"
@@ -85,8 +88,8 @@ proc main() =
     aBuf.marshal(aTest, bigEndian)
     bBuf.marshal(bTest, bigEndian)
 
-    mpz_import(a, aLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, aBuf[0].addr)
-    mpz_import(b, bLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, bBuf[0].addr)
+    mpz_import(a, aLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aBuf[0].addr)
+    mpz_import(b, bLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, bBuf[0].addr)
 
     #########################################################
     # Multiplication
@@ -105,13 +108,11 @@ proc main() =
     #########################################################
     # Check
 
-    {.push warnings: off.} # deprecated csize
-    var aW, bW, rW: csize  # Word written by GMP
-    {.pop.}
+    var aW, bW, rW: csize_t  # Word written by GMP
 
     const rLen = numWords * WordBitWidth
     var rGMP: array[rLen, byte]
-    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, r)
+    discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, r)
 
     var rConstantine: array[rLen, byte]
     marshal(rConstantine, rTest, bigEndian)
@@ -119,8 +120,8 @@ proc main() =
     # Note: in bigEndian, GMP aligns left while constantine aligns right
     doAssert rGMP.toOpenArray(0, rW-1) == rConstantine.toOpenArray(rLen-rW, rLen-1), block:
       # Reexport as bigEndian for debugging
-      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, a)
-      discard mpz_export(bBuf[0].addr, bW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, b)
+      discard mpz_export(aBuf[0].addr, aW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a)
+      discard mpz_export(bBuf[0].addr, bW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, b)
       "\nMultiplication with operands\n" &
       "  a (" & align($aBits, 4) & "-bit):   " & aBuf.toHex() & "\n" &
       "  b (" & align($bBits, 4) & "-bit):   " & bBuf.toHex() & "\n" &

--- a/tests/math_fields/t_finite_fields_vs_gmp.nim
+++ b/tests/math_fields/t_finite_fields_vs_gmp.nim
@@ -72,8 +72,8 @@ proc binary_prologue[Name: static Algebra, N: static int](
   aBuf.marshal(aTest, bigEndian)
   bBuf.marshal(bTest, bigEndian)
 
-  mpz_import(a, aLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, aBuf[0].addr)
-  mpz_import(b, bLen, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, bBuf[0].addr)
+  mpz_import(a, aLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, aBuf[0].addr)
+  mpz_import(b, bLen.csize_t, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, bBuf[0].addr)
 
 proc binary_epilogue[Name: static Algebra, N: static int](
         r, a, b: mpz_t,
@@ -85,21 +85,19 @@ proc binary_epilogue[Name: static Algebra, N: static int](
   #########################################################
   # Check
 
-  {.push warnings: off.} # deprecated csize
-  var aW, bW, rW: csize  # Word written by GMP
-  {.pop.}
+  var aW, bW, rW: csize_t  # Word written by GMP
 
   var rGMP: array[N, byte]
-  discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, r)
+  discard mpz_export(rGMP[0].addr, rW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, r)
 
   var rConstantine: array[N, byte]
   marshal(rConstantine, rTest, bigEndian)
 
   # Note: in bigEndian, GMP aligns left while constantine aligns right
-  doAssert rGMP.toOpenArray(0, rW-1) == rConstantine.toOpenArray(N-rW, N-1), block:
+  doAssert rGMP.toOpenArray(0, rW.int-1) == rConstantine.toOpenArray(N-rW.int, N-1), block:
     # Reexport as bigEndian for debugging
-    discard mpz_export(aBuf[0].unsafeAddr, aW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, a)
-    discard mpz_export(bBuf[0].unsafeAddr, bW.addr, GMP_MostSignificantWordFirst, 1, GMP_WordNativeEndian, 0, b)
+    discard mpz_export(aBuf[0].unsafeAddr, aW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, a)
+    discard mpz_export(bBuf[0].unsafeAddr, bW.addr, GMP_MostSignificantWordFirst.cint, 1.csize_t, GMP_WordNativeEndian.cint, 0.csize_t, b)
     "\nModular " & operation & " on curve " & $Name & " with operands\n" &
     "  a:   " & aBuf.toHex & "\n" &
     "  b:   " & bBuf.toHex & "\n" &
@@ -240,11 +238,14 @@ template testSetup {.dirty.} =
   mpz_init(b)
   mpz_init(p)
   mpz_init(r)
-  defer:
-    mpz_clear(r)
-    mpz_clear(p)
-    mpz_clear(b)
-    mpz_clear(a)
+  # Commented out: =destroy regression introduced in nim-gmp PR#3
+  # https://github.com/subsetpark/nim-gmp/pull/3/changes#diff-f944e5fa543c5f63082058ca2db21047676104fc1d68276b389bb99a51e31efc
+  # Destructors were specifically removed with motivated explanation in PR#2
+  # defer:
+  #   mpz_clear(r)
+  #   mpz_clear(p)
+  #   mpz_clear(b)
+  #   mpz_clear(a)
 
 proc mainMul() =
   testSetup()


### PR DESCRIPTION
This workarounds 2 breaking changes from upstream nim-gmp that is used for fuzzing:

- `csize` (alias for int in Nim) -> `csize_t` which maps exactly to C csize_t, unfortunately there is no version tagged so we might want to pin an exact commit in the future to avoid such regression now that nimble supports lockfiles. But I'm unsure if optinal dependencies locking actual works
-  https://github.com/subsetpark/nim-gmp/pull/3 reintroduced destructors in a low-level API despite me removing them in https://github.com/subsetpark/nim-gmp/pull/2 and that broke usage of mpz_clear ... again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GMP function calls across benchmarks and test suites with explicit C-type conversions for improved type safety.
  * Adjusted memory cleanup patterns in GMP object handling throughout test files.
  * Modified type handling for size and count parameters in cryptographic operation tests.

* **Chores**
  * Updated benchmark code to use explicit typed arguments in library function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->