### PR TITLE
Fix non-assembly reduction for secp256k1

### DIFF
--- a/constantine/math/arithmetic/limbs_crandall.nim
+++ b/constantine/math/arithmetic/limbs_crandall.nim
@@ -96,8 +96,10 @@ func reduceCrandallPartial_impl[N: static int](
 
   # Move all extra bits to hi, i.e. double-word shift
   when S == 0:
-    # Special case for Secp256k1 where m = N*WordBitWidth
+    # Special case for m = N*WordBitWidth like in Secp256k1
     # No shift is needed, hi remains as is
+    # Otherwhise the expression (hi << 0) or (r[N-1) >> 64)
+    # may be undefined depending on the CPU ISA (shift by 0 or wordsize)
     discard
   else:
     hi = (hi shl S) or (r[N-1] shr (WordBitWidth-S))

--- a/constantine/math/arithmetic/limbs_crandall.nim
+++ b/constantine/math/arithmetic/limbs_crandall.nim
@@ -95,11 +95,16 @@ func reduceCrandallPartial_impl[N: static int](
   #                       ≡ hi*cs (mod p)
 
   # Move all extra bits to hi, i.e. double-word shift
-  hi = (hi shl S) or (r[N-1] shr (WordBitWidth-S))
+  when S == 0:
+    # Special case for Secp256k1 where m = N*WordBitWidth
+    # No shift is needed, hi remains as is
+    discard
+  else:
+    hi = (hi shl S) or (r[N-1] shr (WordBitWidth-S))
 
-  # High-bits have been "carried" to `hi`, cancel them in r[N-1].
-  # Note: there might be up to `c` not reduced.
-  r[N-1] = r[N-1] and (MaxWord shr S)
+    # High-bits have been "carried" to `hi`, cancel them in r[N-1].
+    # Note: there might be up to `c` not reduced.
+    r[N-1] = r[N-1] and (MaxWord shr S)
 
   # Partially reduce to up to `m` bits
   # We need to fold what's beyond `m` bits

--- a/tests/math_fields/t_finite_fields_reduction.nim
+++ b/tests/math_fields/t_finite_fields_reduction.nim
@@ -1,0 +1,166 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/[unittest, times],
+  # Internal
+  constantine/named/algebras,
+  constantine/platforms/abstractions,
+  constantine/math/arithmetic,
+  constantine/math/io/io_fields,
+  # Test utilities
+  helpers/prng_unsafe
+
+const Iters = 12
+
+var rng: RngState
+let seed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+rng.seed(seed)
+echo "\n------------------------------------------------------\n"
+echo "test_finite_fields_reduction xoshiro512** seed: ", seed
+
+static: doAssert defined(CTT_TEST_CURVES), "This modules requires the -d:CTT_TEST_CURVES compile option"
+
+suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth & "-bit words]":
+  test "Secp256k1 - multiplication by 1 (S=0 edge case)":
+    ## Bug: When S = N*WordBitWidth - m = 0 (Secp256k1 case),
+    ## the reduction code was doing `r[N-1] shr (WordBitWidth-S)` = `r[3] shr 64`
+    ## which is undefined behavior and caused incorrect reduction.
+    ## This test ensures multiplication by 1 preserves the value.
+    for _ in 0 ..< Iters:
+      let a = rng.random_unsafe(Fp[Secp256k1])
+      var b: Fp[Secp256k1]
+      b.setOne()
+      
+      var r: Fp[Secp256k1]
+      r.prod(a, b)
+      
+      doAssert bool(r == a), block:
+        "\nSecp256k1 mul by 1 failed:" &
+        "\nInput:    " & a.toHex() &
+        "\nExpected: " & a.toHex() &
+        "\nGot:      " & r.toHex()
+
+  test "Secp256k1 - squaring consistency":
+    ## Ensure squaring produces same result as multiplication
+    for _ in 0 ..< Iters:
+      let a = rng.random_unsafe(Fp[Secp256k1])
+      
+      var r_sqr, r_mul: Fp[Secp256k1]
+      r_sqr.square(a)
+      r_mul.prod(a, a)
+      
+      doAssert bool(r_sqr == r_mul), block:
+        "\nSecp256k1 squaring inconsistency:" &
+        "\nInput: " & a.toHex() &
+        "\nSquare: " & r_sqr.toHex() &
+        "\nMul:    " & r_mul.toHex()
+
+  test "Secp256k1 - multiplication associativity":
+    ## (a * b) * c == a * (b * c)
+    for _ in 0 ..< Iters:
+      let a = rng.random_unsafe(Fp[Secp256k1])
+      let b = rng.random_unsafe(Fp[Secp256k1])
+      let c = rng.random_unsafe(Fp[Secp256k1])
+      
+      var r1, r2, tmp: Fp[Secp256k1]
+      tmp.prod(a, b)
+      r1.prod(tmp, c)
+      
+      tmp.prod(b, c)
+      r2.prod(a, tmp)
+      
+      doAssert bool(r1 == r2), block:
+        "\nSecp256k1 associativity failed:" &
+        "\na: " & a.toHex() &
+        "\nb: " & b.toHex() &
+        "\nc: " & c.toHex() &
+        "\n(a*b)*c:     " & r1.toHex() &
+        "\na*(b*c):     " & r2.toHex()
+
+  test "Secp256k1 - multiplication with high Hamming weight values":
+    ## Test reduction with values that have many bits set
+    for _ in 0 ..< Iters:
+      let a = rng.random_highHammingWeight(Fp[Secp256k1])
+      var b: Fp[Secp256k1]
+      b.setOne()
+      
+      var r: Fp[Secp256k1]
+      r.prod(a, b)
+      
+      doAssert bool(r == a), block:
+        "\nSecp256k1 mul by 1 (high Hamming) failed:" &
+        "\nInput:    " & a.toHex() &
+        "\nExpected: " & a.toHex() &
+        "\nGot:      " & r.toHex()
+
+  test "Secp256k1 - specific edge case values":
+    ## Test specific values that triggered the bug
+    block:
+      var a: Fp[Secp256k1]
+      a.fromHex("0x7123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+      
+      var b: Fp[Secp256k1]
+      b.setOne()
+      
+      var r: Fp[Secp256k1]
+      r.prod(a, b)
+      
+      doAssert bool(r == a), block:
+        "\nSecp256k1 specific value test failed:" &
+        "\nInput:    " & a.toHex() &
+        "\nExpected: " & a.toHex() &
+        "\nGot:      " & r.toHex()
+
+    block:
+      var a: Fp[Secp256k1]
+      a.fromHex("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+      
+      var b: Fp[Secp256k1]
+      b.setOne()
+      
+      var r: Fp[Secp256k1]
+      r.prod(a, b)
+      
+      doAssert bool(r == a), block:
+        "\nSecp256k1 specific value test 2 failed:" &
+        "\nInput:    " & a.toHex() &
+        "\nExpected: " & a.toHex() &
+        "\nGot:      " & r.toHex()
+
+  test "Edwards25519 - multiplication by 1":
+    ## Edwards25519 also uses Crandall primes but with S != 0
+    ## This ensures we didn't break non-Secp256k1 Crandall primes
+    for _ in 0 ..< Iters:
+      let a = rng.random_unsafe(Fp[Edwards25519])
+      var b: Fp[Edwards25519]
+      b.setOne()
+      
+      var r: Fp[Edwards25519]
+      r.prod(a, b)
+      
+      doAssert bool(r == a), block:
+        "\nEdwards25519 mul by 1 failed:" &
+        "\nInput:    " & a.toHex() &
+        "\nExpected: " & a.toHex() &
+        "\nGot:      " & r.toHex()
+
+  test "Edwards25519 - squaring consistency":
+    for _ in 0 ..< Iters:
+      let a = rng.random_unsafe(Fp[Edwards25519])
+      
+      var r_sqr, r_mul: Fp[Edwards25519]
+      r_sqr.square(a)
+      r_mul.prod(a, a)
+      
+      doAssert bool(r_sqr == r_mul), block:
+        "\nEdwards25519 squaring inconsistency:" &
+        "\nInput: " & a.toHex() &
+        "\nSquare: " & r_sqr.toHex() &
+        "\nMul:    " & r_mul.toHex()

--- a/tests/math_fields/t_finite_fields_reduction.nim
+++ b/tests/math_fields/t_finite_fields_reduction.nim
@@ -25,7 +25,7 @@ rng.seed(seed)
 echo "\n------------------------------------------------------\n"
 echo "test_finite_fields_reduction xoshiro512** seed: ", seed
 
-static: doAssert defined(CTT_TEST_CURVES), "This modules requires the -d:CTT_TEST_CURVES compile option"
+static: doAssert defined(CTT_TEST_CURVES), "This module requires the -d:CTT_TEST_CURVES compile option"
 
 suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth & "-bit words]":
   test "Secp256k1 - multiplication by 1 (S=0 edge case)":
@@ -37,10 +37,10 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
       let a = rng.random_unsafe(Fp[Secp256k1])
       var b: Fp[Secp256k1]
       b.setOne()
-      
+
       var r: Fp[Secp256k1]
       r.prod(a, b)
-      
+
       doAssert bool(r == a), block:
         "\nSecp256k1 mul by 1 failed:" &
         "\nInput:    " & a.toHex() &
@@ -51,11 +51,11 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
     ## Ensure squaring produces same result as multiplication
     for _ in 0 ..< Iters:
       let a = rng.random_unsafe(Fp[Secp256k1])
-      
+
       var r_sqr, r_mul: Fp[Secp256k1]
       r_sqr.square(a)
       r_mul.prod(a, a)
-      
+
       doAssert bool(r_sqr == r_mul), block:
         "\nSecp256k1 squaring inconsistency:" &
         "\nInput: " & a.toHex() &
@@ -68,14 +68,14 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
       let a = rng.random_unsafe(Fp[Secp256k1])
       let b = rng.random_unsafe(Fp[Secp256k1])
       let c = rng.random_unsafe(Fp[Secp256k1])
-      
+
       var r1, r2, tmp: Fp[Secp256k1]
       tmp.prod(a, b)
       r1.prod(tmp, c)
-      
+
       tmp.prod(b, c)
       r2.prod(a, tmp)
-      
+
       doAssert bool(r1 == r2), block:
         "\nSecp256k1 associativity failed:" &
         "\na: " & a.toHex() &
@@ -90,10 +90,10 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
       let a = rng.random_highHammingWeight(Fp[Secp256k1])
       var b: Fp[Secp256k1]
       b.setOne()
-      
+
       var r: Fp[Secp256k1]
       r.prod(a, b)
-      
+
       doAssert bool(r == a), block:
         "\nSecp256k1 mul by 1 (high Hamming) failed:" &
         "\nInput:    " & a.toHex() &
@@ -105,13 +105,13 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
     block:
       var a: Fp[Secp256k1]
       a.fromHex("0x7123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-      
+
       var b: Fp[Secp256k1]
       b.setOne()
-      
+
       var r: Fp[Secp256k1]
       r.prod(a, b)
-      
+
       doAssert bool(r == a), block:
         "\nSecp256k1 specific value test failed:" &
         "\nInput:    " & a.toHex() &
@@ -121,13 +121,13 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
     block:
       var a: Fp[Secp256k1]
       a.fromHex("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-      
+
       var b: Fp[Secp256k1]
       b.setOne()
-      
+
       var r: Fp[Secp256k1]
       r.prod(a, b)
-      
+
       doAssert bool(r == a), block:
         "\nSecp256k1 specific value test 2 failed:" &
         "\nInput:    " & a.toHex() &
@@ -141,10 +141,10 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
       let a = rng.random_unsafe(Fp[Edwards25519])
       var b: Fp[Edwards25519]
       b.setOne()
-      
+
       var r: Fp[Edwards25519]
       r.prod(a, b)
-      
+
       doAssert bool(r == a), block:
         "\nEdwards25519 mul by 1 failed:" &
         "\nInput:    " & a.toHex() &
@@ -154,11 +154,11 @@ suite "Crandall prime reduction - anti-regression tests" & " [" & $WordBitWidth 
   test "Edwards25519 - squaring consistency":
     for _ in 0 ..< Iters:
       let a = rng.random_unsafe(Fp[Edwards25519])
-      
+
       var r_sqr, r_mul: Fp[Edwards25519]
       r_sqr.square(a)
       r_mul.prod(a, a)
-      
+
       doAssert bool(r_sqr == r_mul), block:
         "\nEdwards25519 squaring inconsistency:" &
         "\nInput: " & a.toHex() &


### PR DESCRIPTION
#445 introduced fast reduction for primes of special form 2ᶜ-m like Secp256k1 and Curve25519.

However there is a bug in the pure Nim fallback, when folding carries during modular reduction if the number of bits of the prime equal the number of bits necessary for storage (for example 256-bit used exactly like for Secp256k1) we have shifts of 0 or 64 if we use the generic formula, shifts that may be undefined in hardware and lead to undefined values.

In assembly, double-word shift `shld` avoids this pitfall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved edge case handling in finite field reduction for specific mathematical parameter configurations

* **Tests**
  * Added comprehensive regression test suite for field arithmetic operations
  * Implemented randomized tests for multiplication and squaring verification across multiple elliptic curves
  * Included dedicated test cases to prevent regression of the fixed issue

<!-- end of auto-generated comment: release notes by coderabbit.ai -->