### PR TITLE
Replace GT Pairing + isOne().bool() pattern with pairing_check [PeerDAS streamlining]

### DIFF
--- a/constantine/commitments/kzg.nim
+++ b/constantine/commitments/kzg.nim
@@ -260,11 +260,7 @@ func kzg_verify*[F2; Name: static Algebra](
   tmzG2.affine(tau_minus_challenge_G2)
   cmyG1.affine(commitment_minus_eval_at_challenge_G1)
 
-  # e([proof]₁, [τ]₂ - [opening_challenge]₂) * e([commitment]₁ - [eval_at_challenge]₁, [-1]₂)
-  var gt {.noInit.}: Name.getGT()
-  gt.pairing([proof, cmyG1], [tmzG2, negG2])
-
-  return gt.isOne().bool()
+  return pairing_check(proof, tmzG2, cmyG1, negG2)
 
 func kzg_verify_batch*[bits: static int, F2; Name: static Algebra](
        commitments: ptr UncheckedArray[EC_ShortW_Aff[Fp[Name], G1]],
@@ -374,7 +370,4 @@ func kzg_verify_batch*[bits: static int, F2; Name: static Algebra](
   var negG2 {.noInit.}: EC_ShortW_Aff[F2, G2]
   negG2.neg(Name.getGenerator("G2"))
 
-  var gt {.noInit.}: Name.getGT()
-  gt.pairing(sums, [tauG2, negG2])
-
-  return gt.isOne().bool()
+  return pairing_check(sums[0], tauG2, sums[1], negG2)

--- a/constantine/commitments/kzg.nim
+++ b/constantine/commitments/kzg.nim
@@ -255,12 +255,9 @@ func kzg_verify*[F2; Name: static Algebra](
   commitment_minus_eval_at_challenge_G1.scalarMul_vartime(eval_at_challenge)
   commitment_minus_eval_at_challenge_G1.diff(commitmentJac, commitment_minus_eval_at_challenge_G1)
 
-  var tmzG2 {.noInit.}: EC_ShortW_Aff[F2, G2]
-  var cmyG1 {.noInit.}: EC_ShortW_Aff[Fp[Name], G1]
-  tmzG2.affine(tau_minus_challenge_G2)
-  cmyG1.affine(commitment_minus_eval_at_challenge_G1)
-
-  return pairing_check(proof, tmzG2, cmyG1, negG2)
+  return pairing_check(
+    proof, tau_minus_challenge_G2,
+    commitment_minus_eval_at_challenge_G1, negG2)
 
 func kzg_verify_batch*[bits: static int, F2; Name: static Algebra](
        commitments: ptr UncheckedArray[EC_ShortW_Aff[Fp[Name], G1]],
@@ -313,9 +310,9 @@ func kzg_verify_batch*[bits: static int, F2; Name: static Algebra](
 
   static: doAssert BigInt[bits] is Fr[Name].getBigInt()
 
-  var sums_jac {.noInit.}: array[2, EC_ShortW_Jac[Fp[Name], G1]]
-  template sum_rand_proofs: untyped = sums_jac[0]
-  template sum_commit_minus_evals_G1: untyped = sums_jac[1]
+  var sum_rand_proofs {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
+  var sum_commit_minus_evals_G1 {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
+  var sum_of_sums {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
   var sum_rand_challenge_proofs {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
 
   # ∑ [rᵢ][proofᵢ]₁
@@ -360,14 +357,13 @@ func kzg_verify_batch*[bits: static int, F2; Name: static Algebra](
 
   # e(∑ [rᵢ][proofᵢ]₁, [τ]₂) . e(∑[rᵢ]([commitmentᵢ]₁ - [eval_at_challengeᵢ]₁) + ∑[rᵢ][zᵢ][proofᵢ]₁, [-1]₂) = 1
   # -----------------------------------------------------------------------------------------------------------
-  template sum_of_sums: untyped = sums_jac[1]
 
   sum_of_sums.sum_vartime(sum_commit_minus_evals_G1, sum_rand_challenge_proofs)
-
-  var sums {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
-  sums.batchAffine(sums_jac)
 
   var negG2 {.noInit.}: EC_ShortW_Aff[F2, G2]
   negG2.neg(Name.getGenerator("G2"))
 
-  return pairing_check(sums[0], tauG2, sums[1], negG2)
+  return pairing_check(
+    sum_rand_proofs, tauG2,
+    sum_of_sums, negG2
+  )

--- a/constantine/commitments/kzg_parallel.nim
+++ b/constantine/commitments/kzg_parallel.nim
@@ -227,7 +227,4 @@ proc kzg_verify_batch_parallel*[bits: static int, F2; Name: static Algebra](
   var negG2 {.noInit.}: EC_ShortW_Aff[F2, G2]
   negG2.neg(Name.getGenerator("G2"))
 
-  var gt {.noInit.}: Name.getGT()
-  gt.pairing(sums, [tauG2, negG2])
-
-  return gt.isOne().bool()
+  return pairing_check(sums[0], tauG2, sums[1], negG2)

--- a/constantine/commitments/kzg_parallel.nim
+++ b/constantine/commitments/kzg_parallel.nim
@@ -123,9 +123,9 @@ proc kzg_verify_batch_parallel*[bits: static int, F2; Name: static Algebra](
 
   static: doAssert BigInt[bits] is Fr[Name].getBigInt()
 
-  var sums_jac {.noInit.}: array[2, EC_ShortW_Jac[Fp[Name], G1]]
-  template sum_rand_proofs: untyped = sums_jac[0]
-  template sum_commit_minus_evals_G1: untyped = sums_jac[1]
+  var sum_rand_proofs {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
+  var sum_commit_minus_evals_G1 {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
+  var sum_of_sums {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
   var sum_rand_challenge_proofs {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
 
   # ∑ [rᵢ][proofᵢ]₁
@@ -211,7 +211,6 @@ proc kzg_verify_batch_parallel*[bits: static int, F2; Name: static Algebra](
 
   # e(∑ [rᵢ][proofᵢ]₁, [τ]₂) . e(∑[rᵢ]([commitmentᵢ]₁ - [eval_at_challengeᵢ]₁) + ∑[rᵢ][zᵢ][proofᵢ]₁, [-1]₂) = 1
   # -----------------------------------------------------------------------------------------------------------
-  template sum_of_sums: untyped = sums_jac[1]
 
   discard sync sum_commit_minus_evals_G1_fv
   discard sync sum_rand_challenge_proofs_fv
@@ -221,10 +220,10 @@ proc kzg_verify_batch_parallel*[bits: static int, F2; Name: static Algebra](
   discard sync sum_rand_proofs_fv
   freeHeapAligned(coefs)
 
-  var sums {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
-  sums.batchAffine(sums_jac)
-
   var negG2 {.noInit.}: EC_ShortW_Aff[F2, G2]
   negG2.neg(Name.getGenerator("G2"))
 
-  return pairing_check(sums[0], tauG2, sums[1], negG2)
+  return pairing_check(
+    sum_rand_proofs, tauG2,
+    sum_of_sums, negG2
+  )

--- a/constantine/math/pairings/pairings_generic.nim
+++ b/constantine/math/pairings/pairings_generic.nim
@@ -11,6 +11,9 @@ import
   ./cyclotomic_subgroups,
   ./pairings_bn, ./pairings_bls12,
   constantine/math/extension_fields,
+  constantine/math/elliptic/ec_shortweierstrass_affine,
+  constantine/math/elliptic/ec_shortweierstrass_jacobian,
+  constantine/math/elliptic/ec_shortweierstrass_projective,
   constantine/named/zoo_pairings
 
 func pairing*[Name: static Algebra](gt: var AnyFp12[Name], P, Q: auto) {.inline.} =
@@ -20,6 +23,84 @@ func pairing*[Name: static Algebra](gt: var AnyFp12[Name], P, Q: auto) {.inline.
     pairing_bls12(gt, P, Q)
   else:
     {.error: "Pairing not implemented for " & $Name.}
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Aff[Fp[Name], G1],
+       Q0: EC_ShortW_Aff[Fp2[Name], G2],
+       P1: EC_ShortW_Aff[Fp[Name], G1],
+       Q1: EC_ShortW_Aff[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  gt.pairing([P0, P1], [Q0, Q1])
+  return gt.isOne().bool()
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Jac[Fp[Name], G1],
+       Q0: EC_ShortW_Jac[Fp2[Name], G2],
+       P1: EC_ShortW_Jac[Fp[Name], G1],
+       Q1: EC_ShortW_Jac[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  var Ps {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
+  var Qs {.noInit.}: array[2, EC_ShortW_Aff[Fp2[Name], G2]]
+  Ps.batchAffine([P0, P1])
+  Qs.batchAffine([Q0, Q1])
+  gt.pairing(Ps, Qs)
+  return gt.isOne().bool()
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Jac[Fp[Name], G1],
+       Q0: EC_ShortW_Aff[Fp2[Name], G2],
+       P1: EC_ShortW_Jac[Fp[Name], G1],
+       Q1: EC_ShortW_Aff[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  var Ps {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
+  Ps.batchAffine([P0, P1])
+  gt.pairing(Ps, [Q0, Q1])
+  return gt.isOne().bool()
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Jac[Fp[Name], G1],
+       Q0: EC_ShortW_Aff[Fp2[Name], G2],
+       P1: EC_ShortW_Aff[Fp[Name], G1],
+       Q1: EC_ShortW_Jac[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  var Ps {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
+  var Qs {.noInit.}: array[2, EC_ShortW_Aff[Fp2[Name], G2]]
+  Ps[0].affine(P0)
+  Ps[1] = P1
+  Qs[0] = Q0
+  Qs[1].affine(Q1)
+  gt.pairing(Ps, Qs)
+  return gt.isOne().bool()
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Aff[Fp[Name], G1],
+       Q0: EC_ShortW_Jac[Fp2[Name], G2],
+       P1: EC_ShortW_Jac[Fp[Name], G1],
+       Q1: EC_ShortW_Aff[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  var Ps {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
+  var Qs {.noInit.}: array[2, EC_ShortW_Aff[Fp2[Name], G2]]
+  Ps[0] = P0
+  Ps[1].affine(P1)
+  Qs[0].affine(Q0)
+  Qs[1] = Q1
+  gt.pairing(Ps, Qs)
+  return gt.isOne().bool()
+
+func pairing_check*[Name: static Algebra](
+       P0: EC_ShortW_Jac[Fp[Name], G1],
+       Q0: EC_ShortW_Jac[Fp2[Name], G2],
+       P1: EC_ShortW_Aff[Fp[Name], G1],
+       Q1: EC_ShortW_Aff[Fp2[Name], G2]): bool {.inline.} =
+  var gt {.noInit.}: Name.getGT()
+  var Ps {.noInit.}: array[2, EC_ShortW_Aff[Fp[Name], G1]]
+  var Qs {.noInit.}: array[2, EC_ShortW_Aff[Fp2[Name], G2]]
+  Ps[0].affine(P0)
+  Ps[1] = P1
+  Qs[0].affine(Q0)
+  Qs[1] = Q1
+  gt.pairing(Ps, Qs)
+  return gt.isOne().bool()
 
 func millerLoop*[Name: static Algebra](gt: var AnyFp12[Name], Q, P: auto, n: int) {.inline.} =
   when Name == BN254_Snarks:

--- a/constantine/serialization/codecs_bls12_381.nim
+++ b/constantine/serialization/codecs_bls12_381.nim
@@ -48,6 +48,8 @@ import
     constantine/math/io/[io_bigints, io_fields],
     ./codecs_status_codes
 
+export CttCodecScalarStatus, CttCodecEccStatus
+
 const pre = "ctt_bls12_381_"
 import ../zoo_exports
 

--- a/constantine/signatures/bls_signatures.nim
+++ b/constantine/signatures/bls_signatures.nim
@@ -95,18 +95,11 @@ func coreVerify*[Pubkey, Sig](
   negG.neg(Pubkey.F.Name.getGenerator($Pubkey.G))
   H.hashToCurve(k, Q, augmentation, message, domainSepTag)
 
-  when Sig.F.Name.getEmbeddingDegree() == 12:
-    var gt {.noInit.}: Fp12[Sig.F.Name]
-  else:
-    {.error: "Not implemented: signature on k=" & $Sig.F.Name.getEmbeddingDegree() & " for curve " & $$Sig.F.Name.}
-
   # e(PK, H(msg))*e(sig, -G) == 1
   when Sig.G == G2:
-    pairing(gt, [pubkey, negG], [Q, signature])
+    return pairing_check(pubkey, Q, negG, signature)
   else:
-    pairing(gt, [Q, signature], [pubkey, negG])
-
-  return gt.isOne().bool()
+    return pairing_check(Q, pubkey, negG, signature)
 
 # ############################################################
 #

--- a/constantine/signatures/bls_signatures.nim
+++ b/constantine/signatures/bls_signatures.nim
@@ -99,7 +99,7 @@ func coreVerify*[Pubkey, Sig](
   when Sig.G == G2:
     return pairing_check(pubkey, Q, negG, signature)
   else:
-    return pairing_check(Q, pubkey, negG, signature)
+    return pairing_check(Q, pubkey, signature, negG)
 
 # ############################################################
 #


### PR DESCRIPTION
This replaces the pattern of GT pairing + isOne().bool() pattern with pairing_check

This has been extracted from #592 / #593 so they can be rebased with a more focused PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized KZG commitment verification algorithms (single and batch modes) and BLS signature verification by replacing intermediate computation steps with direct verification methods.

* **New Features**
  * Added utility functions for batch cryptographic pairing verification with support for multiple point coordinate representations.

* **Chores**
  * Expanded serialization codec API exports to include scalar and elliptic curve status code types for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->