### PR TITLE
FFT / bit-reversal  / Lagrange polynomials refactorings - +50~100% FFT accel [PeerDAS streamlining]

### DIFF
--- a/.agents/skills/seq-arrays-openarrays-slicing-views/SKILL.md
+++ b/.agents/skills/seq-arrays-openarrays-slicing-views/SKILL.md
@@ -128,14 +128,29 @@ template allocStackArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T]
 
 ### Heap Allocation
 ```nim
+# Standard allocation (uninitialized memory)
 proc allocHeap*(T: typedesc): ptr T
 proc allocHeapUnchecked*(T: typedesc, size: int): ptr T
 proc allocHeapArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T]
 proc allocHeapAligned*(T: typedesc, alignment: static Natural): ptr T
 proc allocHeapArrayAligned*(T: typedesc, len: int, alignment: static Natural): ptr UncheckedArray[T]
+proc allocHeapAlignedPtr*(T: typedesc[ptr], alignment: static Natural): T
+proc allocHeapUncheckedAlignedPtr*(T: typedesc[ptr], size: int, alignment: static Natural): T
+
+# Zero-initialized allocation (critical for ARC with custom =destroy procs)
+proc alloc0Heap*(T: typedesc): ptr T
+proc alloc0HeapUnchecked*(T: typedesc, size: int): ptr T
+proc alloc0HeapArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T]
+proc alloc0HeapAligned*(T: typedesc, alignment: static Natural): ptr T
 proc alloc0HeapArrayAligned*(T: typedesc, len: int, alignment: static Natural): ptr UncheckedArray[T]
-  ## Allocation + zero initialization
+proc alloc0HeapAlignedPtr*(T: typedesc[ptr], alignment: static Natural): T
+proc alloc0HeapUncheckedAlignedPtr*(T: typedesc[ptr], size: int, alignment: static Natural): T
 ```
+
+**Important**: Use `alloc0*` variants when:
+- Allocating structs with custom `=destroy` procs that check for nil pointers
+- Working with ARC memory management to avoid double-free on uninitialized memory
+- Example: `EthereumKZGContext` has `ECFFT_Descriptor` fields with `=destroy` that free memory
 
 ## varargs
 

--- a/benchmarks/bench_fft.nim
+++ b/benchmarks/bench_fft.nim
@@ -93,7 +93,7 @@ proc bench_EC_FFT*() =
 
     let start = getMonotime()
     for i in 0 ..< NumIters:
-      let status = ec_fft_nr(fftDesc, coefsOut, data)
+      let status = ec_fft_nn(fftDesc, coefsOut, data)
       doAssert status == FFT_Success
     let stop = getMonotime()
 

--- a/benchmarks/bench_fft.nim
+++ b/benchmarks/bench_fft.nim
@@ -88,6 +88,52 @@ proc warmup() =
   let stop = cpuTime()
   echo &"Warmup: {stop - start:>4.4f} s, result {foo}"
 
+proc bench_Fr_FFT*() =
+  echo "\n=== Fr FFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
+    let order = 1 shl scale
+    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[F](order)
+    for i in 0 ..< order:
+      data[i].fromUint(uint64(i + 1))
+
+    var freq = newSeq[F](order)
+
+    bench("Fr FFT", "Fr[BLS12-381]", order, NumIters):
+      let status = fft_nn(fftDesc, freq, data)
+      doAssert status == FFT_Success
+
+proc bench_Fr_IFFT*() =
+  echo "\n=== Fr IFFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
+    let order = 1 shl scale
+    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[F](order)
+    for i in 0 ..< order:
+      data[i].fromUint(uint64(i + 1))
+
+    var freq = newSeq[F](order)
+    discard fft_nn(fftDesc, freq, data)
+
+    var recovered = newSeq[F](order)
+
+    bench("Fr IFFT", "Fr[BLS12-381]", order, NumIters):
+      let status = ifft_nn(fftDesc, recovered, freq)
+      doAssert status == FFT_Success
+
+
 proc bench_EC_FFT*() =
   echo "\n=== EC FFT Benchmark ==="
   separator()
@@ -135,51 +181,6 @@ proc bench_EC_IFFT*() =
       let status = ec_ifft_nn(fftDesc, recovered, coefsOut)
       doAssert status == FFT_Success
 
-proc bench_Fr_FFT*() =
-  echo "\n=== Fr FFT Benchmark ==="
-  separator()
-
-  const NumIters = 3
-
-  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
-  for scale in countup(3, 13, 2):
-    let order = 1 shl scale
-    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
-
-    var data = newSeq[F](order)
-    for i in 0 ..< order:
-      data[i].fromUint(uint64(i + 1))
-
-    var freq = newSeq[F](order)
-
-    bench("Fr FFT", "Fr[BLS12-381]", order, NumIters):
-      let status = fft_nn(fftDesc, freq, data)
-      doAssert status == FFT_Success
-
-proc bench_Fr_IFFT*() =
-  echo "\n=== Fr IFFT Benchmark ==="
-  separator()
-
-  const NumIters = 3
-
-  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
-  for scale in countup(3, 13, 2):
-    let order = 1 shl scale
-    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
-
-    var data = newSeq[F](order)
-    for i in 0 ..< order:
-      data[i].fromUint(uint64(i + 1))
-
-    var freq = newSeq[F](order)
-    discard fft_nn(fftDesc, freq, data)
-
-    var recovered = newSeq[F](order)
-
-    bench("Fr IFFT", "Fr[BLS12-381]", order, NumIters):
-      let status = ifft_nn(fftDesc, recovered, freq)
-      doAssert status == FFT_Success
-
 when isMainModule:
   echo "============================================================"
   echo "            FFT / IFFT Benchmarks (BLS12-381)"
@@ -188,9 +189,9 @@ when isMainModule:
   echo "============================================================"
 
   warmup()
-  bench_EC_FFT()
-  bench_EC_IFFT()
   bench_Fr_FFT()
   bench_Fr_IFFT()
+  bench_EC_FFT()
+  bench_EC_IFFT()
 
   echo ""

--- a/benchmarks/bench_fft.nim
+++ b/benchmarks/bench_fft.nim
@@ -1,0 +1,193 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#             Benchmark of FFT (Fast Fourier Transform)
+#
+# ############################################################
+
+import
+  std/[times, monotimes, strformat],
+  constantine/named/algebras,
+  constantine/named/zoo_generators,
+  constantine/math/[arithmetic, ec_shortweierstrass],
+  constantine/math/polynomials/fft,
+  constantine/math/io/io_fields,
+  helpers/prng_unsafe,
+  ./bench_blueprint
+
+proc separator() = separator(145)
+
+const ctt_eth_kzg_fr_pow2_roots_of_unity = [
+  # primitive_root⁽ᵐᵒᵈᵘˡᵘˢ⁻¹⁾/⁽²^ⁱ⁾ for i in [0, 32)
+  # The primitive root chosen is 7
+  Fr[BLS12_381].fromHex"0x1",
+  Fr[BLS12_381].fromHex"0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000",
+  Fr[BLS12_381].fromHex"0x8d51ccce760304d0ec030002760300000001000000000000",
+  Fr[BLS12_381].fromHex"0x345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a",
+  Fr[BLS12_381].fromHex"0x20b1ce9140267af9dd1c0af834cec32c17beb312f20b6f7653ea61d87742bcce",
+  Fr[BLS12_381].fromHex"0x50e0903a157988bab4bcd40e22f55448bf6e88fb4c38fb8a360c60997369df4e",
+  Fr[BLS12_381].fromHex"0x45af6345ec055e4d14a1e27164d8fdbd2d967f4be2f951558140d032f0a9ee53",
+  Fr[BLS12_381].fromHex"0x6898111413588742b7c68b4d7fdd60d098d0caac87f5713c5130c2c1660125be",
+  Fr[BLS12_381].fromHex"0x4f9b4098e2e9f12e6b368121ac0cf4ad0a0865a899e8deff4935bd2f817f694b",
+  Fr[BLS12_381].fromHex"0x95166525526a65439feec240d80689fd697168a3a6000fe4541b8ff2ee0434e",
+  Fr[BLS12_381].fromHex"0x325db5c3debf77a18f4de02c0f776af3ea437f9626fc085e3c28d666a5c2d854",
+  Fr[BLS12_381].fromHex"0x6d031f1b5c49c83409f1ca610a08f16655ea6811be9c622d4a838b5d59cd79e5",
+  Fr[BLS12_381].fromHex"0x564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d36306",
+  Fr[BLS12_381].fromHex"0x485d512737b1da3d2ccddea2972e89ed146b58bc434906ac6fdd00bfc78c8967",
+  Fr[BLS12_381].fromHex"0x56624634b500a166dc86b01c0d477fa6ae4622f6a9152435034d2ff22a5ad9e1",
+  Fr[BLS12_381].fromHex"0x3291357ee558b50d483405417a0cbe39c8d5f51db3f32699fbd047e11279bb6e",
+  Fr[BLS12_381].fromHex"0x2155379d12180caa88f39a78f1aeb57867a665ae1fcadc91d7118f85cd96b8ad",
+  Fr[BLS12_381].fromHex"0x224262332d8acbf4473a2eef772c33d6cd7f2bd6d0711b7d08692405f3b70f10",
+  Fr[BLS12_381].fromHex"0x2d3056a530794f01652f717ae1c34bb0bb97a3bf30ce40fd6f421a7d8ef674fb",
+  Fr[BLS12_381].fromHex"0x520e587a724a6955df625e80d0adef90ad8e16e84419c750194e8c62ecb38d9d",
+  Fr[BLS12_381].fromHex"0x3e1c54bcb947035a57a6e07cb98de4a2f69e02d265e09d9fece7e0e39898d4b",
+  Fr[BLS12_381].fromHex"0x47c8b5817018af4fc70d0874b0691d4e46b3105f04db5844cd3979122d3ea03a",
+  Fr[BLS12_381].fromHex"0xabe6a5e5abcaa32f2d38f10fbb8d1bbe08fec7c86389beec6e7a6ffb08e3363",
+  Fr[BLS12_381].fromHex"0x73560252aa0655b25121af06a3b51e3cc631ffb2585a72db5616c57de0ec9eae",
+  Fr[BLS12_381].fromHex"0x291cf6d68823e6876e0bcd91ee76273072cf6a8029b7d7bc92cf4deb77bd779c",
+  Fr[BLS12_381].fromHex"0x19fe632fd3287390454dc1edc61a1a3c0ba12bb3da64ca5ce32ef844e11a51e",
+  Fr[BLS12_381].fromHex"0xa0a77a3b1980c0d116168bffbedc11d02c8118402867ddc531a11a0d2d75182",
+  Fr[BLS12_381].fromHex"0x23397a9300f8f98bece8ea224f31d25db94f1101b1d7a628e2d0a7869f0319ed",
+  Fr[BLS12_381].fromHex"0x52dd465e2f09425699e276b571905a7d6558e9e3f6ac7b41d7b688830a4f2089",
+  Fr[BLS12_381].fromHex"0xc83ea7744bf1bee8da40c1ef2bb459884d37b826214abc6474650359d8e211b",
+  Fr[BLS12_381].fromHex"0x2c6d4e4511657e1e1339a815da8b398fed3a181fabb30adc694341f608c9dd56",
+  Fr[BLS12_381].fromHex"0x4b5371495990693fad1715b02e5713b5f070bb00e28a193d63e7cb4906ffc93f"
+]
+
+type
+  EC_G1 = EC_ShortW_Prj[Fp[BLS12_381], G1]
+  F = Fr[BLS12_381]
+
+proc warmup() =
+  let start = cpuTime()
+  var foo = 123
+  for i in 0 ..< 300_000_000:
+    foo += i*i mod 456
+    foo = foo mod 789
+  let stop = cpuTime()
+  echo &"Warmup: {stop - start:>4.4f} s, result {foo}"
+
+proc bench_EC_FFT*() =
+  echo "\n=== EC FFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  for scale in 4 ..< 10:
+    let order = 1 shl scale
+    let fftDesc = ECFFT_Descriptor[EC_G1].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[EC_G1](order)
+    data[0].setGenerator()
+    for i in 1 ..< order:
+      data[i].mixedSum(data[i-1], BLS12_381.getGenerator("G1"))
+
+    var coefsOut = newSeq[EC_G1](order)
+
+    let start = getMonotime()
+    for i in 0 ..< NumIters:
+      let status = ec_fft_nr(fftDesc, coefsOut, data)
+      doAssert status == FFT_Success
+    let stop = getMonotime()
+
+    let ns = inNanoseconds((stop-start) div NumIters)
+    let throughput = 1e9 / float64(ns)
+    echo &"EC FFT (G1)     size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+
+proc bench_Fr_FFT*() =
+  echo "\n=== Fr FFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  for scale in 1 ..< 10:
+    let order = 1 shl scale
+    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[F](order)
+    for i in 0 ..< order:
+      data[i].fromUint(uint64(i + 1))
+
+    var freq = newSeq[F](order)
+
+    let start = getMonotime()
+    for i in 0 ..< NumIters:
+      let status = fft_nn(fftDesc, freq, data)
+      doAssert status == FFT_Success
+    let stop = getMonotime()
+
+    let ns = inNanoseconds((stop-start) div NumIters)
+    let throughput = 1e9 / float64(ns)
+    echo &"Fr FFT (BLS12-381)  size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+
+proc bench_Fr_IFFT*() =
+  echo "\n=== Fr IFFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  for scale in 1 ..< 10:
+    let order = 1 shl scale
+    let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[F](order)
+    for i in 0 ..< order:
+      data[i].fromUint(uint64(i + 1))
+
+    var freq = newSeq[F](order)
+    discard fft_nn(fftDesc, freq, data)
+
+    var recovered = newSeq[F](order)
+
+    let start = getMonotime()
+    for i in 0 ..< NumIters:
+      let status = ifft_nn(fftDesc, recovered, freq)
+      doAssert status == FFT_Success
+    let stop = getMonotime()
+
+    let ns = inNanoseconds((stop-start) div NumIters)
+    let throughput = 1e9 / float64(ns)
+    echo &"Fr IFFT (BLS12-381) size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+
+proc bench_BitReversal*() =
+  echo "\n=== Bit-Reversion Permutation Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  for logN in 10 ..< 20:
+    let N = 1 shl logN
+
+    var src = newSeq[int64](N)
+    for i in 0 ..< N:
+      src[i] = int64(i)
+
+    let start = getMonotime()
+    for i in 0 ..< NumIters:
+      var buf = src
+      buf.bit_reversal_permutation()
+    let stop = getMonotime()
+
+    let ns = inNanoseconds((stop-start) div NumIters)
+    let throughput = 1e9 / float64(ns)
+    echo &"Bit-reversal        2^{logN:>2}       {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+
+when isMainModule:
+  echo "============================================================"
+  echo "            FFT / IFFT Benchmarks (BLS12-381)"
+  echo "============================================================"
+
+  warmup()
+  bench_EC_FFT()
+  bench_Fr_FFT()
+  bench_Fr_IFFT()
+  bench_BitReversal()
+
+  echo ""

--- a/benchmarks/bench_fft.nim
+++ b/benchmarks/bench_fft.nim
@@ -17,12 +17,26 @@ import
   constantine/named/algebras,
   constantine/named/zoo_generators,
   constantine/math/[arithmetic, ec_shortweierstrass],
-  constantine/math/polynomials/fft,
+  constantine/math/polynomials/fft {.all.},
   constantine/math/io/io_fields,
   helpers/prng_unsafe,
   ./bench_blueprint
 
 proc separator() = separator(145)
+
+proc report*(op, typ: string, size: int, start, stop: MonoTime, startClk, stopClk: int64, iters: int) =
+  let ns = inNanoseconds((stop-start) div iters)
+  let throughput = 1e9 / float64(ns)
+  when SupportsGetTicks:
+    let cycles = (stopClk - startClk) div iters
+    echo &"{op:<32} size {size:>5}    {typ:<15} {throughput:>15.3f} ops/s  {ns:>12} ns/op  {cycles:>12} CPU cycles"
+  else:
+    echo &"{op:<32} size {size:>5}    {typ:<15} {throughput:>15.3f} ops/s  {ns:>12} ns/op"
+
+template bench*(op, typ: string, size, iters: int, body: untyped): untyped =
+  block:
+    measure(iters, startTime, stopTime, startClk, stopClk, body)
+    report(op, typ, size, startTime, stopTime, startClk, stopClk, iters)
 
 const ctt_eth_kzg_fr_pow2_roots_of_unity = [
   # primitive_root⁽ᵐᵒᵈᵘˡᵘˢ⁻¹⁾/⁽²^ⁱ⁾ for i in [0, 32)
@@ -80,7 +94,8 @@ proc bench_EC_FFT*() =
 
   const NumIters = 3
 
-  for scale in 4 ..< 10:
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
     let order = 1 shl scale
     let fftDesc = ECFFT_Descriptor[EC_G1].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
 
@@ -91,15 +106,34 @@ proc bench_EC_FFT*() =
 
     var coefsOut = newSeq[EC_G1](order)
 
-    let start = getMonotime()
-    for i in 0 ..< NumIters:
+    bench("EC FFT (G1)", "EC_G1", order, NumIters):
       let status = ec_fft_nn(fftDesc, coefsOut, data)
       doAssert status == FFT_Success
-    let stop = getMonotime()
 
-    let ns = inNanoseconds((stop-start) div NumIters)
-    let throughput = 1e9 / float64(ns)
-    echo &"EC FFT (G1)     size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
+proc bench_EC_IFFT*() =
+  echo "\n=== EC IFFT Benchmark ==="
+  separator()
+
+  const NumIters = 3
+
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
+    let order = 1 shl scale
+    let fftDesc = ECFFT_Descriptor[EC_G1].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+
+    var data = newSeq[EC_G1](order)
+    data[0].setGenerator()
+    for i in 1 ..< order:
+      data[i].mixedSum(data[i-1], BLS12_381.getGenerator("G1"))
+
+    var coefsOut = newSeq[EC_G1](order)
+    discard ec_fft_nn(fftDesc, coefsOut, data)
+
+    var recovered = newSeq[EC_G1](order)
+
+    bench("EC IFFT (G1)", "EC_G1", order, NumIters):
+      let status = ec_ifft_nn(fftDesc, recovered, coefsOut)
+      doAssert status == FFT_Success
 
 proc bench_Fr_FFT*() =
   echo "\n=== Fr FFT Benchmark ==="
@@ -107,7 +141,8 @@ proc bench_Fr_FFT*() =
 
   const NumIters = 3
 
-  for scale in 1 ..< 10:
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
     let order = 1 shl scale
     let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
 
@@ -117,15 +152,9 @@ proc bench_Fr_FFT*() =
 
     var freq = newSeq[F](order)
 
-    let start = getMonotime()
-    for i in 0 ..< NumIters:
+    bench("Fr FFT", "Fr[BLS12-381]", order, NumIters):
       let status = fft_nn(fftDesc, freq, data)
       doAssert status == FFT_Success
-    let stop = getMonotime()
-
-    let ns = inNanoseconds((stop-start) div NumIters)
-    let throughput = 1e9 / float64(ns)
-    echo &"Fr FFT (BLS12-381)  size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
 
 proc bench_Fr_IFFT*() =
   echo "\n=== Fr IFFT Benchmark ==="
@@ -133,7 +162,8 @@ proc bench_Fr_IFFT*() =
 
   const NumIters = 3
 
-  for scale in 1 ..< 10:
+  # Test sizes: 8, 32, 128, 512, 2048, 8192 (every 2 powers, up to 8192)
+  for scale in countup(3, 13, 2):
     let order = 1 shl scale
     let fftDesc = FrFFT_Descriptor[F].new(order = order, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
 
@@ -146,48 +176,21 @@ proc bench_Fr_IFFT*() =
 
     var recovered = newSeq[F](order)
 
-    let start = getMonotime()
-    for i in 0 ..< NumIters:
+    bench("Fr IFFT", "Fr[BLS12-381]", order, NumIters):
       let status = ifft_nn(fftDesc, recovered, freq)
       doAssert status == FFT_Success
-    let stop = getMonotime()
-
-    let ns = inNanoseconds((stop-start) div NumIters)
-    let throughput = 1e9 / float64(ns)
-    echo &"Fr IFFT (BLS12-381) size {order:>5}     {throughput:>15.3f} ops/s     {ns:>9} ns/op"
-
-proc bench_BitReversal*() =
-  echo "\n=== Bit-Reversion Permutation Benchmark ==="
-  separator()
-
-  const NumIters = 3
-
-  for logN in 10 ..< 20:
-    let N = 1 shl logN
-
-    var src = newSeq[int64](N)
-    for i in 0 ..< N:
-      src[i] = int64(i)
-
-    let start = getMonotime()
-    for i in 0 ..< NumIters:
-      var buf = src
-      buf.bit_reversal_permutation()
-    let stop = getMonotime()
-
-    let ns = inNanoseconds((stop-start) div NumIters)
-    let throughput = 1e9 / float64(ns)
-    echo &"Bit-reversal        2^{logN:>2}       {throughput:>15.3f} ops/s     {ns:>9} ns/op"
 
 when isMainModule:
   echo "============================================================"
   echo "            FFT / IFFT Benchmarks (BLS12-381)"
   echo "============================================================"
+  echo "Testing every 2 powers of 2, up to 8192 elements"
+  echo "============================================================"
 
   warmup()
   bench_EC_FFT()
+  bench_EC_IFFT()
   bench_Fr_FFT()
   bench_Fr_IFFT()
-  bench_BitReversal()
 
   echo ""

--- a/benchmarks/bench_fft_bit_reversal.nim
+++ b/benchmarks/bench_fft_bit_reversal.nim
@@ -67,19 +67,22 @@ proc bench_BitReversal*(T: typedesc) =
 
   const
     NumIters = 3
+    MinLogN = 2
     MaxLogN = 26
+    LogNStep = 4
+    MaxAllocLogN = MinLogN + ((MaxLogN - 1 - MinLogN) div LogNStep) * LogNStep
 
   var rng: RngState
   rng.seed 1234
 
-  let maxN = 1 shl MaxLogN
+  let maxN = 1 shl MaxAllocLogN
   var src = newSeq[T](maxN)
   rng.random_unsafe(src)
 
   echo "=== In-Place Variants ==="
   separator()
 
-  for logN in countup(2, MaxLogN-1, 4):
+  for logN in countup(MinLogN, MaxLogN-1, LogNStep):
     let N = 1 shl logN
     var buf = src[0..<N]
 
@@ -100,7 +103,7 @@ proc bench_BitReversal*(T: typedesc) =
   echo "\n=== Out-of-Place Variants ==="
   separator()
 
-  for logN in countup(2, MaxLogN-1, 4):
+  for logN in countup(MinLogN, MaxLogN-1, LogNStep):
     let N = 1 shl logN
     var dst = newSeq[T](N)
 

--- a/benchmarks/bench_fft_bit_reversal.nim
+++ b/benchmarks/bench_fft_bit_reversal.nim
@@ -1,0 +1,140 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#        Benchmark of Bit-Reversal Permutation Algorithms
+#
+# ############################################################
+# Compares:
+#   - Naive algorithm (simple, cache-unfriendly)
+#   - COBRA algorithm (cache-optimized, Carter & Gatlin 1998)
+#   - Out-of-place + copy (in-place via temporary buffer)
+#   - Automatic threshold selection
+#
+# Tests both in-place and out-of-place variants
+# ############################################################
+
+import
+  std/[times, monotimes, strformat],
+  constantine/named/algebras,
+  constantine/math/arithmetic,
+  constantine/math/polynomials/fft {.all.},
+  constantine/math/io/io_fields,
+  constantine/platforms/bithacks,
+  helpers/prng_unsafe,
+  ./bench_blueprint
+
+proc separator() = separator(145)
+
+proc report*(op, typ: string, size: int, start, stop: MonoTime, startClk, stopClk: int64, iters: int) =
+  let ns = inNanoseconds((stop-start) div iters)
+  let throughput = 1e9 / float64(ns)
+  when SupportsGetTicks:
+    let cycles = (stopClk - startClk) div iters
+    echo &"{op:<32} size {size:>7}    {typ:<15} {throughput:>15.3f} ops/s  {ns:>12} ns/op  {cycles:>12} CPU cycles"
+  else:
+    echo &"{op:<32} size {size:>7}    {typ:<15} {throughput:>15.3f} ops/s  {ns:>12} ns/op"
+
+template bench*(op, typ: string, size, iters: int, body: untyped): untyped =
+  block:
+    measure(iters, startTime, stopTime, startClk, stopClk, body)
+    report(op, typ, size, startTime, stopTime, startClk, stopClk, iters)
+
+func bitReversalInPlaceViaCopy[T](buf: var openArray[T]) =
+  ## In-place bit-reversal via out-of-place + copy.
+  ## This is often faster than true in-place algorithms because:
+  ## 1. Out-of-place has better cache locality
+  ## 2. No swap overhead
+  ## 3. Copy is a simple linear scan
+  var temp = newSeq[T](buf.len)
+  bit_reversal_permutation(temp, buf)
+  for i in 0 ..< buf.len:
+    buf[i] = temp[i]
+
+proc bench_BitReversal*(T: typedesc) =
+  const name = $T
+  echo "\n=== Bit-Reversal Permutation Benchmark (" & name & ") ==="
+  separator()
+  echo "Comparing naive, COBRA, out-of-place+copy, and auto-dispatch algorithms"
+  echo "Threshold: out-of-place = 2^7 = 128 elements"
+  echo ""
+
+  const
+    NumIters = 3
+    MaxLogN = 26
+
+  var rng: RngState
+  rng.seed 1234
+
+  let maxN = 1 shl MaxLogN
+  var src = newSeq[T](maxN)
+  rng.random_unsafe(src)
+
+  echo "=== In-Place Variants ==="
+  separator()
+
+  for logN in countup(2, MaxLogN-1, 4):
+    let N = 1 shl logN
+    var buf = src[0..<N]
+
+    bench("Naive (in-place)", name, N, NumIters):
+      buf.bit_reversal_permutation_naive()
+
+    bench("COBRA (in-place)", name, N, NumIters):
+      buf.bit_reversal_permutation_cobra()
+
+    bench("OOP+Copy (in-place)", name, N, NumIters):
+      buf.bitReversalInPlaceViaCopy()
+
+    bench("Auto-dispatch", name, N, NumIters):
+      buf.bit_reversal_permutation()
+
+    echo "----"
+
+  echo "\n=== Out-of-Place Variants ==="
+  separator()
+
+  for logN in countup(2, MaxLogN-1, 4):
+    let N = 1 shl logN
+    var dst = newSeq[T](N)
+
+    bench("Naive (out-of-place)", name, N, NumIters):
+      bit_reversal_permutation_naive(dst, src.toOpenArray(0, N-1))
+
+    bench("COBRA (out-of-place)", name, N, NumIters):
+      bit_reversal_permutation_cobra(dst, src.toOpenArray(0, N-1))
+
+    bench("Auto-dispatch", name, N, NumIters):
+      bit_reversal_permutation(dst, src.toOpenArray(0, N-1))
+
+    echo "----"
+
+  echo "\n=== Summary ==="
+  echo &"Threshold (out-of-place): 2^7 = 128 elements"
+  echo &"Threshold (in-place):     2^18 = 262,144 elements"
+  echo ""
+  echo "Note: Out-of-place is at least 2x faster than true in-place"
+  echo "      due to better cache locality and no swap overhead."
+  echo "      The 'OOP+Copy' variant is often the best in-place option."
+
+when isMainModule:
+  echo "============================================================"
+  echo "        Bit-Reversal Permutation Benchmarks"
+  echo "============================================================"
+  echo ""
+
+  warmup()
+
+  echo "Testing with uint32 (4 bytes per element):"
+  bench_BitReversal(uint32)
+
+  echo "\n\nTesting with Fr[BLS12_381] (32 bytes per element):"
+  bench_BitReversal(Fr[BLS12_381])
+
+  echo ""

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -614,6 +614,8 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # Polynomials
   # ----------------------------------------------------------
   ("tests/math_polynomials/t_polynomials.nim", false),
+  ("tests/math_polynomials/t_fft.nim", false),
+  ("tests/math_polynomials/t_fft_coset.nim", false),
 
   # Protocols
   # ----------------------------------------------------------
@@ -726,6 +728,8 @@ const benchDesc = [
   "bench_verkle_primitives",
   "bench_eth_evm_precompiles",
   "bench_multilinear_extensions",
+  "bench_fft",
+  
   # "zkalc", # Already tested through make_zkalc
 ]
 
@@ -1188,3 +1192,8 @@ task bench_eth_eip2537_subgroup_checks_impact, "Run EIP2537 subgroup checks impa
 # ------------------------------------------
 task bench_eth_evm_precompiles, "Run Ethereum EVM precompiles - CC compiler":
   runBench("bench_eth_evm_precompiles")
+
+# FFT
+# ------------------------------------------
+task bench_fft, "Run FFT / IFFT Benchmarks (BLS12-381) - CC compiler":
+  runBench("bench_fft")

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -616,6 +616,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   ("tests/math_polynomials/t_polynomials.nim", false),
   ("tests/math_polynomials/t_fft.nim", false),
   ("tests/math_polynomials/t_fft_coset.nim", false),
+  ("tests/math_polynomials/t_bit_reversal.nim", false),
 
   # Protocols
   # ----------------------------------------------------------
@@ -729,6 +730,7 @@ const benchDesc = [
   "bench_eth_evm_precompiles",
   "bench_multilinear_extensions",
   "bench_fft",
+  "bench_fft_bit_reversal",
   
   # "zkalc", # Already tested through make_zkalc
 ]
@@ -1197,3 +1199,6 @@ task bench_eth_evm_precompiles, "Run Ethereum EVM precompiles - CC compiler":
 # ------------------------------------------
 task bench_fft, "Run FFT / IFFT Benchmarks (BLS12-381) - CC compiler":
   runBench("bench_fft")
+
+task bench_fft_bit_reversal, "Run Bit-Reversal Permutation Benchmarks - CC compiler":
+  runBench("bench_fft_bit_reversal")

--- a/constantine/commitments/eth_verkle_ipa.nim
+++ b/constantine/commitments/eth_verkle_ipa.nim
@@ -137,18 +137,18 @@ func innerProduct[F](r: var F, a, b: distinct(View[F] or MutableView[F])) =
     r += t
 
 func ipa_commit*[N: static int, EC, F](
-      crs: PolynomialEval[N, EC],
+      crs: PolynomialEval[N, EC, kNaturalOrder],
       r: var EC,
-      poly: PolynomialEval[N, F]) =
+      poly: PolynomialEval[N, F, kNaturalOrder]) =
   crs.pedersen_commit(r, poly)
 
 func ipa_prove*[N, logN: static int, EcAff, F](
-      crs: PolynomialEval[N, EcAff],
+      crs: PolynomialEval[N, EcAff, kNaturalOrder],
       domain: PolyEvalLinearDomain[N, F],
       transcript: var EthVerkleTranscript,
       eval_at_challenge: var F,
       proof: var IpaProof[logN, EcAff, F],
-      poly: PolynomialEval[N, F],
+      poly: PolynomialEval[N, F, kNaturalOrder],
       commitment: EcAff,
       opening_challenge: F) =
 
@@ -324,7 +324,7 @@ func computeChangeOfBasisFactors[F](
   s.computeChangeOfBasisFactors(u, one)
 
 func ipa_verify*[N, logN: static int, EcAff, F](
-      crs: PolynomialEval[N, EcAff],
+      crs: PolynomialEval[N, EcAff, kNaturalOrder],
       domain: PolyEvalLinearDomain[N, F],
       transcript: var EthVerkleTranscript,
       commitment: EcAff,
@@ -524,9 +524,9 @@ func sorterByChallenge[N: static int](
 
 func sumPolysByChallenge[N: static int, F](
       zs: ptr UncheckedArray[uint32],
-      fs: ptr UncheckedArray[PolynomialEval[N, F]],
+      fs: ptr UncheckedArray[PolynomialEval[N, F, kNaturalOrder]],
       challenges_counts: array[N, uint32],
-      ungrouped_polys: ptr UncheckedArray[PolynomialEval[N, F]],
+      ungrouped_polys: ptr UncheckedArray[PolynomialEval[N, F, kNaturalOrder]],
       sortingKeys: ptr UncheckedArray[tuple[z, idx: uint32]],
       num_queries: int) =
   ## Returns a sparse representation of:
@@ -655,11 +655,11 @@ func sumCommitmentsAndEvalsByChallenge[N: static int, F, ECaff](
   freeHeapAligned(idxmap)
 
 func ipa_multi_prove*[N, logN: static int, EcAff, F](
-      crs: PolynomialEval[N, EcAff],
+      crs: PolynomialEval[N, EcAff, kNaturalOrder],
       domain: PolyEvalLinearDomain[N, F],
       transcript: var EthVerkleTranscript,
       proof: var IpaMultiProof[logN, EcAff, F],
-      polys: openArray[PolynomialEval[N, F]],
+      polys: openArray[PolynomialEval[N, F, kNaturalOrder]],
       commitments: openArray[EcAff],
       opening_challenges_in_domain: openArray[SomeUnsignedInt]) =
   ## Create a combined proof that
@@ -694,7 +694,7 @@ func ipa_multi_prove*[N, logN: static int, EcAff, F](
 
   # Sparse data by distinct challenges
   let sparse_challenges = allocHeapArrayAligned(uint32, num_distinct_challenges, alignment = 64)
-  let polys_by_challenges = allocHeapArrayAligned(PolynomialEval[N, F], num_distinct_challenges, alignment = 64)
+  let polys_by_challenges = allocHeapArrayAligned(PolynomialEval[N, F, kNaturalOrder], num_distinct_challenges, alignment = 64)
 
   # Compute the sparse challenges and the summed polys
   sparse_challenges.sumPolysByChallenge(
@@ -709,9 +709,9 @@ func ipa_multi_prove*[N, logN: static int, EcAff, F](
   freeHeapAligned(sortingKeys)
   freeHeapAligned(challenges_counts)
 
-  let g2 = allocHeapAligned(PolynomialEval[N, F], alignment = 64)
-  let g1 = allocHeapAligned(PolynomialEval[N, F], alignment = 64)
-  let g = allocHeapAligned( PolynomialEval[N, F], alignment = 64)
+  let g2 = allocHeapAligned(PolynomialEval[N, F, kNaturalOrder], alignment = 64)
+  let g1 = allocHeapAligned(PolynomialEval[N, F, kNaturalOrder], alignment = 64)
+  let g = allocHeapAligned( PolynomialEval[N, F, kNaturalOrder], alignment = 64)
   let invTminusChallenges = allocHeapArrayAligned(F, num_distinct_challenges, alignment = 64)
   let rpowers = allocHeapArrayAligned(F, num_distinct_challenges, alignment = 64)
 
@@ -832,7 +832,7 @@ func ipa_multi_prove*[N, logN: static int, EcAff, F](
   freeHeapAligned(g2)
 
 func ipa_multi_verify*[N, logN: static int, EcAff, F](
-      crs: PolynomialEval[N, EcAff],
+      crs: PolynomialEval[N, EcAff, kNaturalOrder],
       domain: PolyEvalLinearDomain[N, F],
       transcript: var EthVerkleTranscript,
       commitments: openArray[EcAff],

--- a/constantine/commitments/kzg.nim
+++ b/constantine/commitments/kzg.nim
@@ -174,23 +174,23 @@ import
 # For now we assume that the input polynomial always has the same degree
 # as the powers of τ
 
-func kzg_commit*[N, bits: static int, Name: static Algebra](
-       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1]],
+func kzg_commit*[N, bits: static int, Name: static Algebra; Ord](
+       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1], Ord],
        commitment: var EC_ShortW_Aff[Fp[Name], G1],
-       poly: PolynomialEval[N, BigInt[bits]]) {.tags:[Alloca, HeapAlloc, Vartime].} =
+       poly: PolynomialEval[N, BigInt[bits], Ord]) {.tags:[Alloca, HeapAlloc, Vartime].} =
   var commitmentJac {.noInit.}: EC_ShortW_Jac[Fp[Name], G1]
   commitmentJac.multiScalarMul_vartime(poly.evals, powers_of_tau.evals)
   commitment.affine(commitmentJac)
 
-func kzg_prove*[N: static int, Name: static Algebra](
-       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1]],
-       domain: PolyEvalRootsDomain[N, Fr[Name]],
-       eval_at_challenge: var Fr[Name],
-       proof: var EC_ShortW_Aff[Fp[Name], G1],
-       poly: PolynomialEval[N, Fr[Name]],
-       opening_challenge: Fr[Name]) {.tags:[Alloca, HeapAlloc, Vartime].} =
+func kzg_prove*[N: static int, Name: static Algebra; Ord](
+        powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1], Ord],
+        domain: PolyEvalRootsDomain[N, Fr[Name], Ord],
+        eval_at_challenge: var Fr[Name],
+        proof: var EC_ShortW_Aff[Fp[Name], G1],
+        poly: PolynomialEval[N, Fr[Name], Ord],
+        opening_challenge: Fr[Name]): void {.tags:[Alloca, HeapAlloc, Vartime].} =
 
-  let quotientPoly = allocHeapAligned(PolynomialEval[N, Fr[Name]], alignment = 64)
+  let quotientPoly = allocHeapAligned(PolynomialEval[N, Fr[Name], Ord], alignment = 64)
 
   domain.getQuotientPoly(
     quotientPoly[], eval_at_challenge,

--- a/constantine/commitments/kzg_parallel.nim
+++ b/constantine/commitments/kzg_parallel.nim
@@ -30,11 +30,11 @@ export kzg
 # KZG - Prover - Lagrange basis
 # ------------------------------------------------------------
 
-proc kzg_commit_parallel*[N, bits: static int, Name: static Algebra](
+proc kzg_commit_parallel*[N, bits: static int, Name: static Algebra; Ord: static PolyOrdering](
        tp: Threadpool,
-       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1]],
+       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1], Ord],
        commitment: var EC_ShortW_Aff[Fp[Name], G1],
-       poly: PolynomialEval[N, BigInt[bits]],
+       poly: PolynomialEval[N, BigInt[bits], Ord],
 ) =
   ## KZG Commit to a polynomial in Lagrange / Evaluation form
   ## Parallelism: This only returns when computation is fully done
@@ -42,14 +42,14 @@ proc kzg_commit_parallel*[N, bits: static int, Name: static Algebra](
   tp.multiScalarMul_vartime_parallel(commitmentJac, poly.evals, powers_of_tau.evals)
   commitment.affine(commitmentJac)
 
-proc kzg_prove_parallel*[N: static int, Name: static Algebra](
+proc kzg_prove_parallel*[N: static int, Name: static Algebra; Ord: static PolyOrdering](
        tp: Threadpool,
-       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1]],
-       domain: PolyEvalRootsDomain[N, Fr[Name]],
+       powers_of_tau: PolynomialEval[N, EC_ShortW_Aff[Fp[Name], G1], Ord],
+       domain: PolyEvalRootsDomain[N, Fr[Name], Ord],
        eval_at_challenge: var Fr[Name],
        proof: var EC_ShortW_Aff[Fp[Name], G1],
-       poly: PolynomialEval[N, Fr[Name]],
-       opening_challenge: Fr[Name]) =
+       poly: PolynomialEval[N, Fr[Name], Ord],
+       opening_challenge: Fr[Name]): void =
   ## KZG prove commitment to a polynomial in Lagrange / Evaluation form
   ##
   ## Outputs:
@@ -64,7 +64,7 @@ proc kzg_prove_parallel*[N: static int, Name: static Algebra](
   #
   # z = opening_challenge in the following code
 
-  let quotientPoly = allocHeapAligned(PolynomialEval[N, Fr[Name]], alignment = 64)
+  let quotientPoly = allocHeapAligned(PolynomialEval[N, Fr[Name], Ord], alignment = 64)
   tp.getQuotientPoly_parallel(
     domain,
     quotientPoly[], eval_at_challenge,

--- a/constantine/commitments/pedersen_commitments.nim
+++ b/constantine/commitments/pedersen_commitments.nim
@@ -35,10 +35,10 @@ func pedersen_commit[EC, ECaff](
   ##   Commit(m) := ∑[mᵢ]Gᵢ
   r.multiScalarMul_vartime(messages, public_generators)
 
-func pedersen_commit*[N: static int, EC, ECaff, F](
-      crs: PolynomialEval[N, EcAff],
+func pedersen_commit*[N: static int, EC, ECaff, F, Ord](
+      crs: PolynomialEval[N, EcAff, Ord],
       r: var EC,
-      messages: PolynomialEval[N, F]) {.inline.} =
+      messages: PolynomialEval[N, F, Ord]) {.inline.} =
   ## Vector Pedersen Commitment with elliptic curves
   ##
   ## Context

--- a/constantine/commitments/protocol_quotient_check.nim
+++ b/constantine/commitments/protocol_quotient_check.nim
@@ -20,9 +20,9 @@ import
 # Lagrange polynomial with domain = roots of unity
 # -------------------------------------------------------------
 
-func getQuotientPolyOffDomain[N: static int, Field](
-       r: var PolynomialEval[N, Field],
-       poly: PolynomialEval[N, Field],
+func getQuotientPolyOffDomain[N: static int, Field, Ord](
+       r: var PolynomialEval[N, Field, Ord],
+       poly: PolynomialEval[N, Field, Ord],
        pZ: Field,
        invDomainMinusZ: array[N, Field]) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
@@ -43,10 +43,10 @@ func getQuotientPolyOffDomain[N: static int, Field](
     r.evals[i].prod(qi, invDomainMinusZ[i])
 
 
-func getQuotientPolyInDomain*[N: static int, Field](
-       domain: PolyEvalRootsDomain[N, Field],
-       r: var PolynomialEval[N, Field],
-       poly: PolynomialEval[N, Field],
+func getQuotientPolyInDomain*[N: static int, Field, Ord](
+       domain: PolyEvalRootsDomain[N, Field, Ord],
+       r: var PolynomialEval[N, Field, Ord],
+       poly: PolynomialEval[N, Field, Ord],
        zIndex: uint32,
        invRootsMinusZ: array[N, Field]) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
@@ -84,15 +84,15 @@ func getQuotientPolyInDomain*[N: static int, Field](
     # Compute contribution of qᵢ to qz which can't be computed directly
     # qz = - ∑ q'ᵢ * ωⁱ/z
     var ri {.noinit.}: Field
-    if domain.isBitReversed:
-      const logN = log2_vartime(uint32 N)
-      let invZidx = N - reverseBits(uint32 zIndex, logN)
-      let canonI = reverseBits(i, logN)
-      let idx = reverseBits((canonI + invZidx) and (N-1), logN)
-      ri.prod(r.evals[i], domain.rootsOfUnity[idx])        # qᵢ * ωⁱ/z  (explanation at the bottom)
+    when Ord == kBitReversed:
+        const logN = log2_vartime(uint32 N)
+        let invZidx = N - reverseBits(uint32 zIndex, logN)
+        let canonI = reverseBits(i, logN)
+        let idx = reverseBits((canonI + invZidx) and (N-1), logN)
+        ri.prod(r.evals[i], domain.rootsOfUnity[idx])        # qᵢ * ωⁱ/z  (explanation at the bottom)
     else:
-      ri.prod(r.evals[i],
-              domain.rootsOfUnity[(i+N-zIndex) and (N-1)]) # qᵢ * ωⁱ/z  (explanation at the bottom)
+        ri.prod(r.evals[i],
+                domain.rootsOfUnity[(i+N-zIndex) and (N-1)]) # qᵢ * ωⁱ/z  (explanation at the bottom)
     r.evals[zIndex] -= ri                                  # r[zIndex] = - ∑ qᵢ * ωⁱ/z
 
     # * 1/z computation detail
@@ -113,11 +113,11 @@ func getQuotientPolyInDomain*[N: static int, Field](
     #   in non-brp order but cache misses are expensive
     #   and brp can benefits from instruction-level parallelism
 
-func getQuotientPoly*[N: static int, Field](
-       domain: PolyEvalRootsDomain[N, Field],
-       quotientPoly: var PolynomialEval[N, Field],
+func getQuotientPoly*[N: static int, Field, Ord](
+       domain: PolyEvalRootsDomain[N, Field, Ord],
+       quotientPoly: var PolynomialEval[N, Field, Ord],
        eval_at_challenge: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, Ord],
        opening_challenge: Field) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
   ##
@@ -166,8 +166,8 @@ func getQuotientPoly*[N: static int, Field](
 
 func getQuotientPolyInDomain*[N: static int, Field](
        lindom: PolyEvalLinearDomain[N, Field],
-       r: var PolynomialEval[N, Field],
-       poly: PolynomialEval[N, Field],
+       r: var PolynomialEval[N, Field, kNaturalOrder],
+       poly: PolynomialEval[N, Field, kNaturalOrder],
        zIndex: uint32) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
   ##

--- a/constantine/commitments/protocol_quotient_check_parallel.nim
+++ b/constantine/commitments/protocol_quotient_check_parallel.nim
@@ -19,10 +19,10 @@ import
 ##
 ## ############################################################
 
-proc getQuotientPolyOffDomain_parallel*[N: static int, Field](
+proc getQuotientPolyOffDomain_parallel*[N: static int, Field; Ord: static PolyOrdering](
       tp: Threadpool,
-      r: ptr PolynomialEval[N, Field],
-      poly: ptr PolynomialEval[N, Field],
+      r: ptr PolynomialEval[N, Field, Ord],
+      poly: ptr PolynomialEval[N, Field, Ord],
       pZ: ptr Field,
       invRootsMinusZ: ptr array[N, Field]) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
@@ -50,11 +50,11 @@ proc getQuotientPolyOffDomain_parallel*[N: static int, Field](
       qi.diff(poly.evals[i], pZ[])
       r.evals[i].prod(qi, invRootsMinusZ[i])
 
-proc getQuotientPolyInDomain_parallel*[N: static int, Field](
+proc getQuotientPolyInDomain_parallel*[N: static int, Field; Ord: static PolyOrdering](
       tp: Threadpool,
-      domain: ptr PolyEvalRootsDomain[N, Field],
-      r: ptr PolynomialEval[N, Field],
-      poly: ptr PolynomialEval[N, Field],
+      domain: ptr PolyEvalRootsDomain[N, Field, Ord],
+      r: ptr PolynomialEval[N, Field, Ord],
+      poly: ptr PolynomialEval[N, Field, Ord],
       zIndex: uint32,
       invRootsMinusZ: ptr array[N, Field]) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
@@ -97,7 +97,7 @@ proc getQuotientPolyInDomain_parallel*[N: static int, Field](
           # q'ᵢ = -qᵢ * ωⁱ/z
           # q'idx = ∑ q'ᵢ
           iter_ri.neg(r.evals[i])                                  # -qᵢ
-          if domain.isBitReversed:
+          when Ord == kBitReversed:
             const logN = log2_vartime(uint32 N)
             let invZidx = N - reverseBits(uint32 zIndex, logN)
             let canonI = reverseBits(uint32 i, logN)
@@ -113,12 +113,12 @@ proc getQuotientPolyInDomain_parallel*[N: static int, Field](
 
   r.evals[zIndex] = sync(evalsZindex)
 
-proc getQuotientPoly_parallel*[N: static int, Field](
+proc getQuotientPoly_parallel*[N: static int, Field; Ord: static PolyOrdering](
       tp: Threadpool,
-      domain: PolyEvalRootsDomain[N, Field],
-      quotientPoly: var PolynomialEval[N, Field],
+      domain: PolyEvalRootsDomain[N, Field, Ord],
+      quotientPoly: var PolynomialEval[N, Field, Ord],
       eval_at_challenge: var Field,
-      poly: PolynomialEval[N, Field],
+      poly: PolynomialEval[N, Field, Ord],
       opening_challenge: Field) =
   ## Compute r(x) = (p(x) - p(z)) / (x - z)
   ##

--- a/constantine/commitments_setups/ethereum_kzg_srs.nim
+++ b/constantine/commitments_setups/ethereum_kzg_srs.nim
@@ -8,8 +8,9 @@
 
 import
   constantine/named/algebras,
-  ../math/[ec_shortweierstrass, arithmetic, extension_fields],
-  ../platforms/[allocs, bithacks, fileio],
+  constantine/math/[arithmetic, extension_fields],
+  constantine/math/elliptic/[ec_shortweierstrass_affine, ec_shortweierstrass_jacobian, ec_shortweierstrass_batch_ops],
+  ../platforms/[allocs, bithacks, fileio, views],
   ../serialization/[codecs, codecs_status_codes, codecs_bls12_381],
   ../math/polynomials/[polynomials, fft],
   ../math/io/io_fields
@@ -93,6 +94,7 @@ const ctt_eth_kzg4844_fr_pow2_roots_of_unity = [
 # ------------------------------------------------------------
 
 const FIELD_ELEMENTS_PER_BLOB* = 4096
+const FIELD_ELEMENTS_PER_EXT_BLOB* = 2 * FIELD_ELEMENTS_PER_BLOB
 const KZG_SETUP_G2_LENGTH = 65
 
 # On the number of 𝔾2 points:
@@ -120,9 +122,11 @@ type
 
     # Trusted setup, see https://vitalik.ca/general/2022/03/14/trustedsetup.html
 
-    srs_lagrange_g1*{.align: 64.}: PolynomialEval[FIELD_ELEMENTS_PER_BLOB, EC_ShortW_Aff[Fp[BLS12_381], G1]]
+    srs_lagrange_brp_g1*{.align: 64.}: PolynomialEval[FIELD_ELEMENTS_PER_BLOB, EC_ShortW_Aff[Fp[BLS12_381], G1], kBitReversed]
     # Part of the Structured Reference String (SRS) holding the 𝔾1 points
-    # This is used for committing to polynomials and producing an opening proof at
+    # Stored in bit-reversed evaluation / Lagrange form
+    #
+    # This is used in EIP-4844 for committing to polynomials and producing an opening proof at
     # a random value (chosen via Fiat-Shamir heuristic)
     #
     # Referring to the 𝔾1 generator as G, in monomial basis / coefficient form we would store:
@@ -136,7 +140,7 @@ type
     #
     # https://en.wikipedia.org/wiki/Lagrange_polynomial#Barycentric_form
     #
-    # Conversion can be done with a discrete Fourier transform.
+    # Conversion can be done with a discrete Fourier transform. In EIP-4844 we operate only on the evaluation form of polynomials over 𝔾1 (i.e. the Lagrange basis)
 
     srs_monomial_g2*{.align: 64.}: PolynomialCoef[KZG_SETUP_G2_LENGTH, EC_ShortW_Aff[Fp2[BLS12_381], G2]]
     # Part of the SRS holding the 𝔾2 points
@@ -150,7 +154,12 @@ type
     # For most schemes (Marlin, Plonk, Sonic, Ethereum's Deneb), only [τ]H is needed
     # but Ethereum's sharding will need 64 (65 with the generator H)
 
-    domain*{.align: 64.}: PolyEvalRootsDomain[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]]
+    domain_brp*{.align: 64.}: PolyEvalRootsDomain[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed]
+    # The domain field holds the roots of unity of the polynomial evaluation domain.
+    # Important: for Ethereum, roots of unity are used in bit-reversed order
+
+    ecfft_desc_ext*{.align: 64.}: ECFFT_Descriptor[EC_ShortW_Jac[Fp[BLS12_381], G1]]
+    fft_desc_ext*{.align: 64.}: FrFFT_Descriptor[Fr[BLS12_381]]
 
   TrustedSetupStatus* = enum
     tsSuccess
@@ -166,6 +175,10 @@ func computeRootsOfUnity(dst: var openArray[Fr[BLS12_381]], generatorRootOfUnity
   for i in 1 ..< dst.len:
     dst[i] = cur
     cur *= generatorRootOfUnity
+
+template getRootOfUnityForSize(size: static int): Fr[BLS12_381] =
+  const scale = log2_vartime(uint32 size)
+  ctt_eth_kzg4844_fr_pow2_roots_of_unity[scale]
 
 proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
   ## Read a trusted setup in the reference library c-kzg-4844 format
@@ -221,6 +234,7 @@ proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
 
   block:
     # G1 points - 96 characters + newline
+    # These are the Lagrange form (bit-reversed evaluation) points
     var bufG1Hex {.noInit.}: array[2*g1Bytes+1, char] # On MacOS, an extra byte seems to be needed for fscanf or AddressSanitizer complains
     var bufG1bytes {.noInit.}: array[g1Bytes, byte]
     var charsRead: cint
@@ -229,7 +243,7 @@ proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
       if num_matches != 1 and charsRead != 2*g1Bytes:
         return tsInvalidFile
       bufG1bytes.fromHex(bufG1Hex.toOpenArray(0, 2*g1Bytes-1))
-      let status = ctx.srs_lagrange_g1.evals[i].deserialize_g1_compressed(bufG1bytes)
+      let status = ctx.srs_lagrange_brp_g1.evals[i].deserialize_g1_compressed(bufG1bytes)
       if status != cttCodecEcc_Success:
         c_printf("[Constantine Trusted Setup] Invalid G1 point on line %d: CttCodecEccStatus code %d\n", cint(2+i), status)
         return tsInvalidFile
@@ -250,25 +264,28 @@ proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
         return tsInvalidFile
 
   block:
-    # Roots of Unity
-    ctx.domain.rootsOfUnity.computeRootsOfUnity(
-      generatorRootOfUnity =
-        static(
-          ctt_eth_kzg4844_fr_pow2_roots_of_unity[
-            log2_vartime(uint32 FIELD_ELEMENTS_PER_BLOB)
-          ]
-        )
+    # Initialize FFT descriptors
+    ctx.ecfft_desc_ext = ECFFT_Descriptor[EC_ShortW_Jac[Fp[BLS12_381], G1]].new(
+      order = FIELD_ELEMENTS_PER_EXT_BLOB,
+      generatorRootOfUnity = getRootOfUnityForSize(FIELD_ELEMENTS_PER_EXT_BLOB)
     )
 
-    # Compute the inverse of the domain degree
-    ctx.domain.invMaxDegree.fromUint(ctx.domain.rootsOfUnity.len.uint64)
-    ctx.domain.invMaxDegree.inv_vartime()
+    # Domain: FIELD_ELEMENTS_PER_EXT_BLOB (8192) roots of unity
+    ctx.fft_desc_ext = FrFFT_Descriptor[Fr[BLS12_381]].new(
+      order = FIELD_ELEMENTS_PER_EXT_BLOB,
+      generatorRootOfUnity = getRootOfUnityForSize(FIELD_ELEMENTS_PER_EXT_BLOB)
+    )
 
   block:
-    # Bit-reversal permutations
-    ctx.srs_lagrange_g1.evals.bit_reversal_permutation()
-    ctx.domain.rootsOfUnity.bit_reversal_permutation()
-    ctx.domain.isBitReversed = true
+    # Bit-reverse the Lagrange form points (for EIP-4844 commitments)
+    ctx.srs_lagrange_brp_g1.evals.bit_reversal_permutation()
+
+  block:
+    # Initialize domain (bit-reversed roots of unity for polynomial evaluation)
+    ctx.domain_brp.rootsOfUnity.computeRootsOfUnity(generatorRootOfUnity = getRootOfUnityForSize(FIELD_ELEMENTS_PER_BLOB))
+    ctx.domain_brp.rootsOfUnity.bit_reversal_permutation()
+    ctx.domain_brp.invMaxDegree.fromUint(ctx.domain_brp.rootsOfUnity.len.uint64)
+    ctx.domain_brp.invMaxDegree.inv_vartime()
 
   return tsSuccess
 
@@ -291,5 +308,9 @@ proc trusted_setup_load*(ctx: var ptr EthereumKZGContext, filepath: cstring, for
   return status
 
 proc trusted_setup_delete*(ctx: ptr EthereumKZGContext) {.libPrefix: "ctt_eth_".} =
+  # This is intended for non-nim code.
+  # Nim code would automatically insert destructors
   if not ctx.isNil:
+    `=destroy`(ctx.ecfft_desc_ext)
+    `=destroy`(ctx.fft_desc_ext)
     freeHeapAligned(ctx)

--- a/constantine/commitments_setups/ethereum_kzg_srs.nim
+++ b/constantine/commitments_setups/ethereum_kzg_srs.nim
@@ -298,7 +298,10 @@ proc trusted_setup_load*(ctx: var ptr EthereumKZGContext, filepath: cstring, for
   ## Currently the only format supported
   ## is from the reference implementation c-kzg-4844 text file
 
-  ctx = allocHeapAligned(EthereumKZGContext, alignment = 64)
+  # Use alloc0HeapAligned to zero-initialize memory
+  # This is critical for ARC with custom =destroy procs (e.g., ECFFT_Descriptor, FrFFT_Descriptor)
+  # that free memory - uninitialized garbage pointers would cause double-free crashes
+  ctx = alloc0HeapAligned(EthereumKZGContext, alignment = 64)
 
   var f: File
   let ok = f.open(filepath, kRead)

--- a/constantine/commitments_setups/ethereum_kzg_srs.nim
+++ b/constantine/commitments_setups/ethereum_kzg_srs.nim
@@ -235,6 +235,10 @@ proc load_ckzg4844(ctx: ptr EthereumKZGContext, f: File): TrustedSetupStatus =
   block:
     # G1 points - 96 characters + newline
     # These are the Lagrange form (bit-reversed evaluation) points
+    # Original ceremony files:
+    # - https://github.com/ethereum/kzg-ceremony-verifier/blob/master/output_setups/trusted_setup_4096.json
+    # - https://github.com/ethereum/c-kzg-4844/blob/v2.1.7/src/trusted_setup.txt
+    # On disk, G1 points are stored in natural order and will need bit-reversal
     var bufG1Hex {.noInit.}: array[2*g1Bytes+1, char] # On MacOS, an extra byte seems to be needed for fscanf or AddressSanitizer complains
     var bufG1bytes {.noInit.}: array[g1Bytes, byte]
     var charsRead: cint

--- a/constantine/ethereum_eip4844_kzg.nim
+++ b/constantine/ethereum_eip4844_kzg.nim
@@ -178,7 +178,7 @@ func bytes_to_kzg_proof(dst: var KZGProof, src: array[48, byte]): CttCodecEccSta
   return status
 
 func blob_to_bigint_polynomial(
-       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt()],
+       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt(), kBitReversed],
        blob: Blob): CttCodecScalarStatus =
   ## Convert a blob to a polynomial in evaluation form
 
@@ -196,7 +196,7 @@ func blob_to_bigint_polynomial(
   return cttCodecScalar_Success
 
 func blob_to_field_polynomial(
-       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]],
+       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed],
        blob: Blob): CttCodecScalarStatus =
   ## Convert a blob to a polynomial in evaluation form
 
@@ -288,13 +288,13 @@ func blob_to_kzg_commitment*(
   ##
   ##   with proof = [(p(τ) - p(z)) / (τ-z)]₁
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt()], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt(), kBitReversed], 64)
 
   block HappyPath:
     check HappyPath, poly.blob_to_bigint_polynomial(blob)
 
     var r {.noinit.}: EC_ShortW_Aff[Fp[BLS12_381], G1]
-    kzg_commit(ctx.srs_lagrange_g1, r, poly[])
+    kzg_commit(ctx.srs_lagrange_brp_g1, r, poly[])
     discard dst.serialize_g1_compressed(r)
 
     result = cttEthKzg_Success
@@ -326,7 +326,7 @@ func compute_kzg_proof*(
   var z {.noInit.}: Fr[BLS12_381]
   checkReturn z.bytes_to_bls_field(z_bytes)
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial
@@ -337,8 +337,8 @@ func compute_kzg_proof*(
     var proof {.noInit.}: EC_ShortW_Aff[Fp[BLS12_381], G1] # [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁
 
     kzg_prove(
-      ctx.srs_lagrange_g1,
-      ctx.domain,
+      ctx.srs_lagrange_brp_g1,
+      ctx.domain_brp,
       y, proof,
       poly[],
       z)
@@ -391,7 +391,7 @@ func compute_blob_kzg_proof*(
   checkReturn commitment.bytes_to_kzg_commitment(commitment_bytes)
 
   # Blob -> Polynomial
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial
@@ -406,8 +406,8 @@ func compute_blob_kzg_proof*(
     var proof {.noInit.}: EC_ShortW_Aff[Fp[BLS12_381], G1] # [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁
 
     kzg_prove(
-      ctx.srs_lagrange_g1,
-      ctx.domain,
+      ctx.srs_lagrange_brp_g1,
+      ctx.domain_brp,
       y, proof,
       poly[],
       opening_challenge)
@@ -432,7 +432,7 @@ func verify_blob_kzg_proof*(
   var proof {.noInit.}: KZGProof
   checkReturn proof.bytes_to_kzg_proof(proof_bytes)
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial
@@ -442,7 +442,7 @@ func verify_blob_kzg_proof*(
     var opening_challenge {.noInit.}: Fr[BLS12_381]
     var eval_at_challenge {.noInit.}: Fr[BLS12_381]
     opening_challenge.addr.fiatShamirChallenge(blob, commitment_bytes)
-    ctx.domain.evalPolyAt(eval_at_challenge, poly[], opening_challenge)
+    ctx.domain_brp.evalPolyAt(eval_at_challenge, poly[], opening_challenge)
 
     # KZG verification
     let verif = kzg_verify(EC_ShortW_Aff[Fp[BLS12_381], G1](commitment),
@@ -486,7 +486,7 @@ func verify_blob_kzg_proof_batch*(
   let opening_challenges = allocHeapArrayAligned(Fr[BLS12_381], n, alignment = 64)
   let evals_at_challenges = allocHeapArrayAligned(Fr[BLS12_381].getBigInt(), n, alignment = 64)
   let proofs = allocHeapArrayAligned(KZGProof, n, alignment = 64)
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], alignment = 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], alignment = 64)
 
   block HappyPath:
     for i in 0 ..< n:
@@ -495,7 +495,7 @@ func verify_blob_kzg_proof_batch*(
       opening_challenges[i].addr.fiatShamirChallenge(blobs[i], commitments_bytes[i])
 
       var eval_at_challenge_fr {.noInit.}: Fr[BLS12_381]
-      ctx.domain.evalPolyAt(
+      ctx.domain_brp.evalPolyAt(
         eval_at_challenge_fr,
         poly[], opening_challenges[i]
       )

--- a/constantine/ethereum_eip4844_kzg_parallel.nim
+++ b/constantine/ethereum_eip4844_kzg_parallel.nim
@@ -46,7 +46,7 @@ import ./zoo_exports
 
 proc blob_to_bigint_polynomial_parallel(
        tp: Threadpool,
-       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt()],
+       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt(), kBitReversed],
        blob: Blob): CttCodecScalarStatus =
   ## Convert a blob to a polynomial in evaluation form
   mixin globalStatus
@@ -79,7 +79,7 @@ proc blob_to_bigint_polynomial_parallel(
 
 proc blob_to_field_polynomial_parallel_async(
        tp: Threadpool,
-       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]],
+       dst: ptr PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed],
        blob: Blob): Flowvar[CttCodecScalarStatus] =
   ## Convert a blob to a polynomial in evaluation form
   ## The result is a `Flowvar` handle and MUST be awaited with `sync`
@@ -144,13 +144,13 @@ proc blob_to_kzg_commitment_parallel*(
   ##
   ##   with proof = [(p(τ) - p(z)) / (τ-z)]₁
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt()], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381].getBigInt(), kBitReversed], 64)
 
   block HappyPath:
     check HappyPath, tp.blob_to_bigint_polynomial_parallel(poly, blob)
 
     var r {.noinit.}: EC_ShortW_Aff[Fp[BLS12_381], G1]
-    tp.kzg_commit_parallel(ctx.srs_lagrange_g1, r, poly[])
+    tp.kzg_commit_parallel(ctx.srs_lagrange_brp_g1, r, poly[])
     discard dst.serialize_g1_compressed(r)
 
     result = cttEthKzg_Success
@@ -183,7 +183,7 @@ proc compute_kzg_proof_parallel*(
   var z {.noInit.}: Fr[BLS12_381]
   checkReturn z.bytes_to_bls_field(z_bytes)
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial
@@ -194,8 +194,8 @@ proc compute_kzg_proof_parallel*(
     var proof {.noInit.}: EC_ShortW_Aff[Fp[BLS12_381], G1] # [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁
 
     tp.kzg_prove_parallel(
-      ctx.srs_lagrange_g1,
-      ctx.domain,
+      ctx.srs_lagrange_brp_g1,
+      ctx.domain_brp,
       y, proof,
       poly[],
       z)
@@ -220,7 +220,7 @@ proc compute_blob_kzg_proof_parallel*(
   checkReturn commitment.bytes_to_kzg_commitment(commitment_bytes)
 
   # Blob -> Polynomial
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial, spawn async on other threads
@@ -238,8 +238,8 @@ proc compute_blob_kzg_proof_parallel*(
     var proof {.noInit.}: EC_ShortW_Aff[Fp[BLS12_381], G1] # [proof]₁ = [(p(τ) - p(z)) / (τ-z)]₁
 
     tp.kzg_prove_parallel(
-      ctx.srs_lagrange_g1,
-      ctx.domain,
+      ctx.srs_lagrange_brp_g1,
+      ctx.domain_brp,
       y, proof,
       poly[],
       opening_challenge)
@@ -265,7 +265,7 @@ proc verify_blob_kzg_proof_parallel*(
   var proof {.noInit.}: KZGProof
   checkReturn proof.bytes_to_kzg_proof(proof_bytes)
 
-  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], 64)
+  let poly = allocHeapAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], 64)
 
   block HappyPath:
     # Blob -> Polynomial, spawn async on other threads
@@ -282,7 +282,7 @@ proc verify_blob_kzg_proof_parallel*(
     # Technically we could interleavethe blob_to_field_polynomial_parallel_async
     # and the first part of evalPolyAt_parallel: inverseDifferenceArray
     # but performance cost should be minimal compared to readability.
-    tp.evalPolyAt_parallel(ctx.domain, eval_at_challenge, poly[], opening_challenge)
+    tp.evalPolyAt_parallel(ctx.domain_brp, eval_at_challenge, poly[], opening_challenge)
 
     # KZG verification
     let verif = kzg_verify(EC_ShortW_Aff[Fp[BLS12_381], G1](commitment),
@@ -329,7 +329,7 @@ proc verify_blob_kzg_proof_batch_parallel*(
   let opening_challenges = allocHeapArrayAligned(Fr[BLS12_381], n, alignment = 64)
   let evals_at_challenges = allocHeapArrayAligned(Fr[BLS12_381].getBigInt(), n, alignment = 64)
   let proofs = allocHeapArrayAligned(KZGProof, n, alignment = 64)
-  let polys = allocHeapArrayAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381]], n, alignment = 64)
+  let polys = allocHeapArrayAligned(PolynomialEval[FIELD_ELEMENTS_PER_BLOB, Fr[BLS12_381], kBitReversed], n, alignment = 64)
 
   block HappyPath:
     tp.parallelFor i in 0 ..< n:
@@ -355,7 +355,7 @@ proc verify_blob_kzg_proof_batch_parallel*(
 
           var eval_at_challenge_fr{.noInit.}: Fr[BLS12_381]
           tp.evalPolyAt_parallel(
-            ctx.domain,
+            ctx.domain_brp,
             eval_at_challenge_fr,
             polys[i], opening_challenges[i]
           )

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -4,7 +4,7 @@
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
-# at your option. This file may not be copied, modified, or distributed according to those terms.
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Test with:
 #   nim c -r -d:release --hints:off --warnings:off --outdir:build/tmp --nimcache:nimcache/tmp tests/math_polynomials/t_fft.nim
@@ -142,6 +142,12 @@ func fft_nr*[F](
   ## Domain: roots of unity (no shift)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## The FFT algorithm is NOT in-place safe. Using the same array for both
+  ## input and output will produce incorrect results.
+  ##
+  ## Note: The {.noalias.} annotation documents this requirement but is not
+  ## currently enforced by the compiler. It serves as documentation and may
+  ## be used by future compiler optimizations or static analysis tools.
   if vals.len > desc.order:
     return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
@@ -160,6 +166,20 @@ func fft_nn*[F](
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
   ## FFT from natural order to natural order.
+  ## Input: natural order values
+  ## Output: natural order values in Fourier domain
+  ## Domain: roots of unity (no shift)
+  ##
+  ## Algorithm: FFT (natural to bit-reversed) + Bit-reverse permutation
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ##
+  ## Note: The {.noalias.} annotation documents this requirement but is not
+  ## currently enforced by the compiler. It serves as documentation and may
+  ## be used by future compiler optimizations or static analysis tools.
+  ##
+  ## Use this when you have natural order input and want natural order output.
+  ## If you want bit-reversed output (more efficient), use fft_nr directly.
   let status = fft_nr(desc, output, vals)
   if status != FFT_Success:
     return status
@@ -172,8 +192,17 @@ func ifft_rn*[F](
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime], meter.} =
   ## IFFT from bit-reversed order to natural order.
+  ## Input: bit-reversed order values in Fourier domain
+  ## Output: natural order values
+  ## Domain: roots of unity (no shift)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## The IFFT algorithm is NOT in-place safe. Using the same array for both
+  ## input and output will produce incorrect results.
+  ##
+  ## Note: The {.noalias.} annotation documents this requirement but is not
+  ## currently enforced by the compiler. It serves as documentation and may
+  ## be used by future compiler optimizations or static analysis tools.
   if vals.len > desc.order:
     return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
@@ -201,8 +230,21 @@ func ifft_nn*[F](
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
   ## IFFT from natural order to natural order.
+  ## Input: natural order values in Fourier domain
+  ## Output: natural order values
+  ## Domain: roots of unity (no shift)
+  ##
+  ## Algorithm: Bit-reverse permutation + IFFT (bit-reversed to natural)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## The IFFT algorithm is NOT in-place safe.
+  ##
+  ## Note: The {.noalias.} annotation documents this requirement but is not
+  ## currently enforced by the compiler. It serves as documentation and may
+  ## be used by future compiler optimizations or static analysis tools.
+  ##
+  ## Use this when you have natural order input and want natural order output.
+  ## If you already have bit-reversed input, use ifft_rn directly.
 
   # Create temporary buffer and bit-reverse vals into it (natural → bit-reversed)
   var temp_buf = allocHeapArrayAligned(F, vals.len, alignment = 64)
@@ -213,13 +255,53 @@ func ifft_nn*[F](
   freeHeapAligned(temp_buf)
   return status
 
-# Coset FFT (for Reed-Solomon erasure coding)
+# ############################################################
+#
+#               Coset FFT (for Reed-Solomon erasure coding)
+#
+# ############################################################
+#
+# Coset FFT is used for polynomial division in evaluation form.
+# By shifting the domain, we can divide by polynomials that vanish
+# on points of the original domain without running into division by zero.
+#
+# Background on Reed-Solomon erasure coding:
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# - A polynomial p(x) of degree < k can be uniquely reconstructed from k+1 samples
+# - Extended to degree < 2n using 2n samples (Reed-Solomon encoding)
+# - The extension uses FFT to compute evaluations at 2n points
+#
+# Division by 0 during reconstruction:
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# - When reconstructing from samples, we compute (E * Z)(x) / Z(x)
+#   where E is the "extended" polynomial with zeros for missing samples
+#   and Z is the vanishing polynomial for missing points
+# - Direct division fails when evaluating at points where Z(x) = 0
+# - Coset FFT shifts the domain so Z never evaluates to zero
+#
+# An alternative would be using L'Hôpital's rule
+#
+# Algorithm (from spec):
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Forward (coset_fft):
+#   1. Multiply vals[i] by shift_factor^i for all i
+#   2. Apply standard FFT
+#
+# Inverse (coset_ifft):
+#   1. Apply standard IFFT
+#   2. Multiply result[i] by shift_factor^(-i) for all i
 
 func shift_vals*[F](
        output: var openarray[F],
        vals: openarray[F],
        shift_factor: F) =
   ## Multiply each entry in vals by succeeding powers of shift_factor
+  ## i.e., output[0] = vals[0] * shift_factor^0
+  ##       output[1] = vals[1] * shift_factor^1
+  ##       ...
+  ##       output[n] = vals[n] * shift_factor^n
+  ##
+  ## This is used in coset FFT to shift the evaluation domain.
   var shift_pow {.noInit.}: F
   shift_pow.setOne()
   for i in 0 ..< vals.len:
@@ -231,6 +313,10 @@ func unshift_vals*[F](
        vals: openarray[F],
        inv_shift_factor: F) =
   ## Multiply each entry in vals by succeeding powers of inv_shift_factor
+  ## i.e., output[i] = vals[i] * inv_shift_factor^i
+  ##
+  ## This is the inverse operation of shift_vals
+  ## (uses the inverse of the shift factor)
   var inv_shift_pow {.noInit.}: F
   inv_shift_pow.setOne()
   for i in 0 ..< vals.len:
@@ -243,6 +329,22 @@ func coset_fft_nr*[F](
        vals: openarray[F],
        cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
   ## Compute FFT over a coset of the roots of unity (natural to bit-reversed order).
+  ##
+  ## This is used for polynomial operations where we need to avoid
+  ## division by zero. By shifting the domain, polynomials that vanish
+  ## at certain points won't cause issues during division.
+  ##
+  ## Algorithm:
+  ##   1. Multiply vals[i] by shift_factor^i (shift into coset)
+  ##   2. Apply standard FFT (natural to bit-reversed order)
+  ##
+  ## Parameters:
+  ##   - desc: FFT descriptor with roots of unity
+  ##   - output: output array (must have same length as vals)
+  ##   - vals: input values in evaluation form
+  ##   - cosetShift, the coset shift
+  ##
+  ## Returns FFT_Success on success, error code otherwise
   let n = vals.len
   var shifted = allocHeapArrayAligned(F, n, alignment = 64)
   shifted.toOpenArray(n).shift_vals(vals, cosetShift)
@@ -256,13 +358,58 @@ func coset_ifft_rn*[F](
        vals: openarray[F],
        cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
   ## Compute inverse FFT over a coset of the roots of unity (bit-reversed to natural order).
-  result = desc.ifft_rn(output, vals)
+  ##
+  ## This is used after polynomial division in the coset domain
+  ## to get back the polynomial coefficients.
+  ##
+  ## Algorithm:
+  ##   1. Apply standard IFFT
+  ##   2. Multiply result[i] by shift_factor⁻ⁱ (unshift from coset)
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## The coset IFFT algorithm is NOT in-place safe.
+  ##
+  ## Parameters:
+  ##   - desc: FFT descriptor with roots of unity
+  ##   - output: output array (must have same length as vals)
+  ##   - vals: input values in evaluation form over coset
+  ##   - cosetShift, the coset shift (which will be inverted)
+  ##
+  ## Returns FFT_Success on success, error code otherwise
+  let status = desc.ifft_rn(output, vals)
+  if status != FFT_Success:
+    return status
 
   var inv_shift_factor {.noInit.}: F
   inv_shift_factor.inv_vartime(cosetShift)
   output.unshift_vals(output, inv_shift_factor)
 
   return FFT_Success
+
+# ############################################################
+#
+#                   Elliptic Curve FFT
+#
+# ############################################################
+
+func simpleFT[EC; bits: static int](
+       output: var StridedView[EC],
+       vals: StridedView[EC],
+       rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
+  ## EC naive evaluation (O(n^2) base case for small FFT sizes)
+
+  let L = output.len
+  var last {.noInit.}, v {.noInit.}: EC
+
+  var v0w0 {.noInit.} = vals[0]
+  v0w0.scalarMul_vartime(rootsOfUnity[0])
+
+  for i in 0 ..< L:
+    last = v0w0
+    for j in 1 ..< L:
+      v.scalarMul_vartime(rootsOfUnity[(i*j) mod L], vals[j])
+      last.sum_vartime(last, v)
+    output[i] = last
 
 func fft_internal[EC; bits: static int](
        output: var StridedView[EC],
@@ -493,173 +640,3 @@ func bit_reversal_permutation*[T](buf: var openArray[T]) =
           swap(buf[idx], t[tIdx])
 
   freeHeap(t)
-
-# ############################################################
-#
-#                    Sanity checks
-#
-# ############################################################
-
-when isMainModule:
-
-  import
-    std/[times, monotimes, strformat],
-    helpers/prng_unsafe,
-    constantine/named/zoo_generators,
-    constantine/math/io/[io_fields, io_ec],
-    constantine/platforms/static_for
-
-  const ctt_eth_kzg_fr_pow2_roots_of_unity = [
-    # primitive_root⁽ᵐᵒᵈᵘˡᵘˢ⁻¹⁾/⁽²^ⁱ⁾ for i in [0, 32)
-    # The primitive root chosen is 7
-    Fr[BLS12_381].fromHex"0x1",
-    Fr[BLS12_381].fromHex"0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000",
-    Fr[BLS12_381].fromHex"0x8d51ccce760304d0ec030002760300000001000000000000",
-    Fr[BLS12_381].fromHex"0x345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a",
-    Fr[BLS12_381].fromHex"0x20b1ce9140267af9dd1c0af834cec32c17beb312f20b6f7653ea61d87742bcce",
-    Fr[BLS12_381].fromHex"0x50e0903a157988bab4bcd40e22f55448bf6e88fb4c38fb8a360c60997369df4e",
-    Fr[BLS12_381].fromHex"0x45af6345ec055e4d14a1e27164d8fdbd2d967f4be2f951558140d032f0a9ee53",
-    Fr[BLS12_381].fromHex"0x6898111413588742b7c68b4d7fdd60d098d0caac87f5713c5130c2c1660125be",
-    Fr[BLS12_381].fromHex"0x4f9b4098e2e9f12e6b368121ac0cf4ad0a0865a899e8deff4935bd2f817f694b",
-    Fr[BLS12_381].fromHex"0x95166525526a65439feec240d80689fd697168a3a6000fe4541b8ff2ee0434e",
-    Fr[BLS12_381].fromHex"0x325db5c3debf77a18f4de02c0f776af3ea437f9626fc085e3c28d666a5c2d854",
-    Fr[BLS12_381].fromHex"0x6d031f1b5c49c83409f1ca610a08f16655ea6811be9c622d4a838b5d59cd79e5",
-    Fr[BLS12_381].fromHex"0x564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d36306",
-    Fr[BLS12_381].fromHex"0x485d512737b1da3d2ccddea2972e89ed146b58bc434906ac6fdd00bfc78c8967",
-    Fr[BLS12_381].fromHex"0x56624634b500a166dc86b01c0d477fa6ae4622f6a9152435034d2ff22a5ad9e1",
-    Fr[BLS12_381].fromHex"0x3291357ee558b50d483405417a0cbe39c8d5f51db3f32699fbd047e11279bb6e",
-    Fr[BLS12_381].fromHex"0x2155379d12180caa88f39a78f1aeb57867a665ae1fcadc91d7118f85cd96b8ad",
-    Fr[BLS12_381].fromHex"0x224262332d8acbf4473a2eef772c33d6cd7f2bd6d0711b7d08692405f3b70f10",
-    Fr[BLS12_381].fromHex"0x2d3056a530794f01652f717ae1c34bb0bb97a3bf30ce40fd6f421a7d8ef674fb",
-    Fr[BLS12_381].fromHex"0x520e587a724a6955df625e80d0adef90ad8e16e84419c750194e8c62ecb38d9d",
-    Fr[BLS12_381].fromHex"0x3e1c54bcb947035a57a6e07cb98de4a2f69e02d265e09d9fece7e0e39898d4b",
-    Fr[BLS12_381].fromHex"0x47c8b5817018af4fc70d0874b0691d4e46b3105f04db5844cd3979122d3ea03a",
-    Fr[BLS12_381].fromHex"0xabe6a5e5abcaa32f2d38f10fbb8d1bbe08fec7c86389beec6e7a6ffb08e3363",
-    Fr[BLS12_381].fromHex"0x73560252aa0655b25121af06a3b51e3cc631ffb2585a72db5616c57de0ec9eae",
-    Fr[BLS12_381].fromHex"0x291cf6d68823e6876e0bcd91ee76273072cf6a8029b7d7bc92cf4deb77bd779c",
-    Fr[BLS12_381].fromHex"0x19fe632fd3287390454dc1edc61a1a3c0ba12bb3da64ca5ce32ef844e11a51e",
-    Fr[BLS12_381].fromHex"0xa0a77a3b1980c0d116168bffbedc11d02c8118402867ddc531a11a0d2d75182",
-    Fr[BLS12_381].fromHex"0x23397a9300f8f98bece8ea224f31d25db94f1101b1d7a628e2d0a7869f0319ed",
-    Fr[BLS12_381].fromHex"0x52dd465e2f09425699e276b571905a7d6558e9e3f6ac7b41d7b688830a4f2089",
-    Fr[BLS12_381].fromHex"0xc83ea7744bf1bee8da40c1ef2bb459884d37b826214abc6474650359d8e211b",
-    Fr[BLS12_381].fromHex"0x2c6d4e4511657e1e1339a815da8b398fed3a181fabb30adc694341f608c9dd56",
-    Fr[BLS12_381].fromHex"0x4b5371495990693fad1715b02e5713b5f070bb00e28a193d63e7cb4906ffc93f"
-  ]
-
-  type EC_G1 = EC_ShortW_Prj[Fp[BLS12_381], G1]
-
-  proc roundtrip() =
-    let fftDesc = ECFFT_Descriptor[EC_G1].new(order = 1 shl 4, ctt_eth_kzg_fr_pow2_roots_of_unity[4])
-    defer: `=destroy`(fftDesc)
-
-    var data = newSeq[EC_G1](fftDesc.order)
-    data[0].setGenerator()
-    for i in 1 ..< fftDesc.order:
-      data[i].mixedSum(data[i-1], BLS12_381.getGenerator("G1"))
-
-    var coefs = newSeq[EC_G1](data.len)
-    let fftOk = ec_fft_nr(fftDesc, coefs, data)
-    doAssert fftOk == FFTS_Success
-    # display("coefs", 0, coefs)
-
-    var res = newSeq[EC_G1](data.len)
-    let ifftOk = ec_ifft_rn(fftDesc, res, coefs)
-    doAssert ifftOk == FFTS_Success
-    # display("res", 0, res)
-
-    for i in 0 ..< res.len:
-      if bool(res[i] != data[i]):
-        echo "Error: expected ", data[i].toHex(), " but got ", res[i].toHex()
-        quit 1
-
-    echo "FFT round-trip check SUCCESS"
-
-  proc warmup() =
-    # Warmup - make sure cpu is on max perf
-    let start = cpuTime()
-    var foo = 123
-    for i in 0 ..< 300_000_000:
-      foo += i*i mod 456
-      foo = foo mod 789
-
-    # Compiler shouldn't optimize away the results as cpuTime rely on sideeffects
-    let stop = cpuTime()
-    echo &"Warmup: {stop - start:>4.4f} s, result {foo} (displayed to avoid compiler optimizing warmup away)\n"
-
-
-  proc bench() =
-    echo "Starting benchmark ..."
-    const NumIters = 3
-
-    var rng: RngState
-    rng.seed 0x1234
-    # TODO: view types complain about mutable borrow
-    # in `random_unsafe` due to pseudo view type LimbsViewMut
-    # (which was views before Nim properly supported them)
-
-    warmup()
-
-    for scale in 4 ..< 10:
-      # Setup
-
-      let fftDesc = ECFFT_Descriptor[EC_G1].new(order = 1 shl scale, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
-      var data = newSeq[EC_G1](fftDesc.order)
-      data[0].setGenerator()
-      for i in 1 ..< fftDesc.order:
-        data[i].mixedSum(data[i-1], BLS12_381.getGenerator("G1"))
-
-      var coefsOut = newSeq[EC_G1](data.len)
-
-      # Bench
-      let start = getMonotime()
-      for i in 0 ..< NumIters:
-        let status = ec_fft_nr(fftDesc, coefsOut, data)
-        doAssert status == FFTS_Success
-      let stop = getMonotime()
-
-      let ns = inNanoseconds((stop-start) div NumIters)
-      echo &"FFT scale {scale:>2}     {ns:>8} ns/op"
-
-      `=destroy`(fftDesc)
-
-
-  proc bit_reversal() =
-    let k = 28
-
-    echo "Bit-reversal permutation 2^", k, " = ", 1 shl k, " int64"
-
-    var a = newSeq[int64](1 shl k)
-    for i in 0'i64 ..< a.len:
-      a[i] = i
-
-    var b = newSeq[int64](1 shl k)
-
-    let startNaive = getMonotime()
-    for i in 0'i64 ..< a.len:
-      # It's better to make prefetching easy on the write side
-      b[i] = a[int reverseBits(uint64 i, uint64 k)]
-    let stopNaive = getMonotime()
-
-    echo "Naive bit-reversal: ", inMilliseconds(stopNaive-startNaive), " ms"
-
-    let startOpt = getMonotime()
-    a.bit_reversal_permutation()
-    let stopOpt = getMonotime()
-
-    echo "Optimized bit-reversal: ", inMilliseconds(stopOpt-startOpt), " ms"
-
-    doAssert a == b
-    echo "SUCCESS bit reversal permutation"
-
-    block:
-      let optTile = 1 shl optimalLogTileSize(uint64)
-      echo "optimal tile size for uint64: ", optTile, "x", optTile," (", sizeof(uint64) * optTile * optTile, " bytes)"
-
-    block:
-      let optTile = 1 shl optimalLogTileSize(EC_ShortW_Aff[Fp[BLS12_381], G1])
-      echo "optimal tile size for EC_ShortW_Aff[Fp[BLS12_381], G1]: ", optTile, "x", optTile," (", sizeof(EC_ShortW_Aff[Fp[BLS12_381], G1]) * optTile * optTile, " bytes)"
-
-  roundtrip()
-  warmup()
-  bench()
-  bit_reversal()

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -30,9 +30,6 @@ func bit_reversal_permutation*[T](buf: var openArray[T])
 #
 # ############################################################
 
-# Elliptic curve Fast Fourier Transform
-# ----------------------------------------------------------------
-
 type
   FFTStatus* = enum
     FFT_Success
@@ -59,6 +56,12 @@ proc `=destroy`*[EC](ctx: ECFFT_Descriptor[EC]) =
   if not ctx.rootsOfUnity.isNil():
     ctx.rootsOfUnity.freeHeapAligned()
 
+# ############################################################
+#
+#                   Field FFT
+#
+# ############################################################
+
 func computeRootsOfUnity[F](ctx: var FrFFT_Descriptor[F], generatorRootOfUnity: F) =
   ctx.rootsOfUnity[0].setOne()
 
@@ -75,29 +78,12 @@ func new*(T: type FrFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
 
   result.computeRootsOfUnity(generatorRootOfUnity)
 
-func computeRootsOfUnity[EC](ctx: var ECFFT_Descriptor[EC], generatorRootOfUnity: auto) =
-  static: doAssert typeof(generatorRootOfUnity) is Fr[EC.getName()]
-
-  ctx.rootsOfUnity[0].setOne()
-
-  var cur = generatorRootOfUnity
-  for i in 1 .. ctx.order:
-    ctx.rootsOfUnity[i].fromField(cur)
-    cur *= generatorRootOfUnity
-
-  doAssert ctx.rootsOfUnity[ctx.order].isOne().bool()
-
-func new*(T: type ECFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
-  result.order = order
-  result.rootsOfUnity = allocHeapArrayAligned(T.EC.getScalarField().getBigInt(), order+1, alignment = 64)
-
-  result.computeRootsOfUnity(generatorRootOfUnity)
-
-func simpleFT[F](
+func simpleFT_nn[F](
        output: var StridedView[F],
        vals: StridedView[F],
        rootsOfUnity: StridedView[F]) =
   ## Polynomial naive evaluation (naive is O(n^2))
+  ## Produces natural order output from natural order input
 
   let L = output.len
   var last {.noInit.}, v {.noInit.}: F
@@ -109,20 +95,20 @@ func simpleFT[F](
       last += v
     output[i] = last
 
-func fft_internal[F](
+func fft_internal_nn[F](
        output: var StridedView[F],
        vals: StridedView[F],
        rootsOfUnity: StridedView[F]) =
   if output.len <= 4:
-    simpleFT(output, vals, rootsOfUnity)
+    simpleFT_nn(output, vals, rootsOfUnity)
     return
 
   let (evenVals, oddVals) = vals.splitAlternate()
   var (outLeft, outRight) = output.splitHalf()
   let halfROI = rootsOfUnity.skipHalf()
 
-  fft_internal(outLeft, evenVals, halfROI)
-  fft_internal(outRight, oddVals, halfROI)
+  fft_internal_nn(outLeft, evenVals, halfROI)
+  fft_internal_nn(outRight, oddVals, halfROI)
 
   let half = outLeft.len
   var y_times_root{.noinit.}: F
@@ -132,13 +118,13 @@ func fft_internal[F](
     output[i+half] .diff(output[i], y_times_root)
     output[i]      += y_times_root
 
-func fft_nr*[F](
+func fft_nn*[F](
        desc: FrFFT_Descriptor[F],
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime], meter.} =
-  ## FFT from natural order to bit-reversed order.
+  ## FFT from natural order to natural order.
   ## Input: natural order values
-  ## Output: bit-reversed order values in Fourier domain
+  ## Output: natural order values in Fourier domain
   ## Domain: roots of unity (no shift)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
@@ -158,19 +144,19 @@ func fft_nr*[F](
                   .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
-  fft_internal(voutput, vals.toStridedView(), rootz)
+  fft_internal_nn(voutput, vals.toStridedView(), rootz)
   return FFT_Success
 
-func fft_nn*[F](
+func fft_nr*[F](
        desc: FrFFT_Descriptor[F],
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
-  ## FFT from natural order to natural order.
+  ## FFT from natural order to bit-reversed order.
   ## Input: natural order values
-  ## Output: natural order values in Fourier domain
+  ## Output: bit-reversed order values in Fourier domain
   ## Domain: roots of unity (no shift)
   ##
-  ## Algorithm: FFT (natural to bit-reversed) + Bit-reverse permutation
+  ## Algorithm: FFT (natural to natural) + Bit-reverse permutation
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
   ##
@@ -178,21 +164,21 @@ func fft_nn*[F](
   ## currently enforced by the compiler. It serves as documentation and may
   ## be used by future compiler optimizations or static analysis tools.
   ##
-  ## Use this when you have natural order input and want natural order output.
-  ## If you want bit-reversed output (more efficient), use fft_nr directly.
-  let status = fft_nr(desc, output, vals)
+  ## Use this when you have natural order input and want bit-reversed order output.
+  ## If you want natural order output (more convenient), use fft_nn directly.
+  let status = fft_nn(desc, output, vals)
   if status != FFT_Success:
     return status
 
   bit_reversal_permutation(output)
   return FFT_Success
 
-func ifft_rn*[F](
+func ifft_nn*[F](
        desc: FrFFT_Descriptor[F],
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime], meter.} =
-  ## IFFT from bit-reversed order to natural order.
-  ## Input: bit-reversed order values in Fourier domain
+  ## IFFT from natural order to natural order.
+  ## Input: natural order values in Fourier domain
   ## Output: natural order values
   ## Domain: roots of unity (no shift)
   ##
@@ -214,7 +200,7 @@ func ifft_rn*[F](
                   .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
-  fft_internal(voutput, vals.toStridedView(), rootz)
+  fft_internal_nn(voutput, vals.toStridedView(), rootz)
 
   var invLen {.noInit.}: F
   invLen.fromUint(vals.len.uint64)
@@ -225,16 +211,16 @@ func ifft_rn*[F](
 
   return FFT_Success
 
-func ifft_nn*[F](
+func ifft_rn*[F](
        desc: FrFFT_Descriptor[F],
        output{.noalias.}: var openarray[F],
        vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
-  ## IFFT from natural order to natural order.
-  ## Input: natural order values in Fourier domain
+  ## IFFT from bit-reversed order to natural order.
+  ## Input: bit-reversed order values in Fourier domain
   ## Output: natural order values
   ## Domain: roots of unity (no shift)
   ##
-  ## Algorithm: Bit-reverse permutation + IFFT (bit-reversed to natural)
+  ## Algorithm: Bit-reverse permutation + IFFT (natural to natural)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
   ## The IFFT algorithm is NOT in-place safe.
@@ -243,15 +229,15 @@ func ifft_nn*[F](
   ## currently enforced by the compiler. It serves as documentation and may
   ## be used by future compiler optimizations or static analysis tools.
   ##
-  ## Use this when you have natural order input and want natural order output.
-  ## If you already have bit-reversed input, use ifft_rn directly.
+  ## Use this when you have bit-reversed order input and want natural order output.
+  ## If you have natural order input, use ifft_nn directly.
 
-  # Create temporary buffer and bit-reverse vals into it (natural → bit-reversed)
+  # Create temporary buffer and bit-reverse vals into it (bit-reversed → natural)
   var temp_buf = allocHeapArrayAligned(F, vals.len, alignment = 64)
   bit_reversal_permutation(temp_buf.toOpenArray(0, vals.len-1), vals)
 
-  # Call ifft_rn (bit-reversed → natural)
-  let status = ifft_rn(desc, output, temp_buf.toOpenArray(0, vals.len-1))
+  # Call ifft_nn (natural → natural)
+  let status = ifft_nn(desc, output, temp_buf.toOpenArray(0, vals.len-1))
   freeHeapAligned(temp_buf)
   return status
 
@@ -323,12 +309,12 @@ func unshift_vals*[F](
     output[i].prod(vals[i], inv_shift_pow)
     inv_shift_pow *= inv_shift_factor
 
-func coset_fft_nr*[F](
+func coset_fft_nn*[F](
        desc: FrFFT_Descriptor[F],
        output: var openarray[F],
        vals: openarray[F],
        cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
-  ## Compute FFT over a coset of the roots of unity (natural to bit-reversed order).
+  ## Compute FFT over a coset of the roots of unity (natural to natural order).
   ##
   ## This is used for polynomial operations where we need to avoid
   ## division by zero. By shifting the domain, polynomials that vanish
@@ -336,7 +322,7 @@ func coset_fft_nr*[F](
   ##
   ## Algorithm:
   ##   1. Multiply vals[i] by shift_factor^i (shift into coset)
-  ##   2. Apply standard FFT (natural to bit-reversed order)
+  ##   2. Apply standard FFT (natural to natural order)
   ##
   ## Parameters:
   ##   - desc: FFT descriptor with roots of unity
@@ -349,21 +335,21 @@ func coset_fft_nr*[F](
   var shifted = allocHeapArrayAligned(F, n, alignment = 64)
   shifted.toOpenArray(n).shift_vals(vals, cosetShift)
 
-  result = desc.fft_nr(output, shifted.toOpenArray(n))
+  result = desc.fft_nn(output, shifted.toOpenArray(n))
   freeHeapAligned(shifted)
 
-func coset_ifft_rn*[F](
+func coset_ifft_nn*[F](
        desc: FrFFT_Descriptor[F],
        output: var openarray[F],
        vals: openarray[F],
-       cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
-  ## Compute inverse FFT over a coset of the roots of unity (bit-reversed to natural order).
+       cosetShift: F): FFTStatus {.tags: [VarTime], meter.} =
+  ## Compute inverse FFT over a coset of the roots of unity (natural to natural order).
   ##
   ## This is used after polynomial division in the coset domain
   ## to get back the polynomial coefficients.
   ##
   ## Algorithm:
-  ##   1. Apply standard IFFT
+  ##   1. Apply standard IFFT (natural to natural)
   ##   2. Multiply result[i] by shift_factor⁻ⁱ (unshift from coset)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
@@ -376,7 +362,7 @@ func coset_ifft_rn*[F](
   ##   - cosetShift, the coset shift (which will be inverted)
   ##
   ## Returns FFT_Success on success, error code otherwise
-  let status = desc.ifft_rn(output, vals)
+  let status = desc.ifft_nn(output, vals)
   if status != FFT_Success:
     return status
 
@@ -386,17 +372,57 @@ func coset_ifft_rn*[F](
 
   return FFT_Success
 
+func coset_ifft_rn*[F](
+       desc: FrFFT_Descriptor[F],
+       output: var openarray[F],
+       vals: openarray[F],
+       cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## Compute inverse FFT over a coset of the roots of unity (bit-reversed to natural order).
+  ##
+  ## Algorithm:
+  ##   1. Bit-reverse permutation (bit-reversed → natural)
+  ##   2. Apply standard IFFT (natural to natural)
+  ##   3. Multiply result[i] by shift_factor⁻ⁱ (unshift from coset)
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  let n = vals.len
+  var temp_buf = allocHeapArrayAligned(F, n, alignment = 64)
+  bit_reversal_permutation(temp_buf.toOpenArray(0, n-1), vals)
+
+  let status = desc.coset_ifft_nn(output, temp_buf.toOpenArray(0, n-1), cosetShift)
+  freeHeapAligned(temp_buf)
+  return status
+
 # ############################################################
 #
 #                   Elliptic Curve FFT
 #
 # ############################################################
 
-func simpleFT[EC; bits: static int](
+func computeRootsOfUnity[EC](ctx: var ECFFT_Descriptor[EC], generatorRootOfUnity: auto) =
+  static: doAssert typeof(generatorRootOfUnity) is Fr[EC.getName()]
+
+  ctx.rootsOfUnity[0].setOne()
+
+  var cur = generatorRootOfUnity
+  for i in 1 .. ctx.order:
+    ctx.rootsOfUnity[i].fromField(cur)
+    cur *= generatorRootOfUnity
+
+  doAssert ctx.rootsOfUnity[ctx.order].isOne().bool()
+
+func new*(T: type ECFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
+  result.order = order
+  result.rootsOfUnity = allocHeapArrayAligned(T.EC.getScalarField().getBigInt(), order+1, alignment = 64)
+
+  result.computeRootsOfUnity(generatorRootOfUnity)
+
+func simpleFT_nn[EC; bits: static int](
        output: var StridedView[EC],
        vals: StridedView[EC],
        rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
   ## EC naive evaluation (O(n^2) base case for small FFT sizes)
+  ## Produces natural order output from natural order input
 
   let L = output.len
   var last {.noInit.}, v {.noInit.}: EC
@@ -411,12 +437,12 @@ func simpleFT[EC; bits: static int](
       last.sum_vartime(last, v)
     output[i] = last
 
-func fft_internal[EC; bits: static int](
+func fft_internal_nn[EC; bits: static int](
        output: var StridedView[EC],
        vals: StridedView[EC],
        rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
   if output.len <= 4:
-    simpleFT(output, vals, rootsOfUnity)
+    simpleFT_nn(output, vals, rootsOfUnity)
     return
 
   # Recursive Divide-and-Conquer
@@ -424,8 +450,8 @@ func fft_internal[EC; bits: static int](
   var (outLeft, outRight) = output.splitHalf()
   let halfROI = rootsOfUnity.skipHalf()
 
-  fft_internal(outLeft, evenVals, halfROI)
-  fft_internal(outRight, oddVals, halfROI)
+  fft_internal_nn(outLeft, evenVals, halfROI)
+  fft_internal_nn(outRight, oddVals, halfROI)
 
   let half = outLeft.len
   var y_times_root{.noinit.}: EC
@@ -436,10 +462,10 @@ func fft_internal[EC; bits: static int](
     output[i+half] .diff_vartime(output[i], y_times_root)
     output[i]      .sum_vartime(output[i], y_times_root)
 
-func ec_fft_nr*[EC](
+func ec_fft_nn*[EC](
        desc: ECFFT_Descriptor[EC],
        output: var openarray[EC],
-       vals: openarray[EC]): FFTStatus {.tags: [VarTime, HeapAlloc, Alloca], meter.} =
+       vals: openarray[EC]): FFTStatus {.tags: [VarTime, Alloca], meter.} =
   if vals.len > desc.order:
     return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
@@ -450,14 +476,27 @@ func ec_fft_nr*[EC](
                   .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
-  fft_internal(voutput, vals.toStridedView(), rootz)
+  fft_internal_nn(voutput, vals.toStridedView(), rootz)
   return FFT_Success
 
-func ec_ifft_rn*[EC](
+func ec_fft_nr*[EC](
        desc: ECFFT_Descriptor[EC],
        output: var openarray[EC],
        vals: openarray[EC]): FFTStatus {.tags: [VarTime, HeapAlloc, Alloca], meter.} =
-  ## Inverse FFT
+  ## EC FFT from natural order to bit-reversed order
+  ## Algorithm: FFT (natural to natural) + Bit-reverse permutation
+  let status = ec_fft_nn(desc, output, vals)
+  if status != FFT_Success:
+    return status
+
+  bit_reversal_permutation(output)
+  return status
+
+func ec_ifft_nn*[EC](
+       desc: ECFFT_Descriptor[EC],
+       output: var openarray[EC],
+       vals: openarray[EC]): FFTStatus {.tags: [VarTime, Alloca], meter.} =
+  ## Inverse FFT from natural order to natural order
   if vals.len > desc.order:
     return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
@@ -469,7 +508,7 @@ func ec_ifft_rn*[EC](
                   .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
-  fft_internal(voutput, vals.toStridedView(), rootz)
+  fft_internal_nn(voutput, vals.toStridedView(), rootz)
 
   var invLen {.noInit.}: Fr[EC.getName()]
   invLen.fromUint(vals.len.uint64)
@@ -479,6 +518,24 @@ func ec_ifft_rn*[EC](
     output[i].scalarMul_vartime(invLen.toBig())
 
   return FFT_Success
+
+func ec_ifft_rn*[EC](
+       desc: ECFFT_Descriptor[EC],
+       output: var openarray[EC],
+       vals: openarray[EC]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## Inverse FFT from bit-reversed order to natural order
+  ## Algorithm: Bit-reverse permutation + IFFT (natural to natural)
+  if vals.len > desc.order:
+    return FFT_TooManyValues
+  if not vals.len.uint64.isPowerOf2_vartime():
+    return FFT_SizeNotPowerOfTwo
+
+  var temp_buf = allocHeapArrayAligned(EC, vals.len, alignment = 64)
+  bit_reversal_permutation(temp_buf.toOpenArray(0, vals.len-1), vals)
+
+  let status = ec_ifft_nn(desc, output, temp_buf.toOpenArray(0, vals.len-1))
+  freeHeapAligned(temp_buf)
+  return status
 
 # ############################################################
 #

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -4,15 +4,25 @@
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
-# at your option. This file may not be copied, modified, or distributed except according to those terms.
+# at your option. This file may not be copied, modified, or distributed according to those terms.
+
+# Test with:
+#   nim c -r -d:release --hints:off --warnings:off --outdir:build/tmp --nimcache:nimcache/tmp tests/math_polynomials/t_fft.nim
+#   nim c -r -d:release --hints:off --warnings:off --outdir:build/tmp --nimcache:nimcache/tmp tests/math_polynomials/t_fft_coset.nim
 
 import
   constantine/named/algebras,
   constantine/math/arithmetic,
-  constantine/math/io/io_bigints,
+  constantine/math/io/[io_bigints, io_fields],
   constantine/math/ec_shortweierstrass,
   constantine/math/elliptic/ec_scalar_mul_vartime,
   constantine/platforms/[abstractions, allocs, views]
+
+{.push raises: [], checks: off.} # No exceptions
+
+# Forward declarations for bit_reversal_permutation (defined later in file)
+func bit_reversal_permutation*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T])
+func bit_reversal_permutation*[T](buf: var openArray[T])
 
 # ############################################################
 #
@@ -25,9 +35,14 @@ import
 
 type
   FFTStatus* = enum
-    FFTS_Success
-    FFTS_TooManyValues = "Input length greater than the field 2-adicity (number of roots of unity)"
-    FFTS_SizeNotPowerOfTwo = "Input must be of a power of 2 length"
+    FFT_Success
+    FFT_TooManyValues = "Input length greater than the field 2-adicity (number of roots of unity)"
+    FFT_SizeNotPowerOfTwo = "Input must be of a power of 2 length"
+
+  FrFFT_Descriptor*[F] = object
+    ## Metadata for FFT on field elements
+    order*: int
+    rootsOfUnity*: ptr UncheckedArray[F]
 
   ECFFT_Descriptor*[EC] = object
     ## Metadata for FFT on Elliptic Curve
@@ -35,6 +50,30 @@ type
     rootsOfUnity*: ptr UncheckedArray[getBigInt(EC.getName(), kScalarField)]
       ## domain, starting and ending with 1, length is cardinality+1
       ## This allows FFT and inverse FFT to use the same buffer for roots.
+
+proc `=destroy`*[F](ctx: FrFFT_Descriptor[F]) =
+  if not ctx.rootsOfUnity.isNil():
+    ctx.rootsOfUnity.freeHeapAligned()
+
+proc `=destroy`*[EC](ctx: ECFFT_Descriptor[EC]) =
+  if not ctx.rootsOfUnity.isNil():
+    ctx.rootsOfUnity.freeHeapAligned()
+
+func computeRootsOfUnity[F](ctx: var FrFFT_Descriptor[F], generatorRootOfUnity: F) =
+  ctx.rootsOfUnity[0].setOne()
+
+  var cur = generatorRootOfUnity
+  for i in 1 .. ctx.order:
+    ctx.rootsOfUnity[i] = cur
+    cur *= generatorRootOfUnity
+
+  doAssert ctx.rootsOfUnity[ctx.order].isOne().bool()
+
+func new*(T: type FrFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
+  result.order = order
+  result.rootsOfUnity = allocHeapArrayAligned(T.F, order+1, alignment = 64)
+
+  result.computeRootsOfUnity(generatorRootOfUnity)
 
 func computeRootsOfUnity[EC](ctx: var ECFFT_Descriptor[EC], generatorRootOfUnity: auto) =
   static: doAssert typeof(generatorRootOfUnity) is Fr[EC.getName()]
@@ -54,33 +93,181 @@ func new*(T: type ECFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
 
   result.computeRootsOfUnity(generatorRootOfUnity)
 
-func delete*(ctx: ECFFT_Descriptor) =
-  ctx.rootsOfUnity.freeHeapAligned()
-
-func simpleFT[EC; bits: static int](
-       output: var StridedView[EC],
-       vals: StridedView[EC],
-       rootsOfUnity: StridedView[BigInt[bits]]) =
-  # FFT is a recursive algorithm
-  # This is the base-case using a O(n²) algorithm
+func simpleFT[F](
+       output: var StridedView[F],
+       vals: StridedView[F],
+       rootsOfUnity: StridedView[F]) =
+  ## Polynomial naive evaluation (naive is O(n^2))
 
   let L = output.len
-  var last {.noInit.}, v {.noInit.}: EC
-
-  var v0w0 {.noInit.} = vals[0]
-  v0w0.scalarMul_vartime(rootsOfUnity[0])
+  var last {.noInit.}, v {.noInit.}: F
 
   for i in 0 ..< L:
-    last = v0w0
+    last.prod(vals[0], rootsOfUnity[0])
     for j in 1 ..< L:
-      v.scalarMul_vartime(rootsOfUnity[(i*j) mod L], vals[j])
-      last.sum_vartime(last, v)
+      v.prod(vals[j], rootsOfUnity[(i*j) mod L])
+      last += v
     output[i] = last
+
+func fft_internal[F](
+       output: var StridedView[F],
+       vals: StridedView[F],
+       rootsOfUnity: StridedView[F]) =
+  if output.len <= 4:
+    simpleFT(output, vals, rootsOfUnity)
+    return
+
+  let (evenVals, oddVals) = vals.splitAlternate()
+  var (outLeft, outRight) = output.splitHalf()
+  let halfROI = rootsOfUnity.skipHalf()
+
+  fft_internal(outLeft, evenVals, halfROI)
+  fft_internal(outRight, oddVals, halfROI)
+
+  let half = outLeft.len
+  var y_times_root{.noinit.}: F
+
+  for i in 0 ..< half:
+    y_times_root   .prod(output[i+half], rootsOfUnity[i])
+    output[i+half] .diff(output[i], y_times_root)
+    output[i]      += y_times_root
+
+func fft_nr*[F](
+       desc: FrFFT_Descriptor[F],
+       output{.noalias.}: var openarray[F],
+       vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime], meter.} =
+  ## FFT from natural order to bit-reversed order.
+  ## Input: natural order values
+  ## Output: bit-reversed order values in Fourier domain
+  ## Domain: roots of unity (no shift)
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  if vals.len > desc.order:
+    return FFT_TooManyValues
+  if not vals.len.uint64.isPowerOf2_vartime():
+    return FFT_SizeNotPowerOfTwo
+
+  let rootz = desc.rootsOfUnity
+                  .toStridedView(desc.order)
+                  .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
+
+  var voutput = output.toStridedView()
+  fft_internal(voutput, vals.toStridedView(), rootz)
+  return FFT_Success
+
+func fft_nn*[F](
+       desc: FrFFT_Descriptor[F],
+       output{.noalias.}: var openarray[F],
+       vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## FFT from natural order to natural order.
+  let status = fft_nr(desc, output, vals)
+  if status != FFT_Success:
+    return status
+
+  bit_reversal_permutation(output)
+  return FFT_Success
+
+func ifft_rn*[F](
+       desc: FrFFT_Descriptor[F],
+       output{.noalias.}: var openarray[F],
+       vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime], meter.} =
+  ## IFFT from bit-reversed order to natural order.
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  if vals.len > desc.order:
+    return FFT_TooManyValues
+  if not vals.len.uint64.isPowerOf2_vartime():
+    return FFT_SizeNotPowerOfTwo
+
+  let rootz = desc.rootsOfUnity
+                  .toStridedView(desc.order+1)
+                  .reversed()
+                  .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
+
+  var voutput = output.toStridedView()
+  fft_internal(voutput, vals.toStridedView(), rootz)
+
+  var invLen {.noInit.}: F
+  invLen.fromUint(vals.len.uint64)
+  invLen.inv_vartime()
+
+  for i in 0 ..< output.len:
+    output[i] *= invLen
+
+  return FFT_Success
+
+func ifft_nn*[F](
+       desc: FrFFT_Descriptor[F],
+       output{.noalias.}: var openarray[F],
+       vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## IFFT from natural order to natural order.
+  ##
+  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+
+  # Create temporary buffer and bit-reverse vals into it (natural → bit-reversed)
+  var temp_buf = allocHeapArrayAligned(F, vals.len, alignment = 64)
+  bit_reversal_permutation(temp_buf.toOpenArray(0, vals.len-1), vals)
+
+  # Call ifft_rn (bit-reversed → natural)
+  let status = ifft_rn(desc, output, temp_buf.toOpenArray(0, vals.len-1))
+  freeHeapAligned(temp_buf)
+  return status
+
+# Coset FFT (for Reed-Solomon erasure coding)
+
+func shift_vals*[F](
+       output: var openarray[F],
+       vals: openarray[F],
+       shift_factor: F) =
+  ## Multiply each entry in vals by succeeding powers of shift_factor
+  var shift_pow {.noInit.}: F
+  shift_pow.setOne()
+  for i in 0 ..< vals.len:
+    output[i].prod(vals[i], shift_pow)
+    shift_pow *= shift_factor
+
+func unshift_vals*[F](
+       output: var openarray[F],
+       vals: openarray[F],
+       inv_shift_factor: F) =
+  ## Multiply each entry in vals by succeeding powers of inv_shift_factor
+  var inv_shift_pow {.noInit.}: F
+  inv_shift_pow.setOne()
+  for i in 0 ..< vals.len:
+    output[i].prod(vals[i], inv_shift_pow)
+    inv_shift_pow *= inv_shift_factor
+
+func coset_fft_nr*[F](
+       desc: FrFFT_Descriptor[F],
+       output: var openarray[F],
+       vals: openarray[F],
+       cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## Compute FFT over a coset of the roots of unity (natural to bit-reversed order).
+  let n = vals.len
+  var shifted = allocHeapArrayAligned(F, n, alignment = 64)
+  shifted.toOpenArray(n).shift_vals(vals, cosetShift)
+
+  result = desc.fft_nr(output, shifted.toOpenArray(n))
+  freeHeapAligned(shifted)
+
+func coset_ifft_rn*[F](
+       desc: FrFFT_Descriptor[F],
+       output: var openarray[F],
+       vals: openarray[F],
+       cosetShift: F): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+  ## Compute inverse FFT over a coset of the roots of unity (bit-reversed to natural order).
+  result = desc.ifft_rn(output, vals)
+
+  var inv_shift_factor {.noInit.}: F
+  inv_shift_factor.inv_vartime(cosetShift)
+  output.unshift_vals(output, inv_shift_factor)
+
+  return FFT_Success
 
 func fft_internal[EC; bits: static int](
        output: var StridedView[EC],
        vals: StridedView[EC],
-       rootsOfUnity: StridedView[BigInt[bits]]) =
+       rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
   if output.len <= 4:
     simpleFT(output, vals, rootsOfUnity)
     return
@@ -98,53 +285,53 @@ func fft_internal[EC; bits: static int](
 
   for i in 0 ..< half:
     # FFT Butterfly
-    y_times_root   .scalarMul_vartime(output[i+half], rootsOfUnity[i])
+    y_times_root   .scalarMul_vartime(rootsOfUnity[i], output[i+half])
     output[i+half] .diff_vartime(output[i], y_times_root)
     output[i]      .sum_vartime(output[i], y_times_root)
 
-func fft_vartime*[EC](
+func ec_fft_nr*[EC](
        desc: ECFFT_Descriptor[EC],
        output: var openarray[EC],
-       vals: openarray[EC]): FFT_Status =
+       vals: openarray[EC]): FFTStatus {.tags: [VarTime, HeapAlloc, Alloca], meter.} =
   if vals.len > desc.order:
-    return FFTS_TooManyValues
+    return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
-    return FFTS_SizeNotPowerOfTwo
+    return FFT_SizeNotPowerOfTwo
 
   let rootz = desc.rootsOfUnity
                   .toStridedView(desc.order)
-                  .slice(0, desc.order-1, desc.order div vals.len)
+                  .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
   fft_internal(voutput, vals.toStridedView(), rootz)
-  return FFTS_Success
+  return FFT_Success
 
-func ifft_vartime*[EC](
+func ec_ifft_rn*[EC](
        desc: ECFFT_Descriptor[EC],
        output: var openarray[EC],
-       vals: openarray[EC]): FFT_Status =
+       vals: openarray[EC]): FFTStatus {.tags: [VarTime, HeapAlloc, Alloca], meter.} =
   ## Inverse FFT
   if vals.len > desc.order:
-    return FFTS_TooManyValues
+    return FFT_TooManyValues
   if not vals.len.uint64.isPowerOf2_vartime():
-    return FFTS_SizeNotPowerOfTwo
+    return FFT_SizeNotPowerOfTwo
 
   let rootz = desc.rootsOfUnity
                   .toStridedView(desc.order+1) # Extra 1 at the end so that when reversed the buffer starts with 1
                   .reversed()
-                  .slice(0, desc.order-1, desc.order div vals.len)
+                  .slice(0, desc.order-1, desc.order shr log2_vartime(uint vals.len))
 
   var voutput = output.toStridedView()
   fft_internal(voutput, vals.toStridedView(), rootz)
 
-  var invLen {.noInit.}: EC.F.getBigInt()
+  var invLen {.noInit.}: Fr[EC.getName()]
   invLen.fromUint(vals.len.uint64)
-  invLen.invmod_vartime(invLen, EC.F.getModulus())
+  invLen.inv_vartime()
 
   for i in 0 ..< output.len:
-    output[i].scalarMul_vartime(invLen)
+    output[i].scalarMul_vartime(invLen.toBig())
 
-  return FFTS_Success
+  return FFT_Success
 
 # ############################################################
 #
@@ -200,22 +387,35 @@ func deriveLogTileSize(T: type, logN: uint): uint =
   return q
 
 
+func bit_reversal_permutation_naive[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) =
+  ## Out-of-place bit reversal permutation using a naive algorithm.
+  debug: doAssert src.len.uint.isPowerOf2_vartime()
+  debug: doAssert dst.len == src.len
+
+  let logN = log2_vartime(uint src.len)
+  for i in 0'u ..< src.len.uint:
+    dst[int reverseBits(i, logN)] = src[i]
+
+func bit_reversal_permutation*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) =
+  ## Out-of-place bit reversal permutation.
+  bit_reversal_permutation_naive(dst, src)
+
 func bit_reversal_permutation*[T](buf: var openArray[T]) =
   ## In-place bit reversal permutation using a cache-blocking algorithm
   #
   # We adapt the following out-of-place algorithm to in-place.
   #
   # for b = 0 to 2ˆ(lgN-2q) - 1
-  #   b’ = r(b)
+  #   b' = r(b)
   #   for a = 0 to 2ˆq - 1
-  #     a’ = r(a)
+  #     a' = r(a)
   #     for c = 0 to 2ˆq - 1
-  #       T[a’c] = A[abc]
+  #       T[a'c] = A[abc]
   #
   #   for c = 0 to 2ˆq - 1
-  #     c’ = r(c)                <- Note: typo in paper, they say c'=r(a)
-  #     for a’ = 0 to 2ˆq - 1
-  #       B[c’b’a’] = T[a’c]
+  #     c' = r(c)                <- Note: typo in paper, they say c'=r(a)
+  #     for a' = 0 to 2ˆq - 1
+  #       B[c'b'a'] = T[a'c]
   #
   # As we are in-place, A and B refer to the same buffer and
   # we don't want to destructively write to B.
@@ -227,31 +427,31 @@ func bit_reversal_permutation*[T](buf: var openArray[T]) =
   # Hence
   #
   # for b = 0 to 2ˆ(lgN-2q) - 1
-  #   b’ = r(b)
+  #   b' = r(b)
   #   for a = 0 to 2ˆq - 1
-  #     a’ = r(a)
+  #     a' = r(a)
   #     for c = 0 to 2ˆq - 1
-  #       T[a’c] = A[abc]
+  #       T[a'c] = A[abc]
   #
   #   for c = 0 to 2ˆq - 1
-  #     c’ = r(c)
-  #     for a’ = 0 to 2ˆq - 1
+  #     c' = r(c)
+  #     for a' = 0 to 2ˆq - 1
   #       if abc < c'b'a'
-  #         swap(A[c’b’a’], T[a’c])
+  #         swap(A[c'b'a'], T[a'c])
   #
   #   for a = 0 to 2ˆq - 1
-  #     a’ = r(a)
+  #     a' = r(a)
   #     for c = 0 to 2ˆq - 1
-  #       c’ = r(c)
+  #       c' = r(c)
   #       if abc < c'b'a'
-  #         swap(A[abc], T[a’c])
+  #         swap(A[abc], T[a'c])
 
   debug: doAssert buf.len.uint.isPowerOf2_vartime()
 
   let logN = log2_vartime(uint buf.len)
   let logTileSize = deriveLogTileSize(T, logN)
   let logBLen = logN - 2*logTileSize
-  let bLen = 1'u shl logBlen
+  let bLen = 1'u shl logBLen
   let tileSize = 1'u shl logTileSize
 
   let t = allocHeapArray(T, tileSize*tileSize)
@@ -262,7 +462,7 @@ func bit_reversal_permutation*[T](buf: var openArray[T]) =
     for a in 0'u ..< tileSize:
       let aRev = reverseBits(a, logTileSize)
       for c in 0'u ..< tileSize:
-        # T[a’c] = A[abc]
+        # T[a'c] = A[abc]
         let tIdx = (aRev shl logTileSize) or c
         let idx = (a shl (logBLen+logTileSize)) or
                   (b shl logTileSize) or c
@@ -350,7 +550,7 @@ when isMainModule:
 
   proc roundtrip() =
     let fftDesc = ECFFT_Descriptor[EC_G1].new(order = 1 shl 4, ctt_eth_kzg_fr_pow2_roots_of_unity[4])
-    defer: fftDesc.delete()
+    defer: `=destroy`(fftDesc)
 
     var data = newSeq[EC_G1](fftDesc.order)
     data[0].setGenerator()
@@ -358,12 +558,12 @@ when isMainModule:
       data[i].mixedSum(data[i-1], BLS12_381.getGenerator("G1"))
 
     var coefs = newSeq[EC_G1](data.len)
-    let fftOk = fft_vartime(fftDesc, coefs, data)
+    let fftOk = ec_fft_nr(fftDesc, coefs, data)
     doAssert fftOk == FFTS_Success
     # display("coefs", 0, coefs)
 
     var res = newSeq[EC_G1](data.len)
-    let ifftOk = ifft_vartime(fftDesc, res, coefs)
+    let ifftOk = ec_ifft_rn(fftDesc, res, coefs)
     doAssert ifftOk == FFTS_Success
     # display("res", 0, res)
 
@@ -402,7 +602,7 @@ when isMainModule:
     for scale in 4 ..< 10:
       # Setup
 
-      let fftDesc = ECFFTDescriptor[EC_G1].new(order = 1 shl scale, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
+      let fftDesc = ECFFT_Descriptor[EC_G1].new(order = 1 shl scale, ctt_eth_kzg_fr_pow2_roots_of_unity[scale])
       var data = newSeq[EC_G1](fftDesc.order)
       data[0].setGenerator()
       for i in 1 ..< fftDesc.order:
@@ -413,14 +613,14 @@ when isMainModule:
       # Bench
       let start = getMonotime()
       for i in 0 ..< NumIters:
-        let status = fftDesc.fft_vartime(coefsOut, data)
+        let status = ec_fft_nr(fftDesc, coefsOut, data)
         doAssert status == FFTS_Success
       let stop = getMonotime()
 
       let ns = inNanoseconds((stop-start) div NumIters)
       echo &"FFT scale {scale:>2}     {ns:>8} ns/op"
 
-      fftDesc.delete()
+      `=destroy`(fftDesc)
 
 
   proc bit_reversal() =

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -33,6 +33,7 @@ func bit_reversal_permutation*[T](buf: var openArray[T])
 type
   FFTStatus* = enum
     FFT_Success
+    FFT_InconsistentInputOutputLengths = "Output length must match input length"
     FFT_TooManyValues = "Input length greater than the field 2-adicity (number of roots of unity)"
     FFT_SizeNotPowerOfTwo = "Input must be of a power of 2 length"
 
@@ -136,6 +137,8 @@ func fft_nn*[F](
   ## be used by future compiler optimizations or static analysis tools.
   if vals.len > desc.order:
     return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
 
@@ -191,6 +194,8 @@ func ifft_nn*[F](
   ## be used by future compiler optimizations or static analysis tools.
   if vals.len > desc.order:
     return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
 
@@ -228,9 +233,12 @@ func ifft_rn*[F](
   ## Note: The {.noalias.} annotation documents this requirement but is not
   ## currently enforced by the compiler. It serves as documentation and may
   ## be used by future compiler optimizations or static analysis tools.
-  ##
-  ## Use this when you have bit-reversed order input and want natural order output.
-  ## If you have natural order input, use ifft_nn directly.
+  if vals.len > desc.order:
+    return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
+  if not vals.len.uint64.isPowerOf2_vartime():
+    return FFT_SizeNotPowerOfTwo
 
   # Create temporary buffer and bit-reverse vals into it (bit-reversed → natural)
   var temp_buf = allocHeapArrayAligned(F, vals.len, alignment = 64)
@@ -385,6 +393,22 @@ func coset_ifft_rn*[F](
   ##   3. Multiply result[i] by shift_factor⁻ⁱ (unshift from coset)
   ##
   ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## The coset IFFT algorithm is NOT in-place safe.
+  ##
+  ## Parameters:
+  ##   - desc: CosetFFT descriptor with roots of unity and shift factor
+  ##   - output: output array (must have same length as vals)
+  ##   - vals: input values in evaluation form over coset
+  ##   - cosetShift, the coset shift (which will be inverted)
+  ##
+  ## Returns FFT_Success on success, error code otherwise
+  if vals.len > desc.order:
+    return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
+  if not vals.len.uint64.isPowerOf2_vartime():
+    return FFT_SizeNotPowerOfTwo
+  
   let n = vals.len
   var temp_buf = allocHeapArrayAligned(F, n, alignment = 64)
   bit_reversal_permutation(temp_buf.toOpenArray(0, n-1), vals)
@@ -468,6 +492,8 @@ func ec_fft_nn*[EC](
        vals: openarray[EC]): FFTStatus {.tags: [VarTime, Alloca], meter.} =
   if vals.len > desc.order:
     return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
 
@@ -499,6 +525,8 @@ func ec_ifft_nn*[EC](
   ## Inverse FFT from natural order to natural order
   if vals.len > desc.order:
     return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
 
@@ -527,6 +555,8 @@ func ec_ifft_rn*[EC](
   ## Algorithm: Bit-reverse permutation + IFFT (natural to natural)
   if vals.len > desc.order:
     return FFT_TooManyValues
+  if output.len != vals.len:
+    return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
 

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -79,29 +79,12 @@ func new*(T: type FrFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
 
   result.computeRootsOfUnity(generatorRootOfUnity)
 
-func simpleFT_nn[F](
-       output: var StridedView[F],
-       vals: StridedView[F],
-       rootsOfUnity: StridedView[F]) =
-  ## Polynomial naive evaluation (naive is O(n^2))
-  ## Produces natural order output from natural order input
-
-  let L = output.len
-  var last {.noInit.}, v {.noInit.}: F
-
-  for i in 0 ..< L:
-    last.prod(vals[0], rootsOfUnity[0])
-    for j in 1 ..< L:
-      v.prod(vals[j], rootsOfUnity[(i*j) mod L])
-      last += v
-    output[i] = last
-
 func fft_internal_nn[F](
        output: var StridedView[F],
        vals: StridedView[F],
        rootsOfUnity: StridedView[F]) =
-  if output.len <= 4:
-    simpleFT_nn(output, vals, rootsOfUnity)
+  if output.len == 1:
+    output[0] = vals[0]
     return
 
   let (evenVals, oddVals) = vals.splitAlternate()
@@ -408,7 +391,7 @@ func coset_ifft_rn*[F](
     return FFT_InconsistentInputOutputLengths
   if not vals.len.uint64.isPowerOf2_vartime():
     return FFT_SizeNotPowerOfTwo
-  
+
   let n = vals.len
   var temp_buf = allocHeapArrayAligned(F, n, alignment = 64)
   bit_reversal_permutation(temp_buf.toOpenArray(0, n-1), vals)
@@ -441,32 +424,12 @@ func new*(T: type ECFFT_Descriptor, order: int, generatorRootOfUnity: auto): T =
 
   result.computeRootsOfUnity(generatorRootOfUnity)
 
-func simpleFT_nn[EC; bits: static int](
-       output: var StridedView[EC],
-       vals: StridedView[EC],
-       rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
-  ## EC naive evaluation (O(n^2) base case for small FFT sizes)
-  ## Produces natural order output from natural order input
-
-  let L = output.len
-  var last {.noInit.}, v {.noInit.}: EC
-
-  var v0w0 {.noInit.} = vals[0]
-  v0w0.scalarMul_vartime(rootsOfUnity[0])
-
-  for i in 0 ..< L:
-    last = v0w0
-    for j in 1 ..< L:
-      v.scalarMul_vartime(rootsOfUnity[(i*j) mod L], vals[j])
-      last.sum_vartime(last, v)
-    output[i] = last
-
 func fft_internal_nn[EC; bits: static int](
        output: var StridedView[EC],
        vals: StridedView[EC],
        rootsOfUnity: StridedView[BigInt[bits]]) {.tags: [VarTime, Alloca].} =
-  if output.len <= 4:
-    simpleFT_nn(output, vals, rootsOfUnity)
+  if output.len == 1:
+    output[0] = vals[0]
     return
 
   # Recursive Divide-and-Conquer

--- a/constantine/math/polynomials/fft.nim
+++ b/constantine/math/polynomials/fft.nim
@@ -591,8 +591,14 @@ func deriveLogTileSize(T: type, logN: uint): uint =
   return q
 
 
-func bit_reversal_permutation_naive[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) =
+func bit_reversal_permutation_naive*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) {.inline.} =
   ## Out-of-place bit reversal permutation using a naive algorithm.
+  ##
+  ## For each index i, places src[i] into dst[reverseBits(i)].
+  ##
+  ## **IMPORTANT**: `dst` and `src` must NOT alias (be the same array).
+  ## Use the in-place overload if you need to permute in-place.
+
   debug: doAssert src.len.uint.isPowerOf2_vartime()
   debug: doAssert dst.len == src.len
 
@@ -600,12 +606,97 @@ func bit_reversal_permutation_naive[T](dst{.noalias.}: var openArray[T], src{.no
   for i in 0'u ..< src.len.uint:
     dst[int reverseBits(i, logN)] = src[i]
 
-func bit_reversal_permutation*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) =
-  ## Out-of-place bit reversal permutation.
-  bit_reversal_permutation_naive(dst, src)
+func bit_reversal_permutation_naive*[T](buf: var openArray[T]) {.inline, used.} =
+  ## In-place bit reversal permutation using a naive algorithm.
+  ##
+  ## This uses a swap-based approach where we traverse the array and
+  ## swap elements to their bit-reversed positions.
+  ## Only used for benchmarking.
+  ##   Whether for uint32 (4 bytes) to Fr[BLS12_381]
+  ##   the in-place algorithm is at least 2x slower than out-of-place
+  ##   AND tuning the naive vs cobra threshold is trickier
+  ##   and might severely depend on the memory bandwidth
+  ##   and be very different between Apple CPUs and Intel/AMD
+  debug: doAssert buf.len.uint.isPowerOf2_vartime()
 
-func bit_reversal_permutation*[T](buf: var openArray[T]) =
-  ## In-place bit reversal permutation using a cache-blocking algorithm
+  let logN = log2_vartime(uint buf.len)
+  for i in 0'u ..< buf.len.uint:
+    let rev_i = reverseBits(i, logN)
+    if i < rev_i:
+      swap(buf[i], buf[rev_i])
+
+func bit_reversal_permutation_cobra*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) =
+  ## Out-of-place bit reversal permutation using the COBRA algorithm
+  ## (Cache Optimal BitReverse Algorithm from Carter & Gatlin, 1998)
+  ##
+  ## This implements the "square strategy" which is cache-efficient and
+  ## nearly optimal. It uses a temporary buffer that fits in L1 cache.
+  ##
+  ## Algorithm:
+  ##   for b = 0 to 2^(lgN-2q) - 1
+  ##     b' = r(b)
+  ##     for a = 0 to 2^q - 1
+  ##       a' = r(a)
+  ##       for c = 0 to 2^q - 1
+  ##         T[a'c] = A[abc]
+  ##     for c = 0 to 2^q - 1
+  ##       c' = r(c)
+  ##       for a' = 0 to 2^q - 1
+  ##         B[c'b'a'] = T[a'c]
+  ##
+  ## Parameters:
+  ##   - dst: destination array (must have same length as src)
+  ##   - src: source array in natural order
+  ##
+  ## The destination will contain the bit-reversed permutation of src.
+  ##
+  ## **IMPORTANT**: `dst` and `src` must NOT alias (be the same array).
+  ## Use the in-place overload if you need to permute in-place.
+  ##
+  ## Note: The {.noalias.} annotation documents this requirement but is not
+  ## currently enforced by the compiler. It serves as documentation and may
+  ## be used by future compiler optimizations or static analysis tools.
+  debug: doAssert src.len.uint.isPowerOf2_vartime()
+  debug: doAssert dst.len == src.len
+
+  let logN = log2_vartime(uint src.len)
+  let logTileSize = deriveLogTileSize(T, logN)
+  let logBLen = logN - 2*logTileSize
+  let bLen = 1'u shl logBLen
+  let tileSize = 1'u shl logTileSize
+
+  let t = allocHeapArray(T, tileSize*tileSize)
+
+  for b in 0'u ..< bLen:
+    let bRev = reverseBits(b, logBLen)
+
+    for a in 0'u ..< tileSize:
+      let aRev = reverseBits(a, logTileSize)
+      for c in 0'u ..< tileSize:
+        # T[a'c] = A[abc]
+        let tIdx = (aRev shl logTileSize) or c
+        let idx = (a shl (logBLen+logTileSize)) or
+                  (b shl logTileSize) or c
+        t[tIdx] = src[idx]
+
+    for c in 0'u ..< tileSize:
+      let cRev = reverseBits(c, logTileSize)
+      for aRev in 0'u ..< tileSize:
+        let idx = (cRev shl (logBLen+logTileSize)) or
+                  (bRev shl logTileSize) or aRev
+        let tIdx = (aRev shl logTileSize) or c
+        dst[idx] = t[tIdx]
+
+  freeHeap(t)
+
+func bit_reversal_permutation_cobra[T](buf: var openArray[T]) {.used.} =
+  ## In-place bit reversal permutation using the COBRA algorithm.
+  ## Only used for benchmarking.
+  ##   Whether for uint32 (4 bytes) to Fr[BLS12_381]
+  ##   the in-place algorithm is at least 2x slower than out-of-place
+  ##   AND tuning the naive vs cobra threshold is trickier
+  ##   and might severely depend on the memory bandwidth
+  ##   and be very different between Apple CPUs and Intel/AMD
   #
   # We adapt the following out-of-place algorithm to in-place.
   #
@@ -697,3 +788,38 @@ func bit_reversal_permutation*[T](buf: var openArray[T]) =
           swap(buf[idx], t[tIdx])
 
   freeHeap(t)
+
+const bitReversalInPlaceThreshold {.used.} = 18
+  ## Threshold (as log2) above which the COBRA algorithm is used for in-place.
+  ## Below this threshold, the naive algorithm is faster on modern CPUs.
+
+const bitReversalOutOfPlaceThreshold = 7
+  ## Threshold (as log2) above which the COBRA algorithm is used for out-of-place.
+  ## Below this threshold, the naive algorithm is faster on modern CPUs.
+
+func bit_reversal_permutation*[T](dst{.noalias.}: var openArray[T], src{.noalias.}: openArray[T]) {.meter.} =
+  ## Out-of-place bit reversal permutation.
+  ##
+  ## Automatically selects between naive and COBRA algorithms based on size.
+  ## For small sizes (< 2^7 elements), the naive algorithm is faster.
+  ## For larger sizes, the COBRA cache-optimized algorithm is used.
+  debug: doAssert src.len.uint.isPowerOf2_vartime()
+  debug: doAssert dst.len == src.len
+
+  let logN = log2_vartime(uint src.len)
+  if logN >= bitReversalOutOfPlaceThreshold:
+    # Use out-of-place COBRA for large sizes
+    bit_reversal_permutation_cobra(dst, src)
+  else:
+    # Use naive algorithm for small sizes
+    bit_reversal_permutation_naive(dst, src)
+
+func bit_reversal_permutation*[T](buf: var openArray[T]) {.meter.} =
+  ## In-place bit reversal permutation.
+  ##
+  ## Out-of-place is at least 2x faster than in-place so dispatch to out-of-place
+  debug: doAssert buf.len > 0
+  var tmp = allocHeapArrayAligned(T, buf.len, alignment = 64)
+  bit_reversal_permutation(tmp.toOpenArray(0, buf.len-1), buf)
+  buf[0].addr.copyMem(tmp[0].addr, buf.len * sizeof(buf[0]))
+  tmp.freeHeapAligned()

--- a/constantine/math/polynomials/polynomials.nim
+++ b/constantine/math/polynomials/polynomials.nim
@@ -7,8 +7,10 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
+  constantine/named/algebras,
   constantine/math/arithmetic,
   constantine/math/io/io_fields,
+  constantine/math/polynomials/fft,
   constantine/platforms/[primitives, allocs, static_for]
 
 ## ############################################################
@@ -27,7 +29,11 @@ type
     ## p(x) = a₀ + a₁ x + a₂ x² + ... + aₙ₋₁ xⁿ⁻¹
     coefs*{.align: 64.}: array[N, Group]
 
-  PolynomialEval*[N: static int, Group] = object
+  PolyOrdering* = enum
+    kNaturalOrder
+    kBitReversed
+
+  PolynomialEval*[N: static int, Group; Ord: static PolyOrdering] = object
     ## A polynomial in Lagrange basis (evaluation form)
     ##
     ## The evaluation points must be specified either with
@@ -45,7 +51,7 @@ type
     ##   for example [f(0), f(1), ..., f(n-1)]
     evals*{.align: 64.}: array[N, Group]
 
-  PolyEvalRootsDomain*[N: static int, Field] = object
+  PolyEvalRootsDomain*[N: static int, Field; Ord: static PolyOrdering] = object
     ## Metadata for polynomial in Lagrange basis (evaluation form)
     ## with evaluation points at roots of unity.
     ##
@@ -55,16 +61,17 @@ type
     ## This translates into rootsOfUnity[brp((N-brp(i)) and (N-1))] when bit-reversal permuted
     rootsOfUnity*{.align: 64.}: array[N, Field]
     invMaxDegree*: Field
-    isBitReversed*: bool
 
-  PolyEvalDomain*[N: static int, Field] = object
-    ## Metadata for polynomial in Lagrange basis (evaluation form)
+  PolyEvalDomain*[N: static int, Field; Ord: static PolyOrdering] = object
+    ## Metadata for polynomial in evaluation form (Lagrange basis)
     ## with generic evaluation points
 
     domain*{.align: 64.}: array[N, Field]     # Evaluation domain for a polynomial in Lagrange basis
 
-    vanishing_deriv_poly_eval*{.align: 64.}: PolynomialEval[N, Field]     # A'(X) evaluated on domain
-    vanishing_deriv_poly_eval_inv*{.align: 64.}: PolynomialEval[N, Field] # 1/A'(X) evaluated on domain
+    # A'(X) evaluated on domain
+    vanishing_deriv_poly_eval*{.align: 64.}: PolynomialEval[N, Field, Ord]
+    # 1/A'(X) evaluated on domain
+    vanishing_deriv_poly_eval_inv*{.align: 64.}: PolynomialEval[N, Field, Ord]
 
   PolyEvalLinearDomain*[N: static int, Field] = object
     ## Metadata for polynomial in Lagrange basis (evaluation form)
@@ -73,7 +80,7 @@ type
     # This allows more efficient polynomial division on the domain.
     # has we can precompute the inverses 1/(xᵢ-z) with xᵢ,z ∈ [0, ..., n-1]
     # The first element is 1/0 and unused.
-    dom*{.align: 64.}: PolyEvalDomain[N, Field]
+    dom*{.align: 64.}: PolyEvalDomain[N, Field, kNaturalOrder]
     domain_inverses*{.align: 64.}: array[N, Field]
 
 # Polynomials in coefficient form
@@ -123,6 +130,72 @@ func formal_derivative*[N, M: static int, Field](
     degree.fromInt(i)
     polyprime.coefs[i-1].prod(poly.coefs[i], degree)
 
+func polyDiv*[N, M: static int, Field](
+       quotient: var PolynomialCoef[N, Field],
+       dividend: PolynomialCoef[N, Field],
+       divisor: PolynomialCoef[M, Field]) =
+  ## Polynomial long division in coefficient form.
+  ##
+  ## Computes q(X) = dividend(X) / divisor(X)
+  ## such that dividend(X) = q(X) * divisor(X) + r(X)
+  ## where deg(r) < deg(divisor).
+  ##
+  ## This is the "schoolbook" O(n²) polynomial division algorithm.
+  ##
+  ## Parameters:
+  ##   - quotient: Output array for quotient polynomial (size N)
+  ##   - dividend: Input polynomial of degree N-1
+  ##   - divisor: Input polynomial of degree M-1 (must have non-zero leading coeff)
+  ##
+  ## Note: The quotient array must have size at least N-M+1 for the result,
+  ## but we use fixed size N for simplicity.
+  var working {.noInit.}: PolynomialCoef[N, Field]
+  for i in 0 ..< N:
+    working.coefs[i] = dividend.coefs[i]
+
+  let dividendDeg = N - 1
+  let divisorDeg = M - 1
+  var quotientDeg = dividendDeg - divisorDeg
+
+  if quotientDeg < 0:
+    quotientDeg = 0
+
+  var invDivisorLead {.noInit.}: Field
+  invDivisorLead.inv_vartime(divisor.coefs[divisorDeg])
+
+  for i in countdown(quotientDeg, 0):
+    var coef {.noInit.}: Field
+    coef.prod(working.coefs[i + divisorDeg], invDivisorLead)
+    quotient.coefs[i] = coef
+
+    for j in 0 ..< divisorDeg:
+      var subtrahend {.noInit.}: Field
+      subtrahend.prod(divisor.coefs[j], coef)
+      working.coefs[i + j] -= subtrahend
+
+  for i in (quotientDeg + 1) ..< N:
+    quotient.coefs[i].setZero()
+
+func sum*(r: var PolynomialCoef, f, g: PolynomialCoef) =
+  ## Polynomial addition in coefficient form
+  for i in 0 ..< r.coefs.len:
+    r.coefs[i].sum(f.coefs[i], g.coefs[i])
+
+func `+=`*(f: var PolynomialCoef, g: PolynomialCoef) =
+  ## Polynomial addition in coefficient form
+  for i in 0 ..< f.coefs.len:
+    f.coefs[i] += g.coefs[i]
+
+func diff*(r: var PolynomialCoef, f, g: PolynomialCoef) =
+  ## Polynomial subtraction in coefficient form
+  for i in 0 ..< r.coefs.len:
+    r.coefs[i].diff(f.coefs[i], g.coefs[i])
+
+func `-=`*(f: var PolynomialCoef, g: PolynomialCoef) =
+  ## Polynomial subtraction in coefficient form
+  for i in 0 ..< f.coefs.len:
+    f.coefs[i] -= g.coefs[i]
+
 # Polynomials in evaluation/Lagrange form
 # ------------------------------------------------------
 
@@ -162,17 +235,20 @@ func `-=`*(f: var PolynomialEval, g: PolynomialEval) =
   for i in 0 ..< f.evals.len:
     f.evals[i] -= g.evals[i]
 
-func prod*[N, F](r: var PolynomialEval[N, F], s: F, f: PolynomialEval[N, F]) =
+func prod*[N: static int, F, Ord](r: var PolynomialEval[N, F, Ord], s: F, f: PolynomialEval[N, F, Ord]) =
   ## Rescale a polynomial r(X) <- s.f(X)
   for i in 0 ..< N:
     r.evals[i].prod(s, f.evals[i])
 
-func `*=`*[N, F](f: var PolynomialEval[N, F], s: F) =
+func `*=`*[N: static int, F, Ord](f: var PolynomialEval[N, F, Ord], s: F) =
   ## Rescale a polynomial f(X) <- s.f(X)
   for i in 0 ..< N:
     f.evals[i] *= s
 
-func multiplyAccumulate*[N, F](f: var PolynomialEval[N, F], s: F, g: PolynomialEval[N, F]) =
+func multiplyAccumulate*[N: static int, F, Ord](
+      f: var PolynomialEval[N, F, Ord],
+      s: F,
+      g: PolynomialEval[N, F, Ord]) =
   ## Polynomial f(X) += s.g(X)
   for i in 0 ..< N:
     var t {.noInit.}: F
@@ -275,10 +351,10 @@ func inverseDifferenceArray*[N: static int, Field](
 #   Domain = roots of unity
 # ------------------------------------------------------
 
-func evalPolyOffDomainAt*[N: static int, Field](
-       domain: PolyEvalRootsDomain[N, Field],
+func evalPolyOffDomainAt*[N: static int, Field; Ord](
+       domain: PolyEvalRootsDomain[N, Field, Ord],
        r: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, Ord],
        z: Field,
        invRootsMinusZ: array[N, Field]) =
   ## Evaluate a polynomial in evaluation form
@@ -303,10 +379,10 @@ func evalPolyOffDomainAt*[N: static int, Field](
   r *= t
   r *= domain.invMaxDegree
 
-func evalPolyAt*[N: static int, Field](
-       domain: PolyEvalRootsDomain[N, Field],
+func evalPolyAt*[N: static int, Field; Ord](
+       domain: PolyEvalRootsDomain[N, Field, Ord],
        r: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, Ord],
        z: Field) =
   ## Evaluate a polynomial in evaluation form
   ## at the point z
@@ -393,10 +469,10 @@ func evalVanishingPolyDerivativeAtRoot*[N: static int, Field](
       t.diff(z, roots[i])
       r *= t
 
-func evalPolyAt*[N: static int, Field](
-       domain: PolyEvalDomain[N, Field],
+func evalPolyAt*[N: static int, Field; Ord](
+       domain: PolyEvalDomain[N, Field, Ord],
        r: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, Ord],
        z: Field) =
   ## Evaluate a polynomial p at z: r <- p(z)
   ##
@@ -442,8 +518,8 @@ func evalPolyAt*[N: static int, Field](
 
   freeHeapAligned(invZminusDomain)
 
-func computeLagrangeBasisPolysAt*[N: static int, Field](
-      domain: PolyEvalDomain[N, Field],
+func computeLagrangeBasisPolysAt*[N: static int, Field; Ord](
+      domain: PolyEvalDomain[N, Field, Ord],
       lagrangePolys: var array[N, Field],
       z: Field) =
   ## A polynomial p(X) in evaluation form
@@ -511,7 +587,7 @@ func computeLagrangeBasisPolysAt*[N: static int, Field](
 func evalPolyAt*[N: static int, Field](
        lindom: PolyEvalLinearDomain[N, Field],
        r: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, kNaturalOrder],
        z: Field) =
   lindom.dom.evalPolyAt(r, poly, z)
 
@@ -522,7 +598,7 @@ func computeLagrangeBasisPolysAt*[N: static int, Field](
   lindom.dom.computeLagrangeBasisPolysAt(lagrangePolys, z)
 
 func setupLinearEvaluationDomain*[N: static int, Field](
-      lindom: var PolyEvalLinearDomain[N, Field]) =
+       lindom: var PolyEvalLinearDomain[N, Field]) =
   ## Configure a linear evaluation domain [0, ..., n-1]
   ## for computation with polynomials in barycentric Lagrange form
 
@@ -540,3 +616,15 @@ func setupLinearEvaluationDomain*[N: static int, Field](
 
   lindom.dom.vanishing_deriv_poly_eval_inv.evals
     .batchInv_vartime(lindom.dom.vanishing_deriv_poly_eval.evals)
+
+func computeCoefPoly*[N: static int, Name: static Algebra](
+       dst: var PolynomialCoef[N, Fr[Name]],
+       polynomial: PolynomialEval[N, Fr[Name], kBitReversed],
+       fft_desc: FrFFT_Descriptor[Fr[Name]]) =
+  ## Convert polynomial from evaluation form to coefficient form.
+  ## Input:
+  ##   a polynomial in evaluation form, with evals stored in bit-reversed order.
+  ## Output:
+  ##   a polynomial in coefficient form, with coefficients stored in natural order
+  let status = ifft_rn(fft_desc, dst.coefs, polynomial.evals)
+  doAssert status == FFT_Success

--- a/constantine/math/polynomials/polynomials.nim
+++ b/constantine/math/polynomials/polynomials.nim
@@ -149,32 +149,38 @@ func polyDiv*[N, M: static int, Field](
   ##
   ## Note: The quotient array must have size at least N-M+1 for the result,
   ## but we use fixed size N for simplicity.
-  var working {.noInit.}: PolynomialCoef[N, Field]
-  for i in 0 ..< N:
-    working.coefs[i] = dividend.coefs[i]
 
-  let dividendDeg = N - 1
-  let divisorDeg = M - 1
-  var quotientDeg = dividendDeg - divisorDeg
+  static: doAssert M > 0
+  when M > N:
+    for i in 0 ..< N:
+      quotient.coefs[i].setZero()
+  else:
+    var working {.noInit.}: PolynomialCoef[N, Field]
+    for i in 0 ..< N:
+      working.coefs[i] = dividend.coefs[i]
 
-  if quotientDeg < 0:
-    quotientDeg = 0
+    let dividendDeg = N - 1
+    let divisorDeg = M - 1
+    var quotientDeg = dividendDeg - divisorDeg
 
-  var invDivisorLead {.noInit.}: Field
-  invDivisorLead.inv_vartime(divisor.coefs[divisorDeg])
+    if quotientDeg < 0:
+      quotientDeg = 0
 
-  for i in countdown(quotientDeg, 0):
-    var coef {.noInit.}: Field
-    coef.prod(working.coefs[i + divisorDeg], invDivisorLead)
-    quotient.coefs[i] = coef
+    var invDivisorLead {.noInit.}: Field
+    invDivisorLead.inv_vartime(divisor.coefs[divisorDeg])
 
-    for j in 0 ..< divisorDeg:
-      var subtrahend {.noInit.}: Field
-      subtrahend.prod(divisor.coefs[j], coef)
-      working.coefs[i + j] -= subtrahend
+    for i in countdown(quotientDeg, 0):
+      var coef {.noInit.}: Field
+      coef.prod(working.coefs[i + divisorDeg], invDivisorLead)
+      quotient.coefs[i] = coef
 
-  for i in (quotientDeg + 1) ..< N:
-    quotient.coefs[i].setZero()
+      for j in 0 ..< divisorDeg:
+        var subtrahend {.noInit.}: Field
+        subtrahend.prod(divisor.coefs[j], coef)
+        working.coefs[i + j] -= subtrahend
+
+    for i in (quotientDeg + 1) ..< N:
+      quotient.coefs[i].setZero()
 
 func sum*(r: var PolynomialCoef, f, g: PolynomialCoef) =
   ## Polynomial addition in coefficient form

--- a/constantine/math/polynomials/polynomials_parallel.nim
+++ b/constantine/math/polynomials/polynomials_parallel.nim
@@ -21,11 +21,11 @@ import
 ##
 ## ############################################################
 
-proc evalPolyOffDomainAt_parallel*[N: static int, Field](
+proc evalPolyOffDomainAt_parallel*[N: static int, Field; Ordering: static PolyOrdering](
        tp: Threadpool,
-       domain: ptr PolyEvalRootsDomain[N, Field],
+       domain: ptr PolyEvalRootsDomain[N, Field, Ordering],
        r: var Field,
-       poly: ptr PolynomialEval[N, Field],
+       poly: ptr PolynomialEval[N, Field, Ordering],
        z: ptr Field,
        invRootsMinusZ: ptr array[N, Field]) =
   ## Evaluate a polynomial in evaluation form
@@ -64,11 +64,11 @@ proc evalPolyOffDomainAt_parallel*[N: static int, Field](
   r.prod(t, domain.invMaxDegree)
   r *= sync(globalSum)
 
-proc evalPolyAt_parallel*[N: static int, Field](
+proc evalPolyAt_parallel*[N: static int, Field; Ordering: static PolyOrdering](
        tp: Threadpool,
-       domain: PolyEvalRootsDomain[N, Field],
+       domain: PolyEvalRootsDomain[N, Field, Ordering],
        r: var Field,
-       poly: PolynomialEval[N, Field],
+       poly: PolynomialEval[N, Field, Ordering],
        z: Field) =
   ## Evaluate a polynomial in evaluation form
   ## at the point z

--- a/constantine/platforms/allocs.nim
+++ b/constantine/platforms/allocs.nim
@@ -88,6 +88,24 @@ proc allocHeapArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T] {.inl
 proc freeHeap*(p: pointer) {.inline.} =
   free(p)
 
+proc alloc0Heap*(T: typedesc): ptr T {.inline.} =
+  ## Heap allocation with zero initialization
+  result = cast[type result](malloc(sizeof(T)))
+  zeroMem(result, sizeof(T))
+
+proc alloc0HeapUnchecked*(T: typedesc, size: int): ptr T {.inline.} =
+  ## Heap allocation for types containing a variable-sized UncheckedArray field
+  ## with zero initialization
+  result = cast[type result](malloc(size))
+  zeroMem(result, size)
+
+proc alloc0HeapArray*(T: typedesc, len: SomeInteger): ptr UncheckedArray[T] {.inline.} =
+  ## Heap allocation with zero initialization
+  {.warning[CastSizes]:off.}:
+    let size = sizeof(T) * cast[int](len)
+    result = cast[type result](malloc(size))
+    zeroMem(result, size)
+
 proc allocHeapAligned*(T: typedesc, alignment: static Natural): ptr T {.inline.} =
   # aligned_alloc requires allocating in multiple of the alignment.
   let # Cannot be static with bitfields. Workaround https://github.com/nim-lang/Nim/issues/19040
@@ -122,3 +140,42 @@ proc allocHeapUncheckedAlignedPtr*(T: typedesc[ptr], size: int, alignment: stati
 
 proc freeHeapAligned*(p: pointer) {.inline.} =
   aligned_free(p)
+
+proc alloc0HeapAligned*(T: typedesc, alignment: static Natural): ptr T {.inline.} =
+  ## Aligned heap allocation with zero initialization
+  # aligned_alloc requires allocating in multiple of the alignment.
+  let # Cannot be static with bitfields. Workaround https://github.com/nim-lang/Nim/issues/19040
+    size = sizeof(T)
+    requiredMem = size.round_step_up(alignment)
+
+  result = cast[ptr T](aligned_alloc(alignment, requiredMem))
+  zeroMem(result, requiredMem)
+
+proc alloc0HeapUncheckedAligned*(T: typedesc, size: int, alignment: static Natural): ptr T {.inline.} =
+  ## Aligned heap allocation for types containing a variable-sized UncheckedArray field
+  ## or an importc type with missing size information
+  ## with zero initialization
+  # aligned_alloc requires allocating in multiple of the alignment.
+  let requiredMem = size.round_step_up(alignment)
+
+  result = cast[ptr T](aligned_alloc(alignment, requiredMem))
+  zeroMem(result, requiredMem)
+
+proc alloc0HeapArrayAligned*(T: typedesc, len: int, alignment: static Natural): ptr UncheckedArray[T] {.inline.} =
+  ## Aligned heap allocation with zero initialization
+  # aligned_alloc requires allocating in multiple of the alignment.
+  let
+    size = sizeof(T) * len
+    requiredMem = size.round_step_up(alignment)
+
+  result = cast[ptr UncheckedArray[T]](aligned_alloc(alignment, requiredMem))
+  zeroMem(result, size)
+
+proc alloc0HeapAlignedPtr*(T: typedesc[ptr], alignment: static Natural): T {.inline.} =
+  alloc0HeapAligned(typeof(default(T)[]), alignment)
+
+proc alloc0HeapUncheckedAlignedPtr*(T: typedesc[ptr], size: int, alignment: static Natural): T {.inline.} =
+  ## Aligned heap allocation for types containing a variable-sized UncheckedArray field
+  ## or an importc type with missing size information
+  ## with zero initialization
+  alloc0HeapUncheckedAligned(typeof(default(T)[]), size, alignment)

--- a/research/kzg/fft_fr.nim
+++ b/research/kzg/fft_fr.nim
@@ -88,13 +88,14 @@ func expandRootOfUnity[F](rootOfUnity: F): seq[F] =
 # TODO: research Decimation in Time and Decimation in Frequency
 #       and FFT butterflies
 
-func simpleFT[F](
+func simpleFT_nn[F](
        output: var View[F],
        vals: View[F],
        rootsOfUnity: View[F]
      ) =
   # FFT is a recursive algorithm
   # This is the base-case using a O(n²) algorithm
+  # Produces natural order output from natural order input
 
   let L = output.len
   var last {.noInit.}, v {.noInit.}: F
@@ -106,13 +107,13 @@ func simpleFT[F](
       last += v
     output[i] = last
 
-func fft_internal[F](
+func fft_internal_nn[F](
        output: var View[F],
        vals: View[F],
        rootsOfUnity: View[F]
      ) =
   if output.len <= 4:
-    simpleFT(output, vals, rootsOfUnity)
+    simpleFT_nn(output, vals, rootsOfUnity)
     return
 
   # Recursive Divide-and-Conquer
@@ -120,8 +121,8 @@ func fft_internal[F](
   var (outLeft, outRight) = output.splitHalf()
   let halfROI = rootsOfUnity.skipHalf()
 
-  fft_internal(outLeft, evenVals, halfROI)
-  fft_internal(outRight, oddVals, halfROI)
+  fft_internal_nn(outLeft, evenVals, halfROI)
+  fft_internal_nn(outRight, oddVals, halfROI)
 
   let half = outLeft.len
   var y_times_root{.noinit.}: F

--- a/research/kzg/fft_g1.nim
+++ b/research/kzg/fft_g1.nim
@@ -93,12 +93,13 @@ func expandRootOfUnity[F](rootOfUnity: F): auto {.noInit.} =
 # FFT Algorithm
 # ----------------------------------------------------------------
 
-func simpleFT[EC; bits: static int](
+func simpleFT_nn[EC; bits: static int](
        output: var View[EC],
        vals: View[EC],
        rootsOfUnity: View[BigInt[bits]]) =
   # FFT is a recursive algorithm
   # This is the base-case using a O(n²) algorithm
+  # Produces natural order output from natural order input
 
   let L = output.len
   var last {.noInit.}, v {.noInit.}: EC
@@ -115,12 +116,12 @@ func simpleFT[EC; bits: static int](
       last.sum_vartime(last, v)
     output[i] = last
 
-func fft_internal[EC; bits: static int](
+func fft_internal_nn[EC; bits: static int](
        output: var View[EC],
        vals: View[EC],
        rootsOfUnity: View[BigInt[bits]]) =
   if output.len <= 4:
-    simpleFT(output, vals, rootsOfUnity)
+    simpleFT_nn(output, vals, rootsOfUnity)
     return
 
   # Recursive Divide-and-Conquer
@@ -128,8 +129,8 @@ func fft_internal[EC; bits: static int](
   var (outLeft, outRight) = output.splitHalf()
   let halfROI = rootsOfUnity.skipHalf()
 
-  fft_internal(outLeft, evenVals, halfROI)
-  fft_internal(outRight, oddVals, halfROI)
+  fft_internal_nn(outLeft, evenVals, halfROI)
+  fft_internal_nn(outRight, oddVals, halfROI)
 
   let half = outLeft.len
   var y_times_root{.noinit.}: EC

--- a/tests/math_polynomials/fft_utils.nim
+++ b/tests/math_polynomials/fft_utils.nim
@@ -1,0 +1,130 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/strformat,
+  constantine/platforms/primitives,
+  constantine/named/algebras,
+  constantine/math/arithmetic,
+  constantine/math/io/io_fields,
+  constantine/math/polynomials/fft,
+  constantine/named/properties_fields
+
+const BLS12_381_Fr_primitive_root = 7
+
+func buildRootLUT(F: type Fr): array[32, F] =
+  var exponent {.noInit.}: BigInt[F.bits()]
+  exponent = F.getPrimeMinus1()
+
+  var i = result.len - 1
+  exponent.shiftRight(i)
+  result[i].fromUint(BLS12_381_Fr_primitive_root)
+  result[i].pow_vartime(exponent)
+
+  while i > 0:
+    result[i-1].square(result[i])
+    dec i
+
+let BLS12_381_Fr_ScaleToRootOfUnity = buildRootLUT(Fr[BLS12_381])
+
+template getRootOfUnityForScale(F: typedesc[Fr], scale: int): auto =
+  {.cast(noSideEffect).}:
+    when F is Fr[BLS12_381]:
+      BLS12_381_Fr_ScaleToRootOfUnity[scale]
+    else:
+      {.error: "Roots of unity computation is not implemented for " & $F.}
+
+func createFFTDescriptor*(F: typedesc[Fr], orderSize: int): FrFFT_Descriptor[F] =
+  let scale = int(log2_vartime(orderSize.uint))
+  let root = getRootOfUnityForScale(F, scale)
+  FrFFT_Descriptor[F].new(order = orderSize, generatorRootOfUnity = root)
+
+func createFFTDescriptor*(EC: typedesc, F: typedesc[Fr], orderSize: int): ECFFT_Descriptor[EC] =
+  let scale = int(log2_vartime(orderSize.uint))
+  let root = getRootOfUnityForScale(F, scale)
+  ECFFT_Descriptor[EC].new(order = orderSize, generatorRootOfUnity = root)
+
+when isMainModule:
+  const ctt_eth_kzg_fr_pow2_roots_of_unity = [
+    # primitive_root⁽ᵐᵒᵈᵘˡᵘˢ⁻¹⁾/⁽²^ⁱ⁾ for i in [0, 32)
+    # The primitive root chosen is 7
+    Fr[BLS12_381].fromHex"0x1",
+    Fr[BLS12_381].fromHex"0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000",
+    Fr[BLS12_381].fromHex"0x8d51ccce760304d0ec030002760300000001000000000000",
+    Fr[BLS12_381].fromHex"0x345766f603fa66e78c0625cd70d77ce2b38b21c28713b7007228fd3397743f7a",
+    Fr[BLS12_381].fromHex"0x20b1ce9140267af9dd1c0af834cec32c17beb312f20b6f7653ea61d87742bcce",
+    Fr[BLS12_381].fromHex"0x50e0903a157988bab4bcd40e22f55448bf6e88fb4c38fb8a360c60997369df4e",
+    Fr[BLS12_381].fromHex"0x45af6345ec055e4d14a1e27164d8fdbd2d967f4be2f951558140d032f0a9ee53",
+    Fr[BLS12_381].fromHex"0x6898111413588742b7c68b4d7fdd60d098d0caac87f5713c5130c2c1660125be",
+    Fr[BLS12_381].fromHex"0x4f9b4098e2e9f12e6b368121ac0cf4ad0a0865a899e8deff4935bd2f817f694b",
+    Fr[BLS12_381].fromHex"0x95166525526a65439feec240d80689fd697168a3a6000fe4541b8ff2ee0434e",
+    Fr[BLS12_381].fromHex"0x325db5c3debf77a18f4de02c0f776af3ea437f9626fc085e3c28d666a5c2d854",
+    Fr[BLS12_381].fromHex"0x6d031f1b5c49c83409f1ca610a08f16655ea6811be9c622d4a838b5d59cd79e5",
+    Fr[BLS12_381].fromHex"0x564c0a11a0f704f4fc3e8acfe0f8245f0ad1347b378fbf96e206da11a5d36306",
+    Fr[BLS12_381].fromHex"0x485d512737b1da3d2ccddea2972e89ed146b58bc434906ac6fdd00bfc78c8967",
+    Fr[BLS12_381].fromHex"0x56624634b500a166dc86b01c0d477fa6ae4622f6a9152435034d2ff22a5ad9e1",
+    Fr[BLS12_381].fromHex"0x3291357ee558b50d483405417a0cbe39c8d5f51db3f32699fbd047e11279bb6e",
+    Fr[BLS12_381].fromHex"0x2155379d12180caa88f39a78f1aeb57867a665ae1fcadc91d7118f85cd96b8ad",
+    Fr[BLS12_381].fromHex"0x224262332d8acbf4473a2eef772c33d6cd7f2bd6d0711b7d08692405f3b70f10",
+    Fr[BLS12_381].fromHex"0x2d3056a530794f01652f717ae1c34bb0bb97a3bf30ce40fd6f421a7d8ef674fb",
+    Fr[BLS12_381].fromHex"0x520e587a724a6955df625e80d0adef90ad8e16e84419c750194e8c62ecb38d9d",
+    Fr[BLS12_381].fromHex"0x3e1c54bcb947035a57a6e07cb98de4a2f69e02d265e09d9fece7e0e39898d4b",
+    Fr[BLS12_381].fromHex"0x47c8b5817018af4fc70d0874b0691d4e46b3105f04db5844cd3979122d3ea03a",
+    Fr[BLS12_381].fromHex"0xabe6a5e5abcaa32f2d38f10fbb8d1bbe08fec7c86389beec6e7a6ffb08e3363",
+    Fr[BLS12_381].fromHex"0x73560252aa0655b25121af06a3b51e3cc631ffb2585a72db5616c57de0ec9eae",
+    Fr[BLS12_381].fromHex"0x291cf6d68823e6876e0bcd91ee76273072cf6a8029b7d7bc92cf4deb77bd779c",
+    Fr[BLS12_381].fromHex"0x19fe632fd3287390454dc1edc61a1a3c0ba12bb3da64ca5ce32ef844e11a51e",
+    Fr[BLS12_381].fromHex"0xa0a77a3b1980c0d116168bffbedc11d02c8118402867ddc531a11a0d2d75182",
+    Fr[BLS12_381].fromHex"0x23397a9300f8f98bece8ea224f31d25db94f1101b1d7a628e2d0a7869f0319ed",
+    Fr[BLS12_381].fromHex"0x52dd465e2f09425699e276b571905a7d6558e9e3f6ac7b41d7b688830a4f2089",
+    Fr[BLS12_381].fromHex"0xc83ea7744bf1bee8da40c1ef2bb459884d37b826214abc6474650359d8e211b",
+    Fr[BLS12_381].fromHex"0x2c6d4e4511657e1e1339a815da8b398fed3a181fabb30adc694341f608c9dd56",
+    Fr[BLS12_381].fromHex"0x4b5371495990693fad1715b02e5713b5f070bb00e28a193d63e7cb4906ffc93f"
+  ]
+
+  proc test_rootsOfUnityGeneration() =
+    echo "Testing programmatic root of unity generation..."
+
+    type F = Fr[BLS12_381]
+
+    block:
+      echo "Testing getRootOfUnityForScale:"
+      for scale in 0 .. 13:
+        let root = getRootOfUnityForScale(F, scale)
+        echo "  scale ", scale, " (2^", scale, "): ", root.toHex()
+
+    block:
+      echo "\nVerifying against ethereum_kzg_testing_setups_generator values:"
+      var allMatch = true
+      for scale in 0 .. 13:
+        let computed = getRootOfUnityForScale(F, scale)
+        let expected = ctt_eth_kzg_fr_pow2_roots_of_unity[scale]
+        if bool(computed != expected):
+          echo "  MISMATCH at scale ", scale, ":"
+          echo "    computed: ", computed.toHex()
+          echo "    expected: ", expected.toHex()
+          allMatch = false
+        else:
+          echo "  scale ", scale, ": MATCH"
+
+      if allMatch:
+        echo "\nAll roots match!"
+      else:
+        echo "\nSome roots don't match!"
+        quit 1
+
+    block:
+      echo "\nTesting createFFTDescriptor:"
+      for scale in 2 .. 5:
+        let n = 1 shl scale
+        let fftDesc = createFFTDescriptor(F, n)
+        echo "  n=", n, " roots[0]=", fftDesc.rootsOfUnity[0].toHex(), " roots[1]=", fftDesc.rootsOfUnity[1].toHex()
+
+    echo "\nRoot of unity generation tests PASSED"
+
+  test_rootsOfUnityGeneration()

--- a/tests/math_polynomials/fft_utils.nim
+++ b/tests/math_polynomials/fft_utils.nim
@@ -12,27 +12,25 @@ import
   constantine/named/algebras,
   constantine/math/arithmetic,
   constantine/math/io/io_fields,
-  constantine/math/polynomials/fft,
+  constantine/math/polynomials/[polynomials, fft],
   constantine/named/properties_fields
 
-const BLS12_381_Fr_primitive_root = 7
-
-func buildRootLUT(F: type Fr): array[32, F] =
+func buildRootLUT(F: type Fr, primitive_root: uint): array[32, F] =
   var exponent {.noInit.}: BigInt[F.bits()]
   exponent = F.getPrimeMinus1()
 
   var i = result.len - 1
   exponent.shiftRight(i)
-  result[i].fromUint(BLS12_381_Fr_primitive_root)
+  result[i].fromUint(primitive_root)
   result[i].pow_vartime(exponent)
 
   while i > 0:
     result[i-1].square(result[i])
     dec i
 
-let BLS12_381_Fr_ScaleToRootOfUnity = buildRootLUT(Fr[BLS12_381])
+let BLS12_381_Fr_ScaleToRootOfUnity = buildRootLUT(Fr[BLS12_381], primitive_root = 7)
 
-template getRootOfUnityForScale(F: typedesc[Fr], scale: int): auto =
+template getRootOfUnityForScale*(F: typedesc[Fr], scale: int): auto =
   {.cast(noSideEffect).}:
     when F is Fr[BLS12_381]:
       BLS12_381_Fr_ScaleToRootOfUnity[scale]

--- a/tests/math_polynomials/t_bit_reversal.nim
+++ b/tests/math_polynomials/t_bit_reversal.nim
@@ -1,0 +1,277 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Bit-Reversal Permutation Tests
+#
+# Tests for:
+#   - Naive algorithm (simple, cache-unfriendly)
+#   - COBRA algorithm (cache-optimized, Carter & Gatlin 1998)
+#   - Automatic threshold selection
+#   - Involution property (BRP(BRP(x)) = x)
+#   - Correctness across threshold boundaries
+
+import
+  std/strutils,
+  ../../constantine/named/algebras,
+  ../../constantine/math/arithmetic,
+  ../../constantine/math/polynomials/fft {.all.},
+  ../../constantine/math/io/io_fields,
+  ../../constantine/platforms/bithacks
+
+proc testNaiveOutOfPlace*[T](maxLogN: int) =
+  echo "Testing naive out-of-place bit-reversal..."
+  
+  for logN in 1 .. maxLogN:
+    let N = 1 shl logN
+    
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i)
+    
+    var dst = newSeq[T](N)
+    dst.bit_reversal_permutation_naive(src)
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert dst[i] == T(rev_i),
+        "Naive out-of-place failed at logN=" & $logN & " index=" & $i & 
+        " (expected " & $rev_i & " but got " & $dst[i] & ")"
+  
+  echo "  ✓ Naive out-of-place PASSED (logN=1.." & $maxLogN & ")"
+
+proc testCobraOutOfPlace*[T](minLogN, maxLogN: int) =
+  echo "Testing COBRA out-of-place bit-reversal (logN=" & $minLogN & ".." & $maxLogN & ")..."
+  
+  for logN in minLogN .. maxLogN:
+    let N = 1 shl logN
+    
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i)
+    
+    var dst = newSeq[T](N)
+    dst.bit_reversal_permutation_cobra(src)
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert dst[i] == T(rev_i),
+        "COBRA out-of-place failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $dst[i] & ")"
+  
+  echo "  ✓ COBRA out-of-place PASSED (logN=" & $minLogN & ".." & $maxLogN & ")"
+
+proc testNaiveInPlace*[T](maxLogN: int) =
+  echo "Testing naive in-place bit-reversal..."
+  
+  for logN in 1 .. maxLogN:
+    let N = 1 shl logN
+    
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i)
+    
+    buf.bit_reversal_permutation_naive()
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert buf[i] == T(rev_i),
+        "Naive in-place failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $buf[i] & ")"
+  
+  echo "  ✓ Naive in-place PASSED (logN=1.." & $maxLogN & ")"
+
+proc testCobraInPlace*[T](minLogN, maxLogN: int) =
+  echo "Testing COBRA in-place bit-reversal (logN=" & $minLogN & ".." & $maxLogN & ")..."
+  
+  for logN in minLogN .. maxLogN:
+    let N = 1 shl logN
+    
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i)
+    
+    buf.bit_reversal_permutation_cobra()
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert buf[i] == T(rev_i),
+        "COBRA in-place failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $buf[i] & ")"
+  
+  echo "  ✓ COBRA in-place PASSED (logN=" & $minLogN & ".." & $maxLogN & ")"
+
+proc testAutoOutOfPlace*[T](maxLogN: int) =
+  echo "Testing automatic out-of-place bit-reversal (threshold selection)..."
+  
+  for logN in 1 .. maxLogN:
+    let N = 1 shl logN
+    
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i)
+    
+    var dst = newSeq[T](N)
+    bit_reversal_permutation(dst, src)
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert dst[i] == T(rev_i),
+        "Auto out-of-place failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $dst[i] & ")"
+  
+  echo "  ✓ Auto out-of-place PASSED (logN=1.." & $maxLogN & ")"
+
+proc testAutoInPlace*[T](maxLogN: int) =
+  echo "Testing automatic in-place bit-reversal (threshold selection)..."
+  
+  for logN in 1 .. maxLogN:
+    let N = 1 shl logN
+    
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i)
+    
+    buf.bit_reversal_permutation()
+    
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert buf[i] == T(rev_i),
+        "Auto in-place failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $buf[i] & ")"
+  
+  echo "  ✓ Auto in-place PASSED (logN=1.." & $maxLogN & ")"
+
+proc testInvolution*[T](maxLogN: int) =
+  echo "Testing involution property (BRP(BRP(x)) = x) for logN=1.." & $maxLogN & "..."
+  
+  for logN in 1 .. maxLogN:
+    let N = 1 shl logN
+    
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i + 1)  # Use i+1 to avoid all zeros
+    
+    buf.bit_reversal_permutation()
+    buf.bit_reversal_permutation()
+    
+    for i in 0 ..< N:
+      doAssert buf[i] == T(i + 1),
+        "Involution failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $(i+1) & " but got " & $buf[i] & ")"
+  
+  echo "  ✓ Involution property PASSED (logN=1.." & $maxLogN & ")"
+
+proc testThresholdBoundary*[T]() =
+  echo "Testing threshold boundary behavior..."
+  
+  const Threshold = 7  # bitReversalOutOfPlaceThreshold
+  
+  # Test just below threshold (should use naive)
+  let belowN = 1 shl (Threshold - 1)
+  var src_below = newSeq[T](belowN)
+  for i in 0 ..< belowN:
+    src_below[i] = T(i)
+  
+  var dst_below = newSeq[T](belowN)
+  bit_reversal_permutation(dst_below, src_below)
+  
+  for i in 0 ..< belowN:
+    let rev_i = reverseBits(uint32(i), uint32(Threshold - 1))
+    doAssert dst_below[i] == T(rev_i),
+      "Below threshold failed at index=" & $i
+  
+  # Test at threshold (should use COBRA)
+  let atN = 1 shl Threshold
+  var src_at = newSeq[T](atN)
+  for i in 0 ..< atN:
+    src_at[i] = T(i)
+  
+  var dst_at = newSeq[T](atN)
+  bit_reversal_permutation(dst_at, src_at)
+  
+  for i in 0 ..< atN:
+    let rev_i = reverseBits(uint32(i), uint32(Threshold))
+    doAssert dst_at[i] == T(rev_i),
+      "At threshold failed at index=" & $i
+  
+  # Test just above threshold (should use COBRA)
+  let aboveN = 1 shl (Threshold + 1)
+  var src_above = newSeq[T](aboveN)
+  for i in 0 ..< aboveN:
+    src_above[i] = T(i)
+  
+  var dst_above = newSeq[T](aboveN)
+  bit_reversal_permutation(dst_above, src_above)
+  
+  for i in 0 ..< aboveN:
+    let rev_i = reverseBits(uint32(i), uint32(Threshold + 1))
+    doAssert dst_above[i] == T(rev_i),
+      "Above threshold failed at index=" & $i
+  
+  echo "  ✓ Threshold boundary tests PASSED"
+
+proc testLargeSizes*[T]() =
+  echo "Testing large sizes (logN=12..16)..."
+  
+  for logN in 12 .. 16:
+    let N = 1 shl logN
+    
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i)
+    
+    var dst = newSeq[T](N)
+    bit_reversal_permutation(dst, src)
+    
+    # Spot check a few indices instead of all (for speed)
+    let checkIndices = [0, 1, N-1, N div 2, N div 4, 3*N div 4]
+    for i in checkIndices:
+      let rev_i = reverseBits(uint32(i), uint32(logN))
+      doAssert dst[i] == T(rev_i),
+        "Large size failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $dst[i] & ")"
+    
+    echo "  ✓ logN=" & $logN & " (N=" & $N & ") PASSED (spot check)"
+
+when isMainModule:
+  echo "========================================"
+  echo "    Bit-Reversal Permutation Tests"
+  echo "========================================"
+  echo ""
+  
+  testNaiveOutOfPlace[int64](12)
+  echo ""
+  
+  testCobraOutOfPlace[int64](7, 16)
+  echo ""
+  
+  testNaiveInPlace[int64](12)
+  echo ""
+  
+  testCobraInPlace[int64](7, 14)
+  echo ""
+  
+  testAutoOutOfPlace[int64](16)
+  echo ""
+  
+  testAutoInPlace[int64](16)
+  echo ""
+  
+  testInvolution[int64](14)
+  echo ""
+  
+  testThresholdBoundary[int64]()
+  echo ""
+  
+  testLargeSizes[int64]()
+  echo ""
+  
+  echo ""
+  echo "========================================"
+  echo "    All bit-reversal tests PASSED ✓"
+  echo "========================================"

--- a/tests/math_polynomials/t_fft.nim
+++ b/tests/math_polynomials/t_fft.nim
@@ -1,0 +1,217 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# FFT/IFFT Roundtrip Tests
+#
+# Critical for FK20 multi-proof verification where L=2 uses ω=-1 (2nd root).
+# The IFFT must correctly invert the FFT for ALL root orders, not just 4th roots
+# where negation happens to equal inversion (ω = i, -i = i^{-1}).
+
+# Compile and run with:
+#   nim c -r -d:release --hints:off --warnings:off --outdir:build/tmp --nimcache:nimcache/tmp tests/math_polynomials/t_fft.nim
+
+import
+  ../../constantine/named/algebras,
+  ../../constantine/named/zoo_generators,
+  ../../constantine/math/[arithmetic, ec_shortweierstrass],
+  ../../constantine/math/polynomials/fft,
+  ../../constantine/math/io/io_fields,
+  ./fft_utils
+
+proc testBitReversal*(T: typedesc) =
+  echo "Testing bit-reversal permutation..."
+
+  # Test small sizes
+  for logN in 1 .. 10:
+    let N = 1 shl logN
+
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i)
+
+    var dst = newSeq[T](N)
+    bit_reversal_permutation(dst, src)
+
+    # Verify each element is in correct bit-reversed position
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint i, uint logN)
+      doAssert dst[i] == T(rev_i),
+        "Bit-reversal failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $rev_i & " but got " & $dst[i].int & ")"
+
+  # Test in-place version
+  for logN in 1 .. 10:
+    let N = 1 shl logN
+
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i)
+
+    buf.bit_reversal_permutation()
+
+    for i in 0 ..< N:
+      let rev_i = reverseBits(uint i, uint logN)
+      doAssert buf[i] == T(rev_i),
+        "In-place bit-reversal failed at logN=" & $logN & " index=" & $i
+
+  # Test involution property: applying bit-reversal twice returns to original
+  echo "  Testing involution property (BRP(BRP(x)) = x)..."
+  for logN in 1 .. 12:
+    let N = 1 shl logN
+
+    # Test out-of-place version
+    var src = newSeq[T](N)
+    for i in 0 ..< N:
+      src[i] = T(i + 1)  # Use i+1 to avoid all zeros
+
+    var pass1 = newSeq[T](N)
+    var pass2 = newSeq[T](N)
+
+    bit_reversal_permutation(pass1, src)
+    bit_reversal_permutation(pass2, pass1)
+
+    for i in 0 ..< N:
+      doAssert pass2[i] == src[i],
+        "Out-of-place involution failed at logN=" & $logN & " index=" & $i &
+        " (expected " & $src[i].int & " but got " & $pass2[i].int & ")"
+
+    # Test in-place version
+    var buf = newSeq[T](N)
+    for i in 0 ..< N:
+      buf[i] = T(i + 1)
+
+    buf.bit_reversal_permutation()
+    buf.bit_reversal_permutation()
+
+    for i in 0 ..< N:
+      doAssert buf[i] == T(i + 1),
+        "In-place involution failed at logN=" & $logN & " index=" & $i
+
+  echo "  ✓ All bit-reversal tests PASSED"
+
+proc testFrFFTRoundtrip*(F: typedesc[Fr]) =
+  echo "Testing Fr FFT/IFFT roundtrip..."
+
+  for scale in 1 .. 5:
+    let order = 1 shl scale
+    let fftDesc = createFFTDescriptor(F, order)
+
+    block:
+      var data = newSeq[F](order)
+      for i in 0 ..< order:
+        data[i].fromUint(uint64(i + 1))
+
+      var freq = newSeq[F](order)
+      let fftOk = fft_nr(fftDesc, freq, data)
+      doAssert fftOk == FFT_Success
+
+      var recovered = newSeq[F](order)
+      let ifftOk = ifft_rn(fftDesc, recovered, freq)
+      doAssert ifftOk == FFT_Success
+
+      if order == 2:
+        echo "  === Size 2 Debug ==="
+        echo "  FFT: [", freq[0].toHex(), ", ", freq[1].toHex(), "]"
+        echo "  IFFT: [", recovered[0].toHex(), ", ", recovered[1].toHex(), "]"
+
+      for i in 0 ..< order:
+        doAssert (recovered[i] == data[i]).bool,
+          "Roundtrip failed at size " & $order & " index " & $i
+
+  echo "  ✓ All Fr FFT/IFFT roundtrip tests PASSED"
+
+proc testECFFTRoundtrip*(EC: typedesc, F: typedesc[Fr]) =
+  echo "Testing EC FFT/IFFT roundtrip..."
+
+  for scale in 2 .. 5:
+    let order = 1 shl scale
+
+    let fftDesc = createFFTDescriptor(EC, F, order)
+
+    var data = newSeq[EC](order)
+    data[0].setGenerator()
+    let gen = EC.F.Name.getGenerator($EC.G)
+    for i in 1 ..< order:
+      data[i].mixedSum(data[i-1], gen)
+
+    var freq = newSeq[EC](order)
+    let fftOk = ec_fft_nr(fftDesc, freq, data)
+    doAssert fftOk == FFT_Success
+
+    var recovered = newSeq[EC](order)
+    let ifftOk = ec_ifft_rn(fftDesc, recovered, freq)
+    doAssert ifftOk == FFT_Success
+
+    for i in 0 ..< order:
+      doAssert (recovered[i] == data[i]).bool,
+        "EC Roundtrip failed at size " & $order & " index " & $i
+
+  echo "  ✓ All EC FFT/IFFT roundtrip tests PASSED"
+
+proc testIFFTInterpolation*(F: typedesc[Fr]) =
+  echo "Testing IFFT interpolation correctness..."
+
+  block:
+    let L = 2
+    let fftDesc = createFFTDescriptor(F, L)
+    let omegaL = fftDesc.rootsOfUnity[1]
+
+    var ys: array[2, F]
+    ys[0].fromUint(142'u64)
+    ys[1].fromHex("0x73eda753299d7d483339d80809a1d80553bda402fffe5bfefffffffeffffffff")
+
+    var v0_expected, v1_expected: F
+    var sum_ys, two_inv, omega_inv: F
+    sum_ys.sum(ys[0], ys[1])
+    two_inv.fromUint(2'u64)
+    two_inv.inv()
+    omega_inv.inv(omegaL)
+    v0_expected.prod(sum_ys, two_inv)
+
+    var y1_times_omega_inv: F
+    y1_times_omega_inv.prod(ys[1], omega_inv)
+    v1_expected.sum(ys[0], y1_times_omega_inv)
+    v1_expected.prod(v1_expected, two_inv)
+
+    # Create bit-reversed input for ifft_rn (which expects bit-reversed order)
+    var ys_bitrev: array[2, F]
+    ys_bitrev[0] = ys[0]  # index 0 bit-reversed is 0
+    ys_bitrev[1] = ys[1]  # index 1 bit-reversed is 1 (for log2(2)=1)
+
+    var coeffs: array[2, F]
+    let status = ifft_rn(fftDesc, coeffs.toOpenArray(0, L-1), ys_bitrev.toOpenArray(0, L-1))
+    doAssert status == FFT_Success
+
+    doAssert (coeffs[0] == v0_expected).bool, "IFFT coefficient 0 mismatch for L=2"
+    doAssert (coeffs[1] == v1_expected).bool, "IFFT coefficient 1 mismatch for L=2"
+
+    var v_at_1, v_at_omegaL: F
+    v_at_1.sum(coeffs[0], coeffs[1])
+    v_at_omegaL.diff(coeffs[0], coeffs[1])
+
+    doAssert (v_at_1 == ys[0]).bool, "Interpolation at 1 failed"
+    doAssert (v_at_omegaL == ys[1]).bool, "Interpolation at ω_L failed"
+
+  echo "  ✓ IFFT interpolation test PASSED"
+
+when isMainModule:
+  echo "========================================"
+  echo "    FFT/IFFT Correctness Tests"
+  echo "========================================\n"
+
+  testBitReversal(int64)
+  echo ""
+  testFrFFTRoundtrip(Fr[BLS12_381])
+  echo ""
+  testECFFTRoundtrip(EC_ShortW_Prj[Fp[BLS12_381], G1], Fr[BLS12_381])
+  echo ""
+  testIFFTInterpolation(Fr[BLS12_381])
+
+  echo "\n========================================"
+  echo "    All FFT tests PASSED ✓"
+  echo "========================================"

--- a/tests/math_polynomials/t_fft.nim
+++ b/tests/math_polynomials/t_fft.nim
@@ -107,11 +107,11 @@ proc testFrFFTRoundtrip*(F: typedesc[Fr]) =
         data[i].fromUint(uint64(i + 1))
 
       var freq = newSeq[F](order)
-      let fftOk = fft_nr(fftDesc, freq, data)
+      let fftOk = fft_nn(fftDesc, freq, data)
       doAssert fftOk == FFT_Success
 
       var recovered = newSeq[F](order)
-      let ifftOk = ifft_rn(fftDesc, recovered, freq)
+      let ifftOk = ifft_nn(fftDesc, recovered, freq)
       doAssert ifftOk == FFT_Success
 
       if order == 2:
@@ -140,11 +140,11 @@ proc testECFFTRoundtrip*(EC: typedesc, F: typedesc[Fr]) =
       data[i].mixedSum(data[i-1], gen)
 
     var freq = newSeq[EC](order)
-    let fftOk = ec_fft_nr(fftDesc, freq, data)
+    let fftOk = ec_fft_nn(fftDesc, freq, data)
     doAssert fftOk == FFT_Success
 
     var recovered = newSeq[EC](order)
-    let ifftOk = ec_ifft_rn(fftDesc, recovered, freq)
+    let ifftOk = ec_ifft_nn(fftDesc, recovered, freq)
     doAssert ifftOk == FFT_Success
 
     for i in 0 ..< order:
@@ -178,13 +178,9 @@ proc testIFFTInterpolation*(F: typedesc[Fr]) =
     v1_expected.sum(ys[0], y1_times_omega_inv)
     v1_expected.prod(v1_expected, two_inv)
 
-    # Create bit-reversed input for ifft_rn (which expects bit-reversed order)
-    var ys_bitrev: array[2, F]
-    ys_bitrev[0] = ys[0]  # index 0 bit-reversed is 0
-    ys_bitrev[1] = ys[1]  # index 1 bit-reversed is 1 (for log2(2)=1)
-
+    # Use ifft_nn which expects natural order input
     var coeffs: array[2, F]
-    let status = ifft_rn(fftDesc, coeffs.toOpenArray(0, L-1), ys_bitrev.toOpenArray(0, L-1))
+    let status = ifft_nn(fftDesc, coeffs.toOpenArray(0, L-1), ys.toOpenArray(0, L-1))
     doAssert status == FFT_Success
 
     doAssert (coeffs[0] == v0_expected).bool, "IFFT coefficient 0 mismatch for L=2"
@@ -199,6 +195,113 @@ proc testIFFTInterpolation*(F: typedesc[Fr]) =
 
   echo "  ✓ IFFT interpolation test PASSED"
 
+proc naiveDFT[F](vals: openArray[F], omega: F): seq[F] =
+  ## Compute DFT using naive O(n²) algorithm - produces natural order output
+  result = newSeq[F](vals.len)
+
+  for k in 0..<vals.len:
+    var sum: F
+    sum.setZero()
+
+    var wkj: F
+    wkj.setOne()   # ω^(k*0)
+
+    var wk: F
+    wk.setOne()
+    for _ in 0..<k:
+      wk *= omega  # ω^k
+
+    for j in 0..<vals.len:
+      var term: F
+      term.prod(vals[j], wkj)
+      sum += term
+      wkj *= wk    # ω^(k*(j+1))
+
+    result[k] = sum
+
+proc testFFTOrdering*(F: typedesc[Fr]) =
+  echo "Testing FFT output ordering..."
+
+  for order in [4, 8]:
+    let fftDesc = createFFTDescriptor(F, order)
+    let omega = fftDesc.rootsOfUnity[1]
+
+    var vals = newSeq[F](order)
+    for i in 0..<order:
+      vals[i].fromUint(uint64(i + 1))
+
+    let naive = naiveDFT(vals, omega)
+
+    var output_nn = newSeq[F](order)
+    var output_nr = newSeq[F](order)
+    discard fft_nn(fftDesc, output_nn, vals)
+    discard fft_nr(fftDesc, output_nr, vals)
+
+    var nn_is_natural = true
+    for i in 0..<order:
+      if not (output_nn[i] == naive[i]).bool:
+        nn_is_natural = false
+        break
+
+    var nr_is_bitrev = true
+    let log2_order = order.uint64.log2_vartime()
+    for i in 0..<order:
+      let br_i = reverseBits(uint(i), log2_order)
+      if not (output_nr[i] == naive[br_i]).bool:
+        nr_is_bitrev = false
+        break
+
+    doAssert nn_is_natural, "fft_nn should produce natural order (N=" & $order & ")"
+    doAssert nr_is_bitrev, "fft_nr should produce bit-reversed order (N=" & $order & ")"
+
+  echo "  ✓ FFT ordering tests PASSED"
+
+proc testECFFTOrdering*(EC: typedesc, F: typedesc[Fr]) =
+  echo "Testing EC FFT output ordering..."
+
+  for order in [4, 8]:
+    let fftDesc = createFFTDescriptor(EC, F, order)
+
+    var vals = newSeq[EC](order)
+    vals[0].setGenerator()
+    let gen = EC.F.Name.getGenerator($EC.G)
+    for i in 1..<order:
+      vals[i].mixedSum(vals[i-1], gen)
+
+    var output_nn = newSeq[EC](order)
+    var output_nr = newSeq[EC](order)
+    discard ec_fft_nn(fftDesc, output_nn, vals)
+    discard ec_fft_nr(fftDesc, output_nr, vals)
+
+    for i in 0..<order:
+      let br_i = reverseBits(uint(i), order.uint64.log2_vartime())
+      doAssert (output_nr[i] == output_nn[br_i]).bool,
+        "EC fft_nr should produce bit-reversed of fft_nn (N=" & $order & ")"
+
+  echo "  ✓ EC FFT ordering tests PASSED"
+
+proc testIFFTOrdering*(F: typedesc[Fr]) =
+  echo "Testing IFFT input/output ordering..."
+
+  for order in [4, 8]:
+    let fftDesc = createFFTDescriptor(F, order)
+
+    var vals = newSeq[F](order)
+    for i in 0..<order:
+      vals[i].fromUint(uint64(i + 1))
+
+    var freq_nn = newSeq[F](order)
+    discard fft_nn(fftDesc, freq_nn, vals)
+
+    var recovered_nn = newSeq[F](order)
+    discard ifft_nn(fftDesc, recovered_nn, freq_nn)
+
+    for i in 0..<order:
+      doAssert (recovered_nn[i] == vals[i]).bool,
+        "ifft_nn(fft_nn(x)) should equal x (N=" & $order & ")"
+
+  echo "  ✓ IFFT ordering tests PASSED"
+
 when isMainModule:
   echo "========================================"
   echo "    FFT/IFFT Correctness Tests"
@@ -211,6 +314,12 @@ when isMainModule:
   testECFFTRoundtrip(EC_ShortW_Prj[Fp[BLS12_381], G1], Fr[BLS12_381])
   echo ""
   testIFFTInterpolation(Fr[BLS12_381])
+  echo ""
+  testFFTOrdering(Fr[BLS12_381])
+  echo ""
+  testECFFTOrdering(EC_ShortW_Prj[Fp[BLS12_381], G1], Fr[BLS12_381])
+  echo ""
+  testIFFTOrdering(Fr[BLS12_381])
 
   echo "\n========================================"
   echo "    All FFT tests PASSED ✓"

--- a/tests/math_polynomials/t_fft.nim
+++ b/tests/math_polynomials/t_fft.nim
@@ -178,7 +178,6 @@ proc testIFFTInterpolation*(F: typedesc[Fr]) =
     v1_expected.sum(ys[0], y1_times_omega_inv)
     v1_expected.prod(v1_expected, two_inv)
 
-    # Use ifft_nn which expects natural order input
     var coeffs: array[2, F]
     let status = ifft_nn(fftDesc, coeffs.toOpenArray(0, L-1), ys.toOpenArray(0, L-1))
     doAssert status == FFT_Success
@@ -192,6 +191,33 @@ proc testIFFTInterpolation*(F: typedesc[Fr]) =
 
     doAssert (v_at_1 == ys[0]).bool, "Interpolation at 1 failed"
     doAssert (v_at_omegaL == ys[1]).bool, "Interpolation at ω_L failed"
+
+  block:
+    let L = 4
+    let fftDesc = createFFTDescriptor(F, L)
+    let omegaL = fftDesc.rootsOfUnity[1]
+
+    var ys: array[4, F]
+    ys[0].fromUint(10'u64)
+    ys[1].fromUint(20'u64)
+    ys[2].fromUint(30'u64)
+    ys[3].fromUint(40'u64)
+
+    var ys_bitrev: array[4, F]
+    for i in 0..<4:
+      let rev_i = reverseBits(uint32(i), 2'u32)
+      ys_bitrev[rev_i] = ys[i]
+
+    var coeffs: array[4, F]
+    let status = ifft_nn(fftDesc, coeffs.toOpenArray(0, L-1), ys.toOpenArray(0, L-1))
+    doAssert status == FFT_Success
+
+    var evals: array[4, F]
+    let fftStatus = fft_nn(fftDesc, evals.toOpenArray(0, L-1), coeffs.toOpenArray(0, L-1))
+    doAssert fftStatus == FFT_Success
+
+    for i in 0..<4:
+      doAssert (evals[i] == ys[i]).bool, "Re-evaluation at ω^" & $i & " failed for L=4"
 
   echo "  ✓ IFFT interpolation test PASSED"
 
@@ -299,6 +325,18 @@ proc testIFFTOrdering*(F: typedesc[Fr]) =
     for i in 0..<order:
       doAssert (recovered_nn[i] == vals[i]).bool,
         "ifft_nn(fft_nn(x)) should equal x (N=" & $order & ")"
+
+    var freq_nr = newSeq[F](order)
+    let fftNrStatus = fft_nr(fftDesc, freq_nr, vals)
+    doAssert fftNrStatus == FFT_Success
+
+    var recovered_rn = newSeq[F](order)
+    let ifftRnStatus = ifft_rn(fftDesc, recovered_rn, freq_nr)
+    doAssert ifftRnStatus == FFT_Success
+
+    for i in 0..<order:
+      doAssert (recovered_rn[i] == vals[i]).bool,
+        "ifft_rn(fft_nr(x)) should equal x (N=" & $order & ")"
 
   echo "  ✓ IFFT ordering tests PASSED"
 

--- a/tests/math_polynomials/t_fft_coset.nim
+++ b/tests/math_polynomials/t_fft_coset.nim
@@ -41,11 +41,11 @@ proc testCosetFFTRoundtrip*(F: typedesc[Fr]) =
         data[i].fromUint(uint64(i + 1))
 
       var coset_freq = newSeq[F](n)
-      let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, shift_factor)
+      let cosetFftOk = coset_fft_nn(fftDesc, coset_freq, data, shift_factor)
       doAssert cosetFftOk == FFT_Success
 
       var recovered = newSeq[F](n)
-      let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, shift_factor)
+      let cosetIfftOk = coset_ifft_nn(fftDesc, recovered, coset_freq, shift_factor)
       doAssert cosetIfftOk == FFT_Success
 
       for i in 0 ..< n:
@@ -71,11 +71,11 @@ proc testCosetFFTSpecificSizes*(F: typedesc[Fr]) =
       data[i].fromUint(uint64(i + 1))
 
     var coset_freq = newSeq[F](n)
-    let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, shift_factor)
+    let cosetFftOk = coset_fft_nn(fftDesc, coset_freq, data, shift_factor)
     doAssert cosetFftOk == FFT_Success
 
     var recovered = newSeq[F](n)
-    let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, shift_factor)
+    let cosetIfftOk = coset_ifft_nn(fftDesc, recovered, coset_freq, shift_factor)
     doAssert cosetIfftOk == FFT_Success
 
     for i in 0 ..< n:
@@ -93,11 +93,11 @@ proc testCosetFFTSpecificSizes*(F: typedesc[Fr]) =
       data[i].fromUint(uint64(i + 1))
 
     var coset_freq = newSeq[F](n)
-    let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, coset_shift)
+    let cosetFftOk = coset_fft_nn(fftDesc, coset_freq, data, coset_shift)
     doAssert cosetFftOk == FFT_Success
 
     var recovered = newSeq[F](n)
-    let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, coset_shift)
+    let cosetIfftOk = coset_ifft_nn(fftDesc, recovered, coset_freq, coset_shift)
     doAssert cosetIfftOk == FFT_Success
 
     for i in 0 ..< n:

--- a/tests/math_polynomials/t_fft_coset.nim
+++ b/tests/math_polynomials/t_fft_coset.nim
@@ -1,0 +1,120 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Coset FFT/IFFT Tests
+#
+# These tests verify the coset FFT functions used in:
+# - Layer 1: Polynomial recovery (avoiding division by zero)
+# - EIP-7594 PeerDAS: Data availability sampling
+#
+# Coset FFT shifts the domain so polynomials that vanish at certain points
+# don't cause issues during division operations.
+
+# Compile and run with:
+#   nim c -r -d:release --hints:off --warnings:off --outdir:build/tmp --nimcache:nimcache/tmp tests/math_polynomials/t_fft_coset.nim
+
+import
+  ../../constantine/named/algebras,
+  ../../constantine/math/[arithmetic, ec_shortweierstrass],
+  ../../constantine/math/polynomials/[fft, polynomials],
+  ../../constantine/math/io/io_fields,
+  ./fft_utils
+
+proc testCosetFFTRoundtrip*(F: typedesc[Fr]) =
+  echo "Testing Coset FFT/IFFT roundtrip..."
+
+  for scale in 2 .. 5:
+    let n = 1 shl scale
+    let fftDesc = createFFTDescriptor(F, n)
+
+    var shift_factor: F
+    shift_factor.fromUint(7'u64)
+
+    block:
+      var data = newSeq[F](n)
+      for i in 0 ..< n:
+        data[i].fromUint(uint64(i + 1))
+
+      var coset_freq = newSeq[F](n)
+      let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, shift_factor)
+      doAssert cosetFftOk == FFT_Success
+
+      var recovered = newSeq[F](n)
+      let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, shift_factor)
+      doAssert cosetIfftOk == FFT_Success
+
+      for i in 0 ..< n:
+        doAssert (recovered[i] == data[i]).bool,
+          "Coset roundtrip failed at size " & $n & " index " & $i
+
+  echo "  ✓ All Coset FFT/IFFT roundtrip tests PASSED"
+
+proc testCosetFFTSpecificSizes*(F: typedesc[Fr]) =
+  echo "Testing Coset FFT for specific PeerDAS sizes..."
+
+  const CELLS_PER_EXT_BLOB = 128
+
+  block:
+    let n = 32
+    let fftDesc = createFFTDescriptor(F, n)
+
+    var shift_factor: F
+    shift_factor.fromUint(7'u64)
+
+    var data = newSeq[F](n)
+    for i in 0 ..< n:
+      data[i].fromUint(uint64(i + 1))
+
+    var coset_freq = newSeq[F](n)
+    let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, shift_factor)
+    doAssert cosetFftOk == FFT_Success
+
+    var recovered = newSeq[F](n)
+    let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, shift_factor)
+    doAssert cosetIfftOk == FFT_Success
+
+    for i in 0 ..< n:
+      doAssert (recovered[i] == data[i]).bool,
+        "Coset roundtrip failed at size " & $n & " index " & $i
+
+  block:
+    let n = 32
+    let fftDesc = createFFTDescriptor(F, n)
+    var coset_shift = fftDesc.rootsOfUnity[1]
+    coset_shift.pow_vartime(Fr[BLS12_381].fromUint(uint32(CELLS_PER_EXT_BLOB)))
+
+    var data = newSeq[F](n)
+    for i in 0 ..< n:
+      data[i].fromUint(uint64(i + 1))
+
+    var coset_freq = newSeq[F](n)
+    let cosetFftOk = coset_fft_nr(fftDesc, coset_freq, data, coset_shift)
+    doAssert cosetFftOk == FFT_Success
+
+    var recovered = newSeq[F](n)
+    let cosetIfftOk = coset_ifft_rn(fftDesc, recovered, coset_freq, coset_shift)
+    doAssert cosetIfftOk == FFT_Success
+
+    for i in 0 ..< n:
+      doAssert (recovered[i] == data[i]).bool,
+        "Coset roundtrip failed at size " & $n & " index " & $i & " with PeerDAS coset shift"
+
+  echo "  ✓ Coset FFT PeerDAS-specific tests PASSED"
+
+when isMainModule:
+  echo "========================================"
+  echo "    Coset FFT/IFFT Correctness Tests"
+  echo "========================================\n"
+
+  testCosetFFTRoundtrip(Fr[BLS12_381])
+  echo ""
+  testCosetFFTSpecificSizes(Fr[BLS12_381])
+
+  echo "\n========================================"
+  echo "    All Coset FFT tests PASSED ✓"
+  echo "========================================"

--- a/tests/t_ethereum_verkle_ipa_primitives.nim
+++ b/tests/t_ethereum_verkle_ipa_primitives.nim
@@ -93,7 +93,7 @@ suite "Barycentric Form Tests":
 
         var testVals: array[10, int] = [1,2,3,4,5,6,7,8,9,10]
 
-        var lagrange_values: PolynomialEval[256, Fr[Banderwagon]]
+        var lagrange_values: PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]
         lagrange_values.evals.testPoly256(testVals)
 
         var lindom: PolyEvalLinearDomain[256, Fr[Banderwagon]]
@@ -146,11 +146,11 @@ suite "Barycentric Form Tests":
         var lindom: PolyEvalLinearDomain[256, Fr[Banderwagon]]
         lindom.setupLinearEvaluationDomain()
 
-        var evaluations: PolynomialEval[EthVerkleDomain, Fr[Banderwagon]]
+        var evaluations: PolynomialEval[EthVerkleDomain, Fr[Banderwagon], kNaturalOrder]
         for i in 0 ..< EthVerkleDomain:
           evaluations.evals[i] = points[i].y
 
-        var quotient: PolynomialEval[EthVerkleDomain, Fr[Banderwagon]]
+        var quotient: PolynomialEval[EthVerkleDomain, Fr[Banderwagon], kNaturalOrder]
         lindom.getQuotientPolyInDomain(quotient, evaluations, zIndex = 1)
 
         doAssert quotient.evals[255].toHex(littleEndian) == "0x616b0e203a877177e2090013a77ce4ea8726941aac613b532002f3653d54250b", "Issue with Divide on Domain using Barycentric Precomputes!"
@@ -206,7 +206,7 @@ suite "Barycentric Form Tests":
 #       var basisPoints: PolynomialEval[256, EC_TwEdw_Aff[Fp[Banderwagon]]]
 #       basisPoints.evals.generate_random_points()
 
-#       var test_scalars {.noInit.}: PolynomialEval[256, Fr[Banderwagon]]
+#       var test_scalars {.noInit.}: PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]
 #       for i in 0 ..< 256:
 #         test_scalars.evals[i].fromHex(testScalarsHex[i])
 
@@ -430,7 +430,7 @@ suite "IPA proof tests":
       let status = proof.deserialize(proof_bytes)
       doAssert status == cttEthVerkleIpa_Success
 
-      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]], kNaturalOrder]
       CRS.evals.generate_random_points()
 
       var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
@@ -477,7 +477,7 @@ suite "IPA proof tests":
       var opening_challenge: Fr[Banderwagon]
       opening_challenge.fromInt(2101)
 
-      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]], kNaturalOrder]
       CRS.evals.generate_random_points()
 
       var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
@@ -494,7 +494,7 @@ suite "IPA proof tests":
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
       ]
-      var poly: PolynomialEval[256, Fr[Banderwagon]]
+      var poly: PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]
       poly.evals.testPoly256(testVals)
 
       var comm: EC_TwEdw_Prj[Fp[Banderwagon]]
@@ -543,7 +543,7 @@ suite "IPA proof tests":
       var opening_challenge: Fr[Banderwagon]
       opening_challenge.fromInt(2101)
 
-      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]], kNaturalOrder]
       CRS.evals.generate_random_points()
 
       var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
@@ -551,7 +551,7 @@ suite "IPA proof tests":
 
       # Committer's side
       var testVals : array[9, int] = [1,2,3,4,5,6,7,8,9]
-      var poly: PolynomialEval[256, Fr[Banderwagon]]
+      var poly: PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]
       poly.evals.testPoly256(testVals)
 
       var comm: EC_TwEdw_Prj[Fp[Banderwagon]]
@@ -608,7 +608,7 @@ suite "Multiproof Tests":
       opening_challenges_in_domain[0] = 0'u8
       opening_challenges_in_domain[1] = 0'u8
 
-      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]], kNaturalOrder]
       CRS.evals.generate_random_points()
 
       var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
@@ -637,7 +637,7 @@ suite "Multiproof Tests":
         32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
       ]
 
-      var polys: array[2, PolynomialEval[256, Fr[Banderwagon]]]
+      var polys: array[2, PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]]
       polys[0].evals.testPoly256(testVals1)
       polys[1].evals.testPoly256(testVals2)
 
@@ -671,14 +671,14 @@ suite "Multiproof Tests":
   test "Multiproof Creation and Verification":
     proc testMultiproofCreationAndVerification()=
 
-      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]]]
+      var CRS: PolynomialEval[EthVerkleDomain, EC_TwEdw_Aff[Fp[Banderwagon]], kNaturalOrder]
       CRS.evals.generate_random_points()
 
       var domain: PolyEvalLinearDomain[EthVerkleDomain, Fr[Banderwagon]]
       domain.setupLinearEvaluationDomain()
 
       var testVals: array[14, int] = [1,1,1,4,5,6,7,8,9,10,11,12,13,14]
-      var poly: PolynomialEval[256, Fr[Banderwagon]]
+      var poly: PolynomialEval[256, Fr[Banderwagon], kNaturalOrder]
       poly.evals.testPoly256(testVals)
 
       var prover_comm: EC_TwEdw_Prj[Fp[Banderwagon]]


### PR DESCRIPTION
This PR does 2 things:
- Refactor FFT to ease distinction between FFT, Coset FFT and EC FFT
- Make kNatural or kBitReversed part of Lagrange polynomials and roots of unity types to ease debugging, maintenance and auditability


This is extracted from PeerDAS #592 #593 to streamline the PR and as this touches a lot of non-PeerDAS protocols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Polynomial-evaluation types and commitment/quotient APIs are now ordering-aware (natural vs bit-reversed), with compile-time ordering selection.
* **New Features**
  * Full FFT/IFFT and EC‑FFT suites, coset transforms, out-of-place bit-reversal, FFT descriptor lifecycle and coef↔eval conversion helpers; KZG/blob flows adapted to ordering-aware representations.
* **Tests**
  * Extensive FFT, coset FFT, and bit-reversal correctness tests; existing tests updated for ordering.
* **Benchmarks / Chores**
  * New FFT and bit-reversal benchmark programs and build tasks; FFT test utilities added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->