### PR TITLE
Tune vartime scalar mul [PeerDAS streamlining]

### DIFF
--- a/benchmarks/bench_ec_g1_scalar_mul_vartime.nim
+++ b/benchmarks/bench_ec_g1_scalar_mul_vartime.nim
@@ -1,0 +1,153 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internals
+  constantine/named/[algebras, zoo_endomorphisms, zoo_subgroups],
+  constantine/math/arithmetic,
+  constantine/math/io/io_bigints,
+  constantine/math/ec_shortweierstrass,
+  constantine/math/elliptic/ec_scalar_mul_vartime,
+  constantine/math_arbitrary_precision/arithmetic/[limbs_views, limbs_multiprec],
+  # Helpers
+  helpers/prng_unsafe,
+  ./platforms,
+  ./bench_blueprint,
+  # Reference unsafe scalar multiplication
+  constantine/math/elliptic/ec_scalar_mul_vartime
+
+proc separator*() = separator(179)
+
+macro fixEllipticDisplay(EC: typedesc): untyped =
+  # At compile-time, enums are integers and their display is buggy
+  # we get the Curve ID instead of the curve name.
+  let instantiated = EC.getTypeInst()
+  var name = $instantiated[1][0] # EllipticEquationFormCoordinates
+  let fieldName = $instantiated[1][1][0]
+  let curve = Algebra(instantiated[1][1][1].intVal)
+  let curveName = $curve
+  name.add "[" &
+      fieldName & "[" & curveName & "]" &
+      (if family(curve) != NoFamily:
+        ", " & $Subgroup(instantiated[1][2].intVal)
+      else: "") &
+      "]"
+  result = newLit name
+
+proc report(op, elliptic: string, start, stop: MonoTime, startClk, stopClk: int64, iters: int) =
+  let ns = inNanoseconds((stop-start) div iters)
+  let throughput = 1e9 / float64(ns)
+  when SupportsGetTicks:
+    echo &"{op:<68} {elliptic:<36} {throughput:>15.3f} ops/s {ns:>16} ns/op {(stopClk - startClk) div iters:>12} CPU cycles (approx)"
+  else:
+    echo &"{op:<68} {elliptic:<36} {throughput:>15.3f} ops/s {ns:>16} ns/op"
+
+template bench*(op: string, EC: typedesc, iters: int, body: untyped): untyped =
+  measure(iters, startTime, stopTime, startClk, stopClk, body)
+  report(op, fixEllipticDisplay(EC), startTime, stopTime, startClk, stopClk, iters)
+
+# ############################################################
+#
+#               Benchmark of scalar multiplication
+#            for G1 group of short Weierstrass curves
+#          investigating vartime acceleration thresholds
+#
+#  Key insight: scalarMul_vartime uses getBits_LE_vartime() at runtime
+#  to determine how many bits are set (usedBits), not the compile-time
+#  bit size. This means BigInt[255] with only 4 bits set will use the
+#  4-bit addchain algorithm.
+#
+# ############################################################
+
+const curve = BLS12_381
+const bits = Fr[curve].bits()
+const hasEndo = curve.hasEndomorphismAcceleration()
+const Iters = 1000
+
+proc scalarMulVartimeDoubleAddBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+  var r {.noInit.}: EC
+  var P = rng.random_unsafe(EC)
+  P.clearCofactor()
+
+  bench("EC ScalarMul " & $scalar.limbs.getBits_LE_vartime() & "-bit " & $EC.G & " (vartime reference DoubleAdd)", EC, iters):
+    r = P
+    r.scalarMul_doubleAdd_vartime(scalar)
+
+proc scalarMulVartimeMinHammingWeightRecodingBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+  var r {.noInit.}: EC
+  var P = rng.random_unsafe(EC)
+  P.clearCofactor()
+
+  bench("EC ScalarMul " & $scalar.limbs.getBits_LE_vartime() & "-bit " & $EC.G & " (vartime min Hamming Weight recoding)", EC, iters):
+    r = P
+    r.scalarMul_jy00_vartime(scalar)
+
+proc scalarMulVartimeWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: static int, iters: int) {.noinline.} =
+  var r {.noInit.}: EC
+  var P = rng.random_unsafe(EC)
+  P.clearCofactor()
+
+  bench("EC ScalarMul " & $scalar.limbs.getBits_LE_vartime() & "-bit " & $EC.G & " (vartime wNAF-" & $window & ")", EC, iters):
+    r = P
+    r.scalarMul_wNAF_vartime(scalar, window)
+
+proc scalarMulVartimeEndoWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: static int, iters: int) {.noinline.} =
+  var r {.noInit.}: EC
+  var P = rng.random_unsafe(EC)
+  P.clearCofactor()
+
+  bench("EC ScalarMul " & $scalar.limbs.getBits_LE_vartime() & "-bit " & $EC.G & " (vartime endo + wNAF-" & $window & ")", EC, iters):
+    r = P
+    r.scalarMulEndo_wNAF_vartime(scalar, window)
+
+proc scalarMulVartimeBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+  var r {.noInit.}: EC
+  var P = rng.random_unsafe(EC)
+  P.clearCofactor()
+
+  bench("EC ScalarMul " & $scalar.limbs.getBits_LE_vartime() & "-bit " & $EC.G & " (vartime auto)", EC, iters):
+    r = P
+    r.scalarMul_vartime(scalar)
+
+proc makeSmallScalar(rng: var RngState, size: int): BigInt[bits] =
+  result = rng.random_unsafe(BigInt[bits])
+  # Note there is a BigInt.shiftRight(k) for 0 < k < WordBitwidth
+  # and there is a arbitrary precision limbs shiftRight_vartime for any k
+  result.limbs.shiftRight_vartime(result.limbs, bits-size)
+
+proc main() =
+  separator()
+  echo "BLS12-381 G1 Scalar Multiplication benchmarks"
+  echo "=============================================="
+  echo "Scalar field bits: ", bits
+  echo "Endomorphism acceleration: ", hasEndo
+  echo "EndomorphismThreshold: ", EndomorphismThreshold
+  echo ""
+  echo "NOTE: Using BigInt[255] with controlled bit patterns to test"
+  echo "      runtime threshold detection via getBits_LE_vartime()"
+  echo ""
+
+  const sizes = [1, 2, 4, 5, 6, 7, 8, 12, 16, 20, 24, 28, 32, 40, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 255]
+
+  staticFor s, 0, sizes.len:
+    const size = sizes[s]
+    echo "Testing scalar with ", size, " bits set (runtime-detected)"
+    let smallScalar = rng.makeSmallScalar(size)
+    echo "Scalar: ", smallScalar.toHex()
+    scalarMulVartimeDoubleAddBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
+    scalarMulVartimeMinHammingWeightRecodingBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
+    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 3, Iters)
+    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 4, Iters)
+    when hasEndo:
+      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 3, Iters)
+      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 4, Iters)
+    scalarMulVartimeBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
+    separator()
+
+main()
+notes()

--- a/benchmarks/bench_ec_g1_scalar_mul_vartime.nim
+++ b/benchmarks/bench_ec_g1_scalar_mul_vartime.nim
@@ -17,9 +17,7 @@ import
   # Helpers
   helpers/prng_unsafe,
   ./platforms,
-  ./bench_blueprint,
-  # Reference unsafe scalar multiplication
-  constantine/math/elliptic/ec_scalar_mul_vartime
+  ./bench_blueprint
 
 proc separator*() = separator(179)
 
@@ -64,12 +62,9 @@ template bench*(op: string, EC: typedesc, iters: int, body: untyped): untyped =
 #
 # ############################################################
 
-const curve = BLS12_381
-const bits = Fr[curve].bits()
-const hasEndo = curve.hasEndomorphismAcceleration()
 const Iters = 1000
 
-proc scalarMulVartimeDoubleAddBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+proc scalarMulVartimeDoubleAddBench*(EC: typedesc, scalar: BigInt[255], iters: int) {.noinline.} =
   var r {.noInit.}: EC
   var P = rng.random_unsafe(EC)
   P.clearCofactor()
@@ -78,7 +73,7 @@ proc scalarMulVartimeDoubleAddBench*(EC: typedesc, scalar: BigInt[bits], iters: 
     r = P
     r.scalarMul_doubleAdd_vartime(scalar)
 
-proc scalarMulVartimeMinHammingWeightRecodingBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+proc scalarMulVartimeMinHammingWeightRecodingBench*(EC: typedesc, scalar: BigInt[255], iters: int) {.noinline.} =
   var r {.noInit.}: EC
   var P = rng.random_unsafe(EC)
   P.clearCofactor()
@@ -87,7 +82,7 @@ proc scalarMulVartimeMinHammingWeightRecodingBench*(EC: typedesc, scalar: BigInt
     r = P
     r.scalarMul_jy00_vartime(scalar)
 
-proc scalarMulVartimeWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: static int, iters: int) {.noinline.} =
+proc scalarMulVartimeWNAFBench*(EC: typedesc, scalar: BigInt[255], window: static int, iters: int) {.noinline.} =
   var r {.noInit.}: EC
   var P = rng.random_unsafe(EC)
   P.clearCofactor()
@@ -96,7 +91,7 @@ proc scalarMulVartimeWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: stat
     r = P
     r.scalarMul_wNAF_vartime(scalar, window)
 
-proc scalarMulVartimeEndoWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: static int, iters: int) {.noinline.} =
+proc scalarMulVartimeEndoWNAFBench*(EC: typedesc, scalar: BigInt[255], window: static int, iters: int) {.noinline.} =
   var r {.noInit.}: EC
   var P = rng.random_unsafe(EC)
   P.clearCofactor()
@@ -105,7 +100,7 @@ proc scalarMulVartimeEndoWNAFBench*(EC: typedesc, scalar: BigInt[bits], window: 
     r = P
     r.scalarMulEndo_wNAF_vartime(scalar, window)
 
-proc scalarMulVartimeBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.noinline.} =
+proc scalarMulVartimeBench*(EC: typedesc, scalar: BigInt[255], iters: int) {.noinline.} =
   var r {.noInit.}: EC
   var P = rng.random_unsafe(EC)
   P.clearCofactor()
@@ -114,18 +109,23 @@ proc scalarMulVartimeBench*(EC: typedesc, scalar: BigInt[bits], iters: int) {.no
     r = P
     r.scalarMul_vartime(scalar)
 
-proc makeSmallScalar(rng: var RngState, size: int): BigInt[bits] =
-  result = rng.random_unsafe(BigInt[bits])
+proc makeSmallScalar(rng: var RngState, size: int): BigInt[255] =
+  result = rng.random_unsafe(BigInt[255])
   # Note there is a BigInt.shiftRight(k) for 0 < k < WordBitwidth
   # and there is a arbitrary precision limbs shiftRight_vartime for any k
-  result.limbs.shiftRight_vartime(result.limbs, bits-size)
+  result.limbs.shiftRight_vartime(result.limbs, 255-size)
+
+  # For MSB to 1
+  let limbIdx = (size - 1) div WordBitWidth
+  let bitPos  = (size - 1) mod WordBitWidth
+  result.limbs[limbIdx] = result.limbs[limbIdx] or (SecretWord(1) shl bitPos)
 
 proc main() =
   separator()
   echo "BLS12-381 G1 Scalar Multiplication benchmarks"
   echo "=============================================="
-  echo "Scalar field bits: ", bits
-  echo "Endomorphism acceleration: ", hasEndo
+  echo "Scalar field bits: ", 255
+  echo "Endomorphism acceleration: ", BLS12_381.hasEndomorphismAcceleration()
   echo "EndomorphismThreshold: ", EndomorphismThreshold
   echo ""
   echo "NOTE: Using BigInt[255] with controlled bit patterns to test"
@@ -139,14 +139,14 @@ proc main() =
     echo "Testing scalar with ", size, " bits set (runtime-detected)"
     let smallScalar = rng.makeSmallScalar(size)
     echo "Scalar: ", smallScalar.toHex()
-    scalarMulVartimeDoubleAddBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
-    scalarMulVartimeMinHammingWeightRecodingBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
-    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 3, Iters)
-    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 4, Iters)
-    when hasEndo:
-      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 3, Iters)
-      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, window = 4, Iters)
-    scalarMulVartimeBench(EC_ShortW_Jac[Fp[curve], G1], smallScalar, Iters)
+    scalarMulVartimeDoubleAddBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, Iters)
+    scalarMulVartimeMinHammingWeightRecodingBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, Iters)
+    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, window = 3, Iters)
+    scalarMulVartimeWNAFBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, window = 4, Iters)
+    when BLS12_381.hasEndomorphismAcceleration():
+      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, window = 3, Iters)
+      scalarMulVartimeEndoWNAFBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, window = 4, Iters)
+    scalarMulVartimeBench(EC_ShortW_Jac[Fp[BLS12_381], G1], smallScalar, Iters)
     separator()
 
 main()

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -484,6 +484,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_endomorphism_bn254_snarks", false),
   ("tests/math_elliptic_curves/t_ec_twedwards_mul_endomorphism_bandersnatch", false),
 
+  ("constantine/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim", false),
 
   # Elliptic curve arithmetic 𝔾₂
   # ----------------------------------------------------------
@@ -614,6 +615,7 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # Polynomials
   # ----------------------------------------------------------
   ("tests/math_polynomials/t_polynomials.nim", false),
+  ("tests/math_polynomials/t_fft_internals.nim", false),
   ("tests/math_polynomials/t_fft.nim", false),
   ("tests/math_polynomials/t_fft_coset.nim", false),
   ("tests/math_polynomials/t_bit_reversal.nim", false),
@@ -696,6 +698,7 @@ const benchDesc = [
   "bench_fp12",
   "bench_ec_g1",
   "bench_ec_g1_scalar_mul",
+  "bench_ec_g1_scalar_mul_vartime",
   "bench_ec_g1_batch",
   "bench_ec_msm_bandersnatch",
   "bench_ec_msm_bn254_snarks_g1",
@@ -732,7 +735,7 @@ const benchDesc = [
   "bench_fft_fields",
   "bench_fft_ec",
   "bench_fft_bit_reversal",
-  
+
   # "zkalc", # Already tested through make_zkalc
 ]
 
@@ -1063,6 +1066,9 @@ task bench_ec_g1_batch, "Run benchmark on Elliptic Curve group 𝔾1 (batch ops)
 
 task bench_ec_g1_scalar_mul, "Run benchmark on Elliptic Curve group 𝔾1 (Scalar Multiplication) - CC compiler":
   runBench("bench_ec_g1_scalar_mul")
+
+task bench_ec_g1_scalar_mul_vartime, "Run benchmark on Elliptic Curve group 𝔾1 (Variable-Time Scalar Multiplication) - CC compiler":
+  runBench("bench_ec_g1_scalar_mul_vartime")
 
 # Elliptic curve 𝔾₁ - Multi-scalar-mul
 # ------------------------------------------

--- a/constantine.nimble
+++ b/constantine.nimble
@@ -478,13 +478,13 @@ const testDesc: seq[tuple[path: string, useGMP: bool]] = @[
   # ("tests/math_elliptic_curves/t_ec_twedw_prj_mul_sanity", false),
   ("tests/math_elliptic_curves/t_ec_twedw_prj_mul_distri", false),
 
-  ("tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_endomorphism_bls12_381", false),
-  # ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_endomorphism_bls12_381", false),
-  ("tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_endomorphism_bn254_snarks", false),
-  # ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_endomorphism_bn254_snarks", false),
-  ("tests/math_elliptic_curves/t_ec_twedwards_mul_endomorphism_bandersnatch", false),
+  ("tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_endomorphism_bls12_381.nim", false),
+  # ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_endomorphism_bls12_381.nim", false),
+  ("tests/math_elliptic_curves/t_ec_shortw_jac_g1_mul_endomorphism_bn254_snarks.nim", false),
+  # ("tests/math_elliptic_curves/t_ec_shortw_prj_g1_mul_endomorphism_bn254_snarks.nim", false),
+  ("tests/math_elliptic_curves/t_ec_twedwards_mul_endomorphism_bandersnatch.nim", false),
 
-  ("constantine/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim", false),
+  ("tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim", false),
 
   # Elliptic curve arithmetic 𝔾₂
   # ----------------------------------------------------------

--- a/constantine/math/elliptic/ec_scalar_mul_vartime.nim
+++ b/constantine/math/elliptic/ec_scalar_mul_vartime.nim
@@ -67,91 +67,214 @@ func scalarMul_doubleAdd_vartime*[EC](P: var EC, scalar: BigInt) {.tags:[VarTime
         else:
           P ~+= Paff
 
-func scalarMul_addchain_4bit_vartime[EC](P: var EC, scalar: BigInt) {.tags:[VarTime], meter.} =
+func scalarMul_addchain_5bit_vartime[EC](P: var EC, scalar: BigInt) {.tags:[VarTime], meter.} =
   ## **Variable-time** Elliptic Curve Scalar Multiplication
-  ## This can only handle for small scalars up to 2⁴ = 16 excluded
+  ## This only handles small scalars up to 2⁵ = 32 excluded
   let s = uint scalar.limbs[0]
-
   case s
   of 0:
-    P.setNeutral()
+    P.setNeutral()                                     # P = [0]
   of 1:
-    discard
+    discard                                            # P = [1]P
   of 2:
-    P.double()
+    P.double()                                         # P = [2]P
   of 3:
     var t {.noInit.}: EC
-    t.double(P)
-    P ~+= t
+    t.double(P)                                        # t = [2]P
+    P ~+= t                                            # P = [1]P + [2]P = [3]P
   of 4:
-    P.double()
-    P.double()
+    P.double()                                         # P = [2]P
+    P.double()                                         # P = [4]P
   of 5:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    P ~+= t
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    P ~+= t                                            # P = [1]P + [4]P = [5]P
   of 6:
     var t {.noInit.}: EC
-    t.double(P)
-    P ~+= t
-    P.double()
+    t.double(P)                                        # t = [2]P
+    P ~+= t                                            # P = [1]P + [2]P = [3]P
+    P.double()                                         # P = [6]P
   of 7:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    t.double()
-    P.diff_vartime(t, P)
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    P.diff_vartime(t, P)                               # P = [8]P - [1]P = [7]P
   of 8:
-    P.double()
-    P.double()
-    P.double()
+    P.double()                                         # P = [2]P
+    P.double()                                         # P = [4]P
+    P.double()                                         # P = [8]P
   of 9:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    t.double()
-    P ~+= t
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    P ~+= t                                            # P = [1]P + [8]P = [9]P
   of 10:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    P ~+= t
-    P.double()
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    P ~+= t                                            # P = [1]P + [4]P = [5]P
+    P.double()                                         # P = [10]P
   of 11:
     var t1 {.noInit.}, t2 {.noInit.}: EC
-    t1.double(P)  # [2]P
-    t2.double(t1)
-    t2.double()   # [8]P
-    t1 ~+= t2
-    P ~+= t1
+    t1.double(P)                                       # t1 = [2]P
+    t2.double(t1)                                      # t2 = [4]P
+    t2.double()                                        # t2 = [8]P
+    t1 ~+= t2                                          # t1 = [2]P + [8]P = [10]P
+    P ~+= t1                                           # P = [1]P + [10]P = [11]P
   of 12:
-    var t1 {.noInit.}, t2 {.noInit.}: EC
-    t1.double(P)
-    t1.double()   # [4]P
-    t2.double(t1) # [8]P
-    P.sum_vartime(t1, t2)
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    P.double(t)                                        # P = [8]P
+    P ~+= t                                            # P = [4]P + [8]P = [12]P
   of 13:
     var t1 {.noInit.}, t2 {.noInit.}: EC
-    t1.double(P)
-    t1.double()   # [4]P
-    t2.double(t1) # [8]P
-    t1 ~+= t2
-    P ~+= t1
+    t1.double(P)                                       # t1 = [2]P
+    t1.double()                                        # t1 = [4]P
+    t2.double(t1)                                      # t2 = [8]P
+    t1 ~+= t2                                          # t1 = [4]P + [8]P = [12]P
+    P ~+= t1                                           # P = [1]P + [12]P = [13]P
   of 14:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    t.double()
-    t ~-= P # [7]P
-    P.double(t)
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~-= P                                            # t = [8]P - [1]P = [7]P
+    P.double(t)                                        # P = [14]P
   of 15:
     var t {.noInit.}: EC
-    t.double(P)
-    t.double()
-    t.double()
-    t.double()
-    P.diff_vartime(t, P)
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t.double()                                         # t = [16]P
+    P.diff_vartime(t, P)                               # P = [16]P - [1]P = [15]P
+  of 16:
+    P.double()                                         # P = [2]P
+    P.double()                                         # P = [4]P
+    P.double()                                         # P = [8]P
+    P.double()                                         # P = [16]P
+
+  # --- 17 to 32 ---
+  of 17:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t.double()                                         # t = [16]P
+    P ~+= t                                            # P = [1]P + [16]P = [17]P
+  of 18:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~+= P                                            # t = [1]P + [8]P = [9]P
+    P.double(t)                                        # P = 2 * [9]P = [18]P
+  of 19:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~+= P                                            # t = [1]P + [8]P = [9]P
+    t.double()                                         # t = 2 * [9]P = [18]P
+    P ~+= t                                            # P = [18]P + [1]P = [19]P
+  of 20:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t ~+= P                                            # t = [1]P + [4]P = [5]P
+    t.double()                                         # t = [10]P
+    P.double(t)                                        # P = 2 * [10]P = [20]P
+  of 21:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t ~+= P                                            # t = [1]P + [4]P = [5]P
+    t.double()                                         # t = [10]P
+    t.double()                                         # t = [20]P
+    P ~+= t                                            # P = [1]P + [20]P = [21]P
+  of 22:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t ~+= P                                            # t = [1]P + [4]P = [5]P
+    t.double()                                         # t = [10]P
+    t ~+= P                                            # t = [10]P + [1]P = [11]P
+    P.double(t)                                        # P = 2 * [11]P = [22]P
+  of 23:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t ~+= P                                            # t = [1]P + [2]P = [3]P
+    t.double()                                         # t = [6]P
+    t.double()                                         # t = [12]P
+    t.double()                                         # t = 2 * [12]P = [24]P
+    P.diff_vartime(t, P)                               # P = [24]P - [1]P = [23]P
+  of 24:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t ~+= P                                            # t = [1]P + [2]P = [3]P
+    t.double()                                         # t = [6]P
+    t.double()                                         # t = [12]P
+    P.double(t)                                        # P = 2 * [12]P = [24]P
+  of 25:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t ~+= P                                            # t = [1]P + [2]P = [3]P
+    t.double()                                         # t = [6]P
+    t.double()                                         # t = [12]P
+    t.double()                                         # t = [24]P
+    P ~+= t                                            # P = [1]P + [24]P = [25]P
+  of 26:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t ~+= P                                            # t = [1]P + [2]P = [3]P
+    t.double()                                         # t = [6]P
+    t.double()                                         # t = [12]P
+    t ~+= P                                            # t = [12]P + [1]P = [13]P
+    P.double(t)                                        # P = 2 * [13]P = [26]P
+  of 27:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~+= P                                            # t = [1]P + [8]P = [9]P
+    P.double(t)                                        # P = 2 * [9]P = [18]P
+    P ~+= t                                            # P = [18]P + [9]P = [27]P
+  of 28:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~-= P                                            # t = [8]P - [1]P = [7]P
+    t.double()                                         # t = [14]P
+    P.double(t)                                        # P = 2 * [14]P = [28]P
+  of 29:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t ~-= P                                            # t = [8]P - [1]P = [7]P
+    t.double()                                         # t = [14]P
+    t.double()                                         # t = [28]P
+    P ~+= t                                            # P = [1]P + [28]P = [29]P
+  of 30:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t ~+= P                                            # t = [1]P + [2]P = [3]P
+    t.double()                                         # t = [6]P
+    P.double(t)                                        # P = 2 * [6]P = [12]P
+    P.double()                                         # P = [24]P
+    P ~+= t                                            # P = [24]P + [6]P = [30]P
+  of 31:
+    var t {.noInit.}: EC
+    t.double(P)                                        # t = [2]P
+    t.double()                                         # t = [4]P
+    t.double()                                         # t = [8]P
+    t.double()                                         # t = [16]P
+    t.double()                                         # t = [32]P
+    P.diff_vartime(t, P)                               # P = [32]P - [1]P = [31]P
   else:
     unreachable()
 
@@ -364,16 +487,16 @@ func scalarMul_vartime*[scalBits; EC](P: var EC, scalar: BigInt[scalBits]) {.met
           {.error: "Unreachable".}
         return
 
-  if 64 < usedBits:
+  if usedBits > 64:
     # With a window of 4, we precompute 2^4 = 4 points
     P.scalarMul_wNAF_vartime(scalar, window = 4)
-  elif 16 < usedBits:
+  elif usedBits >= 8:
     # With a window of 3, we precompute 2^1 = 2 points
     P.scalarMul_wNAF_vartime(scalar, window = 3)
-  elif 4 < usedBits:
-    P.scalarMul_jy00_vartime(scalar)
-  else:
-    P.scalarMul_addchain_4bit_vartime(scalar)
+  elif usedBits > 5:
+    P.scalarMul_doubleAdd_vartime(scalar)
+  else: # 5-bit: [0, 32)
+    P.scalarMul_addchain_5bit_vartime(scalar)
 
 func scalarMul_vartime*[EC](P: var EC, scalar: Fr) {.inline.} =
   ## Elliptic Curve Scalar Multiplication

--- a/constantine/math/polynomials/fft_fields.nim
+++ b/constantine/math/polynomials/fft_fields.nim
@@ -435,8 +435,8 @@ func fft_nn_impl_stockham[F](
 
 func fft_nn_stockham[F](
        desc: FrFFT_Descriptor[F],
-       output{.noalias.}: var openarray[F],
-       vals{.noalias.}: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
+       output: var openarray[F],
+       vals: openarray[F]): FFTStatus {.tags: [VarTime, HeapAlloc], meter.} =
   ## FFT from natural order to natural order using Stockham algorithm.
   ## Input: natural order values
   ## Output: natural order values in Fourier domain
@@ -452,7 +452,7 @@ func fft_nn_stockham[F](
   ## - Pros: No bit-reversal, better memory access patterns
   ## - Cons: Requires 2x memory (temporary buffer)
   ##
-  ## **IMPORTANT**: `output` and `vals` must NOT alias (be the same array).
+  ## In-place / Aliasing is supported
   checkSizesReturnEarly(desc, output, vals)
 
   let n = vals.len

--- a/constantine/math/polynomials/fft_fields.nim
+++ b/constantine/math/polynomials/fft_fields.nim
@@ -392,9 +392,10 @@ func fft_nn_impl_stockham[F](
   ##
   ## This autosort property eliminates the need for bit-reversal permutation.
 
-  # Copy input to output buffer
-  for i in 0 ..< n:
-    output[i] = vals[i]
+  # Copy input to output (skip if aliasing for in-place operation)
+  if output[0].addr != vals[0].addr:
+    for i in 0 ..< n:
+      output[i] = vals[i]
 
   var src = output
   var dst = temp

--- a/constantine/named/zoo_endomorphisms.nim
+++ b/constantine/named/zoo_endomorphisms.nim
@@ -121,7 +121,7 @@ func hasEndomorphismAcceleration*(Name: static Algebra): bool {.compileTime.} =
     Vesta
   }
 
-const EndomorphismThreshold* = 192
+const EndomorphismThreshold* = 152
   ## We use substraction by maximum infinity norm coefficient
   ## to split scalars for endomorphisms
   ##

--- a/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim
+++ b/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim
@@ -1,0 +1,103 @@
+# Constantine
+# Copyright (c) 2018-2019    Status Research & Development GmbH
+# Copyright (c) 2020-Present Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/[random],
+  # Internals
+  constantine/named/[algebras, zoo_generators],
+  constantine/math/io/[io_bigints, io_ec],
+  constantine/math/arithmetic,
+  constantine/math/ec_shortweierstrass,
+  constantine/math/elliptic/ec_scalar_mul_vartime {.all.},
+  constantine/math_arbitrary_precision/arithmetic/limbs_views
+
+# Test scalar multiplication addition chains against double-and-add reference
+proc testAddChain5bit() =
+  echo "Testing scalarMul_addchain_5bit_vartime for scalars 0-31"
+  echo "========================================================"
+
+  var failures = 0
+
+  for s in 0 ..< 32:
+    # Create test scalar
+    var scalar = BigInt[Fr[BLS12_381].bits()].fromUint(uint(s))
+
+    # Use generator point - convert to Jacobian
+    var P: EC_ShortW_Jac[Fp[BLS12_381], G1]
+    P.fromAffine(BLS12_381.getGenerator("G1"))
+
+    # Compute using addition chain
+    var result_addchain = P
+    result_addchain.scalarMul_addchain_5bit_vartime(scalar)
+
+    # Compute using double-and-add (reference)
+    var result_ref = P
+    result_ref.scalarMul_doubleAdd_vartime(scalar)
+
+    # Compare
+    if not (result_addchain == result_ref).bool:
+      echo "FAIL: scalar = ", s
+      echo "  Addition chain result: ", result_addchain.toHex()
+      echo "  Double-add result:     ", result_ref.toHex()
+      inc failures
+
+    echo "  s = ", s, ": ", if (result_addchain == result_ref).bool: "PASS" else: "FAIL"
+
+  echo ""
+  echo "Total: ", 32 - failures, "/32 tests passed"
+  if failures > 0:
+    echo "FAILED: ", failures, " tests"
+    quit 1
+  else:
+    echo "SUCCESS: All tests passed!"
+
+# Test dispatch logic
+proc testDispatchLogic() =
+  echo "\nTesting scalarMul_vartime dispatch logic"
+  echo "========================================="
+
+  var failures = 0
+
+  for s in 0 ..< 32:
+    var scalar = BigInt[Fr[BLS12_381].bits()].fromUint(uint(s))
+
+    # Use generator point - convert to Jacobian
+    var P: EC_ShortW_Jac[Fp[BLS12_381], G1]
+    P.fromAffine(BLS12_381.getGenerator("G1"))
+
+    # Compute using auto-dispatch
+    var result_auto = P
+    result_auto.scalarMul_addchain_5bit_vartime(scalar)
+
+    # Compute using double-and-add (reference)
+    var result_ref = P
+    result_ref.scalarMul_doubleAdd_vartime(scalar)
+
+    # Compare
+    if not (result_auto == result_ref).bool:
+      echo "FAIL: scalar = ", s
+      echo "  Auto result: ", result_auto.toHex()
+      echo "  Ref result:  ", result_ref.toHex()
+      inc failures
+
+    echo "  s = ", s, " (", scalar.limbs.getBits_LE_vartime(), " Fr[BLS12_381].bits()): ",
+        if (result_auto == result_ref).bool: "PASS" else: "FAIL"
+
+  echo ""
+  echo "Total: ", 32 - failures, "/32 tests passed"
+  if failures > 0:
+    echo "FAILED: ", failures, " tests"
+    quit 1
+  else:
+    echo "SUCCESS: All tests passed!"
+
+when isMainModule:
+  randomize(12345)
+  testAddChain5bit()
+  testDispatchLogic()

--- a/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim
+++ b/tests/math_elliptic_curves/t_ec_scalar_mul_vartime_exhaustive.nim
@@ -7,15 +7,11 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  # Standard library
-  std/[random],
   # Internals
   constantine/named/[algebras, zoo_generators],
   constantine/math/io/[io_bigints, io_ec],
-  constantine/math/arithmetic,
   constantine/math/ec_shortweierstrass,
-  constantine/math/elliptic/ec_scalar_mul_vartime {.all.},
-  constantine/math_arbitrary_precision/arithmetic/limbs_views
+  constantine/math/elliptic/ec_scalar_mul_vartime {.all.}
 
 # Test scalar multiplication addition chains against double-and-add reference
 proc testAddChain5bit() =
@@ -41,53 +37,13 @@ proc testAddChain5bit() =
     result_ref.scalarMul_doubleAdd_vartime(scalar)
 
     # Compare
-    if not (result_addchain == result_ref).bool:
+    if not bool(result_addchain == result_ref):
       echo "FAIL: scalar = ", s
       echo "  Addition chain result: ", result_addchain.toHex()
       echo "  Double-add result:     ", result_ref.toHex()
       inc failures
 
-    echo "  s = ", s, ": ", if (result_addchain == result_ref).bool: "PASS" else: "FAIL"
-
-  echo ""
-  echo "Total: ", 32 - failures, "/32 tests passed"
-  if failures > 0:
-    echo "FAILED: ", failures, " tests"
-    quit 1
-  else:
-    echo "SUCCESS: All tests passed!"
-
-# Test dispatch logic
-proc testDispatchLogic() =
-  echo "\nTesting scalarMul_vartime dispatch logic"
-  echo "========================================="
-
-  var failures = 0
-
-  for s in 0 ..< 32:
-    var scalar = BigInt[Fr[BLS12_381].bits()].fromUint(uint(s))
-
-    # Use generator point - convert to Jacobian
-    var P: EC_ShortW_Jac[Fp[BLS12_381], G1]
-    P.fromAffine(BLS12_381.getGenerator("G1"))
-
-    # Compute using auto-dispatch
-    var result_auto = P
-    result_auto.scalarMul_addchain_5bit_vartime(scalar)
-
-    # Compute using double-and-add (reference)
-    var result_ref = P
-    result_ref.scalarMul_doubleAdd_vartime(scalar)
-
-    # Compare
-    if not (result_auto == result_ref).bool:
-      echo "FAIL: scalar = ", s
-      echo "  Auto result: ", result_auto.toHex()
-      echo "  Ref result:  ", result_ref.toHex()
-      inc failures
-
-    echo "  s = ", s, " (", scalar.limbs.getBits_LE_vartime(), " Fr[BLS12_381].bits()): ",
-        if (result_auto == result_ref).bool: "PASS" else: "FAIL"
+    echo "  s = ", s, ": ", if bool(result_addchain == result_ref): "PASS" else: "FAIL"
 
   echo ""
   echo "Total: ", 32 - failures, "/32 tests passed"
@@ -98,6 +54,4 @@ proc testDispatchLogic() =
     echo "SUCCESS: All tests passed!"
 
 when isMainModule:
-  randomize(12345)
   testAddChain5bit()
-  testDispatchLogic()


### PR DESCRIPTION
This extracts small scalar mul performance tuning from the PeerDAS PR #592 #593, the `scalarMul_jy00_vartime` is significantly slower than expected on low bits multipliers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive benchmark suite for variable-time scalar multiplication performance, testing multiple algorithms including double-and-add, Hamming weight recoding, wNAF, and endomorphism variants.
  * Expanded scalar multiplication implementation with improved handling of small scalars.

* **Improvements**
  * Optimized FFT operations for in-place computation scenarios.
  * Refined algorithm selection thresholds for scalar multiplication performance.

* **Tests**
  * Added exhaustive correctness test suite for scalar multiplication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->