### PR TITLE
Fix threadpool hangs with `numThreads >= 257`

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -700,6 +700,7 @@ const testDescThreadpool: seq[string] = @[
   "benchmarks-threadpool/matrix_transposition/threadpool_transposes.nim",
   "benchmarks-threadpool/histogram_2D/threadpool_histogram.nim",
   "benchmarks-threadpool/logsumexp/threadpool_logsumexp.nim",
+  "tests/threadpool/t_257_threads.nim",
 ]
 
 const testDescMultithreadedCrypto: seq[string] = @[

--- a/constantine/threadpool/crossthread/backoff.nim
+++ b/constantine/threadpool/crossthread/backoff.nim
@@ -60,7 +60,7 @@ const # bitfield setup
   # - Xeon Platinum 8490H, 60C/120T per socket
   #   - up to 8 sockets: 960 threads
 
-  kPreWaitShift = 8'u32
+  kPreWaitShift = 16'u32
   kPreWait      = 1'u32 shl kPreWaitShift
   kWait         = 1'u32
   kCommitToWait = kWait - kPreWait

--- a/tests/threadpool/t_257_threads.nim
+++ b/tests/threadpool/t_257_threads.nim
@@ -1,0 +1,22 @@
+import constantine/threadpool
+
+# Just check this won't hang
+const numThreads = 257
+const numTasks = numThreads * 4
+
+proc nothing() =
+  discard
+
+proc main() =
+  echo "\n=============================================================================================="
+  echo "Running 'tests/threadpool/t_257_threads.nim'"
+  echo "=============================================================================================="
+
+  let tp = Threadpool.new(numThreads = numThreads)
+  for _ in 0 ..< numTasks:
+    tp.spawn nothing()
+  tp.shutdown()
+
+  echo "ok"
+
+main()


### PR DESCRIPTION
Fix threadpool hangs with `numThreads >= 257`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved threadpool event handling for configurations with large numbers of waiting threads.
  * Prevented potential hangs when queuing many tasks and shutting down the threadpool.

* **Tests**
  * Added stress coverage for threadpools with 257 threads and multiple queued tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->