### PR TITLE
Fix threadpool futexes_macos wait/wake operation

### DIFF
--- a/constantine/threadpool/primitives/futexes_macos.nim
+++ b/constantine/threadpool/primitives/futexes_macos.nim
@@ -105,12 +105,12 @@ proc increment*(futex: var Futex, value: uint32, order: MemoryOrder): uint32 {.i
 
 proc wait*(futex: var Futex, expected: uint32) {.inline.} =
   ## Suspend a thread if the value of the futex is the same as expected.
-  discard ulock_wait(UL_UNFAIR_LOCK64_SHARED or ULF_NO_ERRNO, futex.value.addr, uint64 expected, 0)
+  discard ulock_wait(UL_COMPARE_AND_WAIT or ULF_NO_ERRNO, futex.value.addr, uint64 expected, 0)
 
 proc wake*(futex: var Futex) {.inline.} =
   ## Wake one thread (from the same process)
-  discard ulock_wake(ULF_WAKE_THREAD or ULF_NO_ERRNO, futex.value.addr, 0)
+  discard ulock_wake(UL_COMPARE_AND_WAIT or ULF_NO_ERRNO, futex.value.addr, 0)
 
 proc wakeAll*(futex: var Futex) {.inline.} =
   ## Wake all threads (from the same process)
-  discard ulock_wake(ULF_WAKE_ALL or ULF_NO_ERRNO, futex.value.addr, 0)
+  discard ulock_wake(UL_COMPARE_AND_WAIT or ULF_WAKE_ALL or ULF_NO_ERRNO, futex.value.addr, 0)


### PR DESCRIPTION
Should use `UL_COMPARE_AND_WAIT` as wait/awake operation as used in the wild [zig](https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/libcxx/src/atomic.cpp#L76-L86), [odin](https://github.com/odin-lang/Odin/blob/6983813b4ece0e48539dc1d3e7c7437569db1dc2/core/sync/futex_darwin.odin#L34-L152), etc . The `ULF_WAKE_THREAD` flag expects the parameter to be thread_id from what I've seen.

The current flags `ULF_WAKE_THREAD` and `UL_UNFAIR_LOCK64_SHARED` don't seem to put the thread to sleep in macos x86 (likely arm too).

Note I don't have a mac to check for benchmark regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS thread synchronization behavior by using the appropriate wait and wake operations.
  * Updated wake-all handling to reliably notify all waiting threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->