### PR TITLE
Fix threadpool schedule race condition

### DIFF
--- a/constantine.nimble
+++ b/constantine.nimble
@@ -701,6 +701,7 @@ const testDescThreadpool: seq[string] = @[
   "benchmarks-threadpool/histogram_2D/threadpool_histogram.nim",
   "benchmarks-threadpool/logsumexp/threadpool_logsumexp.nim",
   "tests/threadpool/t_257_threads.nim",
+  "tests/threadpool/t_spawn_spin.nim",
 ]
 
 const testDescMultithreadedCrypto: seq[string] = @[

--- a/constantine/threadpool/crossthread/taskqueues.nim
+++ b/constantine/threadpool/crossthread/taskqueues.nim
@@ -141,7 +141,7 @@ proc teardown*(tq: var Taskqueue) =
   tq.garbageCollect()
   freeHeap(tq.buf.load(moRelaxed))
 
-proc push*(tq: var Taskqueue, item: ptr Task) =
+proc push*(tq: var Taskqueue, item: ptr Task, wasEmpty: var bool) =
   ## Enqueue an item at the back
   ## As the task queue takes ownership of it. The item must not be used afterwards.
   ## This is intended for the producer only.
@@ -162,6 +162,21 @@ proc push*(tq: var Taskqueue, item: ptr Task) =
   buf[][b] = item
   fence(moRelease)
   tq.back.store(b+1, moRelaxed)
+
+  wasEmpty =
+    if wasEmpty:
+      true
+    elif f == b:
+      true
+    else:
+      # Re-check whether the items seen at the initial `top` read
+      # have since been drained; if so we are the one making the deque non-empty.
+      fence(moSequentiallyConsistent)
+      tq.front.load(moRelaxed) >= b
+
+proc push*(tq: var Taskqueue, item: ptr Task) =
+  var wasEmpty = true
+  push(tq, item, wasEmpty)
 
 proc pop*(tq: var Taskqueue): ptr Task =
   ## Dequeue an item at the back. Takes ownership of the item

--- a/constantine/threadpool/threadpool.nim
+++ b/constantine/threadpool/threadpool.nim
@@ -405,8 +405,8 @@ proc schedule(ctx: var WorkerContext, task: ptr Task, forceWake = false) {.inlin
   # Instead of notifying every time a task is scheduled, we notify
   # only when the worker queue is empty. This is a good approximation
   # of starvation in work-stealing.
-  let wasEmpty = ctx.taskqueue[].peek() == 0
-  ctx.taskqueue[].push(task)
+  var wasEmpty = false
+  ctx.taskqueue[].push(task, wasEmpty)
 
   ctx.incCounter(tasksScheduled)
   ctx.incCounter(itersScheduled):

--- a/tests/threadpool/t_spawn_spin.nim
+++ b/tests/threadpool/t_spawn_spin.nim
@@ -1,0 +1,89 @@
+# taskpools
+# Copyright (c) 2021-2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Regression tests for a scheduler lost wakeup.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/[atomics, unittest],
+  constantine/threadpool
+
+const
+  sweepRounds = 400_000
+  senderBatch = 2
+    ## Two is the whole race: the first push finds the deque empty and notifies,
+    ## the second peeks while the first is still queued and must decide again.
+  pollBatch = 2
+
+type
+  Entry = object
+    ready {.align: 64.}: Atomic[bool]
+    value: Atomic[int]
+
+var
+  tp: Threadpool
+  entries: array[senderBatch, Entry]
+
+proc senderTask(i: int): bool =
+  entries[i].value.store(i * 2 + 1, moRelease)
+  entries[i].ready.store(true, moRelease)
+  true
+
+proc pollTask(i: int): int =
+  i * 3 + 1
+
+proc runSenderBatch() =
+  ## withSenderParallel: spawn a batch, wait on a side channel, sync at the end.
+  for i in 0 ..< senderBatch:
+    entries[i].ready.store(false, moRelease)
+    entries[i].value.store(0, moRelease)
+
+  var futs: array[senderBatch, Flowvar[bool]]
+  # Both land in the spawner's own deque; only an empty -> non-empty transition
+  # notifies anybody.
+  for i in 0 ..< senderBatch:
+    futs[i] = tp.spawn senderTask(i)
+
+  # Deliberately not `sync`: waiting here keeps the spawner out of the
+  # scheduler, so it never drains the deque it just filled. If the second task
+  # was stranded this spins forever, which is the intended signal.
+  for i in 0 ..< senderBatch:
+    while not entries[i].ready.load(moAcquire):
+      cpuRelax()
+    doAssert entries[i].value.load(moAcquire) == i * 2 + 1
+
+  # Only now, in the equivalent of the `finally`.
+  for i in 0 ..< senderBatch:
+    doAssert sync(futs[i])
+
+proc allReady(futs: var array[pollBatch, Flowvar[int]]): bool =
+  for i in 0 ..< pollBatch:
+    if not futs[i].isReady():
+      return false
+  true
+
+proc runPollBatch() =
+  ## aristo computeKeyImpl: spawn a batch, poll isReady, sync once ready.
+  var futs: array[pollBatch, Flowvar[int]]
+  for i in 0 ..< pollBatch:
+    futs[i] = tp.spawn pollTask(i)
+
+  while not allReady(futs):
+    cpuRelax()
+
+  for i in 0 ..< pollBatch:
+    doAssert sync(futs[i]) == i * 3 + 1
+
+suite "Spawn then wait without re-entering the scheduler":
+  test "send and poll":
+    tp = Threadpool.new(2)
+    for r in 0 ..< sweepRounds:
+      runSenderBatch()
+      runPollBatch()
+    tp.syncAll()
+    tp.shutdown()


### PR DESCRIPTION
Fix peek+push schedule race cond (which causes a hang) by doing peek, push, then re-check whether the queue got drained in between.

Added regression tests which hang without the fix.

I did not notice a benchmark regression when compiling in release mode. But, interestingly, when compiling in danger mode, nqueens is slower; I was able to restore the perf by returning a bool from push instead of using the var param. My guess is it's something inline related but I did not dig into it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved threadpool task scheduling to prevent missed worker wake-ups.
  * Ensured queued tasks are consistently detected when workers need notification.

* **Tests**
  * Added regression coverage for high-volume task spawning, future polling, synchronization, and threadpool shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->